### PR TITLE
Hide provider sync CTA after successful connection

### DIFF
--- a/src/renderer/features/dashboard/components/ConnectionPanel.tsx
+++ b/src/renderer/features/dashboard/components/ConnectionPanel.tsx
@@ -6,6 +6,7 @@ import type { SavedConnectionConfig } from '../types';
 interface ConnectionPanelProps {
   providerName: string;
   providerKind: SavedConnectionConfig['provider'];
+  isConnected: boolean;
   config: SavedConnectionConfig;
   error: string | null;
   projectDiscoveryWarning: string | null;
@@ -23,6 +24,7 @@ interface ConnectionPanelProps {
 const ConnectionPanel = ({
   providerName,
   providerKind,
+  isConnected,
   config,
   error,
   projectDiscoveryWarning,
@@ -165,16 +167,22 @@ const ConnectionPanel = ({
       <ConnectionHelp provider={providerKind} />
     </div>
 
-    <div className="mt-5 flex items-center justify-end">
-      <button
-        type="button"
-        onClick={onRefresh}
-        disabled={isLoading}
-        className="rounded-full bg-sky-600 px-5 py-2.5 text-sm font-medium text-white transition hover:bg-sky-500 disabled:cursor-not-allowed disabled:bg-slate-400"
-      >
-        {isLoading ? 'Conectando...' : 'Conectar y sincronizar'}
-      </button>
-    </div>
+    {isConnected ? (
+      <div className="mt-5 rounded-2xl border border-emerald-200 bg-emerald-50 px-4 py-3 text-sm text-emerald-800">
+        <span className="font-medium">Conectado correctamente.</span> El provider {providerName} esta sincronizado y listo para usarse.
+      </div>
+    ) : (
+      <div className="mt-5 flex items-center justify-end">
+        <button
+          type="button"
+          onClick={onRefresh}
+          disabled={isLoading}
+          className="rounded-full bg-sky-600 px-5 py-2.5 text-sm font-medium text-white transition hover:bg-sky-500 disabled:cursor-not-allowed disabled:bg-slate-400"
+        >
+          {isLoading ? 'Conectando...' : 'Conectar y sincronizar'}
+        </button>
+      </div>
+    )}
 
     {error ? (
       <div className="mt-4 rounded-2xl border border-rose-200 bg-rose-50 px-4 py-3 text-sm text-rose-700">

--- a/src/renderer/pages/Settings.tsx
+++ b/src/renderer/pages/Settings.tsx
@@ -90,6 +90,7 @@ const Settings = () => {
                 <ConnectionPanel
                   providerName={activeProvider.name}
                   providerKind={activeProvider.kind}
+                  isConnected={isConnectionReady}
                   config={config}
                   error={error}
                   projectDiscoveryWarning={projectDiscoveryWarning}


### PR DESCRIPTION
## Summary
- hide the provider sync button once the active provider is successfully connected
- show a green connected state message in the provider panel instead
- keep the CTA visible again when the configuration changes and the connection is no longer valid

## Validation
- npm run typecheck
- npm run build