### PR TITLE
feat: add custom Electron title bar

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -1,6 +1,7 @@
 import { app, BrowserWindow } from 'electron';
 import * as path from 'path';
 import { registerIpcHandlers } from './main/ipc/register';
+import { attachWindowStateSync } from './main/ipc/window-controls';
 import { buildDefaultRepositoryProviderPorts } from './services/providers/repository-provider.bootstrap';
 import { createRepositoryProviderRegistry } from './services/providers/repository-provider.composition';
 import { RepositoryAnalysisSnapshotProvider } from './services/analysis/repository-analysis.snapshot-provider';
@@ -8,13 +9,43 @@ import { RepositoryAnalysisService } from './services/analysis/repository-analys
 import { PullRequestAnalysisSnapshotProvider } from './services/analysis/pull-request-analysis.snapshot-provider';
 import { PullRequestAnalysisService } from './services/analysis/pull-request-analysis.service';
 
+const APP_ID = 'com.checkpr.desktop';
+const APP_STORAGE_DIRNAME = 'CheckPR';
+
+export function resolveAppStoragePaths() {
+  const localAppDataRoot = process.env.LOCALAPPDATA;
+  const appDataRoot = localAppDataRoot && localAppDataRoot.trim().length > 0
+    ? localAppDataRoot
+    : app.getPath('appData');
+  const userDataPath = path.join(appDataRoot, APP_STORAGE_DIRNAME);
+
+  return {
+    userDataPath,
+    sessionDataPath: path.join(userDataPath, 'SessionData'),
+  };
+}
+
+export function configureAppStorage(): void {
+  const { userDataPath, sessionDataPath } = resolveAppStoragePaths();
+  app.setPath('userData', userDataPath);
+  app.setPath('sessionData', sessionDataPath);
+}
+
+configureAppStorage();
+
 // Asegurarse de que las notificaciones estén habilitadas
-app.setAppUserModelId(process.execPath);
+app.setAppUserModelId(APP_ID);
 
 export function buildMainWindowOptions(): Electron.BrowserWindowConstructorOptions {
   return {
     width: 1200,
     height: 800,
+    minWidth: 1080,
+    minHeight: 720,
+    frame: false,
+    titleBarStyle: process.platform === 'darwin' ? 'hiddenInset' : 'hidden',
+    titleBarOverlay: false,
+    backgroundColor: '#e2e8f0',
     webPreferences: {
       preload: path.join(__dirname, 'preload.js'),
       nodeIntegration: false,
@@ -37,6 +68,7 @@ export function resolveRendererTarget() {
 
 export function createWindow() {
   const mainWindow = new BrowserWindow(buildMainWindowOptions());
+  attachWindowStateSync(mainWindow);
 
   const { rendererUrl, isDevelopment, productionFile } = resolveRendererTarget();
 

--- a/src/main/ipc/register.ts
+++ b/src/main/ipc/register.ts
@@ -1,6 +1,7 @@
 import { registerAnalysisIpc } from './analysis';
 import { registerRepositoryProviderIpc } from './repository-providers';
 import { registerSessionSecretsIpc, SessionSecretsStore } from './session-secrets';
+import { registerWindowControlsIpc } from './window-controls';
 import type { RepositoryProviderRegistry } from '../../services/providers/repository-provider.registry';
 import type { RepositoryAnalysisService } from '../../services/analysis/repository-analysis.service';
 import type { PullRequestAnalysisService } from '../../services/analysis/pull-request-analysis.service';
@@ -14,4 +15,5 @@ export function registerIpcHandlers(
   registerRepositoryProviderIpc(providerRegistry);
   registerAnalysisIpc(repositoryAnalysisService, pullRequestAnalysisService, sessionSecretsStore);
   registerSessionSecretsIpc(sessionSecretsStore);
+  registerWindowControlsIpc();
 }

--- a/src/main/ipc/window-controls.ts
+++ b/src/main/ipc/window-controls.ts
@@ -1,0 +1,74 @@
+import { BrowserWindow, ipcMain } from 'electron';
+
+const GET_STATE_CHANNEL = 'window-controls:get-state';
+const MINIMIZE_CHANNEL = 'window-controls:minimize';
+const TOGGLE_MAXIMIZE_CHANNEL = 'window-controls:toggle-maximize';
+const CLOSE_CHANNEL = 'window-controls:close';
+const STATE_CHANGED_CHANNEL = 'window-controls:state-changed';
+
+function buildWindowState(targetWindow: BrowserWindow): WindowControlsState {
+  return {
+    isMaximized: targetWindow.isMaximized(),
+    isFullScreen: targetWindow.isFullScreen(),
+    platform: process.platform,
+  };
+}
+
+function resolveSenderWindow(sender: Electron.WebContents): BrowserWindow {
+  const targetWindow = BrowserWindow.fromWebContents(sender);
+
+  if (!targetWindow) {
+    throw new Error('Unable to resolve the BrowserWindow for the sender.');
+  }
+
+  return targetWindow;
+}
+
+function emitWindowState(targetWindow: BrowserWindow): void {
+  if (targetWindow.isDestroyed()) {
+    return;
+  }
+
+  targetWindow.webContents.send(STATE_CHANGED_CHANNEL, buildWindowState(targetWindow));
+}
+
+export function attachWindowStateSync(targetWindow: BrowserWindow): void {
+  const syncWindowState = () => emitWindowState(targetWindow);
+
+  targetWindow.on('maximize', syncWindowState);
+  targetWindow.on('unmaximize', syncWindowState);
+  targetWindow.on('enter-full-screen', syncWindowState);
+  targetWindow.on('leave-full-screen', syncWindowState);
+  targetWindow.on('ready-to-show', syncWindowState);
+}
+
+export function registerWindowControlsIpc(): void {
+  ipcMain.handle(GET_STATE_CHANNEL, (event) => {
+    const targetWindow = resolveSenderWindow(event.sender);
+    return buildWindowState(targetWindow);
+  });
+
+  ipcMain.handle(MINIMIZE_CHANNEL, (event) => {
+    const targetWindow = resolveSenderWindow(event.sender);
+    targetWindow.minimize();
+    return buildWindowState(targetWindow);
+  });
+
+  ipcMain.handle(TOGGLE_MAXIMIZE_CHANNEL, (event) => {
+    const targetWindow = resolveSenderWindow(event.sender);
+
+    if (targetWindow.isMaximized()) {
+      targetWindow.unmaximize();
+    } else {
+      targetWindow.maximize();
+    }
+
+    return buildWindowState(targetWindow);
+  });
+
+  ipcMain.handle(CLOSE_CHANNEL, (event) => {
+    const targetWindow = resolveSenderWindow(event.sender);
+    targetWindow.close();
+    return null;
+  });
+}

--- a/src/preload.ts
+++ b/src/preload.ts
@@ -1,6 +1,10 @@
 import { contextBridge, ipcRenderer } from 'electron';
 
 const ALLOWED_CHANNELS = new Set([
+  'window-controls:get-state',
+  'window-controls:minimize',
+  'window-controls:toggle-maximize',
+  'window-controls:close',
   'repository-source:fetchPullRequests',
   'repository-source:fetchProjects',
   'repository-source:fetchRepositories',
@@ -19,6 +23,7 @@ const ALLOWED_CHANNELS = new Set([
 
 export type ElectronInvokeChannel = typeof ALLOWED_CHANNELS extends Set<infer T> ? T : never;
 export const allowedElectronInvokeChannels = Array.from(ALLOWED_CHANNELS);
+const WINDOW_STATE_EVENT = 'window-controls:state-changed';
 
 export function ensureAllowedChannel(channel: string): void {
   if (!ALLOWED_CHANNELS.has(channel)) {
@@ -30,6 +35,17 @@ export const electronApiBridge = {
   invoke(channel: string, payload?: unknown) {
     ensureAllowedChannel(channel);
     return ipcRenderer.invoke(channel, payload);
+  },
+  onWindowStateChange(listener: (payload: unknown) => void) {
+    const wrappedListener = (_event: unknown, payload: unknown) => {
+      listener(payload);
+    };
+
+    ipcRenderer.on(WINDOW_STATE_EVENT, wrappedListener);
+
+    return () => {
+      ipcRenderer.removeListener(WINDOW_STATE_EVENT, wrappedListener);
+    };
   },
 };
 

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -7,6 +7,7 @@ import Sidebar from './components/Layout/Sidebar';
 import Settings from './pages/Settings';
 import RepositoryAnalysis from './pages/RepositoryAnalysis';
 import { RepositorySourceProvider } from './features/dashboard/context/RepositorySourceContext';
+import TitleBar from './components/Layout/TitleBar';
 
 const App = () => {
   return (
@@ -30,18 +31,21 @@ const AppShell = () => {
   }, [location.pathname]);
 
   return (
-    <div className="min-h-screen bg-slate-100">
-      <div className="mx-auto flex min-h-screen max-w-[1600px]">
+    <div className="h-screen overflow-hidden bg-slate-100">
+      <div className="mx-auto flex h-full max-w-[1680px]">
         <Sidebar />
-        <main key={location.pathname} className="min-w-0 flex-1 px-6 py-8 lg:px-10">
-          <Routes location={location}>
-            <Route path="/" element={<Dashboard />} />
-            <Route path="/history" element={<History />} />
-            <Route path="/repository-analysis" element={<RepositoryAnalysis />} />
-            <Route path="/settings" element={<Settings />} />
-            <Route path="*" element={<Navigate to="/" replace />} />
-          </Routes>
-        </main>
+        <div className="flex min-w-0 flex-1 flex-col">
+          <TitleBar pathname={location.pathname} />
+          <main key={location.pathname} className="min-w-0 flex-1 overflow-y-auto px-6 py-8 lg:px-10">
+            <Routes location={location}>
+              <Route path="/" element={<Dashboard />} />
+              <Route path="/history" element={<History />} />
+              <Route path="/repository-analysis" element={<RepositoryAnalysis />} />
+              <Route path="/settings" element={<Settings />} />
+              <Route path="*" element={<Navigate to="/" replace />} />
+            </Routes>
+          </main>
+        </div>
       </div>
     </div>
   );

--- a/src/renderer/components/Layout/Sidebar.tsx
+++ b/src/renderer/components/Layout/Sidebar.tsx
@@ -11,7 +11,7 @@ const navClassName = ({ isActive }: { isActive: boolean }) =>
 
 const Sidebar = () => {
   return (
-    <aside className="sticky top-0 flex h-screen w-72 flex-col border-r border-slate-200 bg-white/95 px-6 py-8 backdrop-blur">
+    <aside className="flex h-full w-72 flex-col border-r border-slate-200 bg-white/95 px-6 py-8 backdrop-blur">
       <div>
         <p className="text-xs font-semibold uppercase tracking-[0.3em] text-sky-600">CheckPR</p>
         <h1 className="mt-3 text-2xl font-semibold text-slate-950">Repo Command Center</h1>

--- a/src/renderer/components/Layout/TitleBar.tsx
+++ b/src/renderer/components/Layout/TitleBar.tsx
@@ -1,0 +1,158 @@
+import React from 'react';
+import {
+  ArrowsPointingOutIcon,
+  MinusIcon,
+  Squares2X2Icon,
+  XMarkIcon,
+} from '@heroicons/react/24/outline';
+
+const dragRegionStyle = { WebkitAppRegion: 'drag' } as React.CSSProperties & { WebkitAppRegion: 'drag' };
+const noDragRegionStyle = { WebkitAppRegion: 'no-drag' } as React.CSSProperties & { WebkitAppRegion: 'no-drag' };
+
+type WindowControlChannel =
+  | 'window-controls:get-state'
+  | 'window-controls:minimize'
+  | 'window-controls:toggle-maximize'
+  | 'window-controls:close';
+
+const pageMetadata: Record<string, { title: string }> = {
+  '/': {
+    title: 'Pull Requests',
+  },
+  '/history': {
+    title: 'Review History',
+  },
+  '/repository-analysis': {
+    title: 'Repository Intelligence',
+  },
+  '/settings': {
+    title: 'Platform Settings',
+  },
+};
+
+const defaultMetadata = {
+  title: 'CheckPR',
+};
+
+function isWindowControlsState(value: unknown): value is WindowControlsState {
+  if (!value || typeof value !== 'object') {
+    return false;
+  }
+
+  const candidate = value as Partial<WindowControlsState>;
+  return typeof candidate.isMaximized === 'boolean'
+    && typeof candidate.isFullScreen === 'boolean'
+    && typeof candidate.platform === 'string';
+}
+
+async function invokeWindowControl(channel: WindowControlChannel): Promise<WindowControlsState | null> {
+  const response = await window.electronApi.invoke(channel);
+
+  if (response === null) {
+    return null;
+  }
+
+  return isWindowControlsState(response) ? response : null;
+}
+
+interface TitleBarProps {
+  pathname: string;
+}
+
+const TitleBar = ({ pathname }: TitleBarProps) => {
+  const metadata = pageMetadata[pathname] ?? defaultMetadata;
+  const [windowState, setWindowState] = React.useState<WindowControlsState>({
+    isMaximized: false,
+    isFullScreen: false,
+    platform: 'win32',
+  });
+
+  React.useEffect(() => {
+    let isSubscribed = true;
+
+    invokeWindowControl('window-controls:get-state')
+      .then((state) => {
+        if (state && isSubscribed) {
+          setWindowState(state);
+        }
+      })
+      .catch(() => undefined);
+
+    const unsubscribe = window.electronApi.onWindowStateChange((state) => {
+      if (isSubscribed) {
+        setWindowState(state);
+      }
+    });
+
+    return () => {
+      isSubscribed = false;
+      unsubscribe();
+    };
+  }, []);
+
+  const handleMinimize = React.useCallback(async () => {
+    const nextState = await invokeWindowControl('window-controls:minimize');
+
+    if (nextState) {
+      setWindowState(nextState);
+    }
+  }, []);
+
+  const handleToggleMaximize = React.useCallback(async () => {
+    const nextState = await invokeWindowControl('window-controls:toggle-maximize');
+
+    if (nextState) {
+      setWindowState(nextState);
+    }
+  }, []);
+
+  const handleClose = React.useCallback(async () => {
+    await invokeWindowControl('window-controls:close');
+  }, []);
+
+  const MaximizeIcon = windowState.isMaximized ? Squares2X2Icon : ArrowsPointingOutIcon;
+
+  return (
+    <header
+      className="border-b border-slate-200/80 bg-slate-100/95 backdrop-blur"
+      style={dragRegionStyle}
+    >
+      <div className="flex h-14 items-center justify-between gap-4 px-6 lg:px-10">
+        <div className="min-w-0">
+          <h2 className="truncate text-sm font-semibold tracking-[0.01em] text-slate-900">{metadata.title}</h2>
+        </div>
+
+        <div className="flex items-center" style={noDragRegionStyle}>
+          <div className="flex items-center rounded-xl border border-slate-200/80 bg-white/80 p-1">
+            <button
+              type="button"
+              aria-label="Minimize window"
+              onClick={handleMinimize}
+              className="rounded-lg p-2 text-slate-500 transition hover:bg-slate-100 hover:text-slate-900"
+            >
+              <MinusIcon className="h-4 w-4" />
+            </button>
+            <button
+              type="button"
+              aria-label={windowState.isMaximized ? 'Restore window' : 'Maximize window'}
+              onClick={handleToggleMaximize}
+              className="rounded-lg p-2 text-slate-500 transition hover:bg-slate-100 hover:text-slate-900"
+            >
+              <MaximizeIcon className="h-4 w-4" />
+            </button>
+            <button
+              type="button"
+              aria-label="Close window"
+              onClick={handleClose}
+              className="rounded-lg p-2 text-slate-500 transition hover:bg-rose-100 hover:text-rose-700"
+            >
+              <XMarkIcon className="h-4 w-4" />
+            </button>
+          </div>
+        </div>
+      </div>
+    </header>
+  );
+};
+
+export default TitleBar;

--- a/src/types/global.d.ts
+++ b/src/types/global.d.ts
@@ -1,7 +1,14 @@
 declare global {
+  interface WindowControlsState {
+    isMaximized: boolean;
+    isFullScreen: boolean;
+    platform: NodeJS.Platform;
+  }
+
   interface Window {
     electronApi: {
       invoke: (channel: string, payload?: unknown) => Promise<unknown>;
+      onWindowStateChange: (listener: (payload: WindowControlsState) => void) => () => void;
     };
   }
 }

--- a/tests/unit/main/main.test.js
+++ b/tests/unit/main/main.test.js
@@ -3,10 +3,13 @@ const loadFile = jest.fn();
 const browserWindowMock = jest.fn().mockImplementation(() => ({
   loadURL,
   loadFile,
+  on: jest.fn(),
 }));
 
 jest.mock('electron', () => ({
   app: {
+    getPath: jest.fn(() => 'C:\\Users\\ianst\\AppData\\Roaming'),
+    setPath: jest.fn(),
     setAppUserModelId: jest.fn(),
     whenReady: jest.fn(() => ({ then: jest.fn() })),
     on: jest.fn(),
@@ -21,12 +24,17 @@ jest.mock('../../../src/main/ipc/register', () => ({
   registerIpcHandlers: jest.fn(),
 }));
 
+jest.mock('../../../src/main/ipc/window-controls', () => ({
+  attachWindowStateSync: jest.fn(),
+}));
+
 jest.mock('../../../src/services/providers/repository-provider.bootstrap', () => ({
   buildDefaultRepositoryProviderPorts: jest.fn(() => []),
   registerDefaultRepositoryProviders: jest.fn(),
 }));
 
 const { registerIpcHandlers } = require('../../../src/main/ipc/register');
+const { attachWindowStateSync } = require('../../../src/main/ipc/window-controls');
 const {
   buildDefaultRepositoryProviderPorts,
   registerDefaultRepositoryProviders,
@@ -36,13 +44,24 @@ const main = require('../../../src/main');
 describe('main process bootstrap', () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    process.env.LOCALAPPDATA = 'C:\\Users\\ianst\\AppData\\Local';
     delete process.env.ELECTRON_RENDERER_URL;
     delete process.env.NODE_ENV;
+  });
+
+  test('resolveAppStoragePaths usa LOCALAPPDATA para aislar cache y session data', () => {
+    const storage = main.resolveAppStoragePaths();
+
+    expect(storage.userDataPath).toContain('AppData\\Local');
+    expect(storage.userDataPath).toContain('CheckPR');
+    expect(storage.sessionDataPath).toContain('SessionData');
   });
 
   test('buildMainWindowOptions endurece webPreferences', () => {
     const options = main.buildMainWindowOptions();
 
+    expect(options.frame).toBe(false);
+    expect(options.titleBarOverlay).toBe(false);
     expect(options.webPreferences).toEqual(expect.objectContaining({
       nodeIntegration: false,
       contextIsolation: true,
@@ -57,7 +76,8 @@ describe('main process bootstrap', () => {
 
     expect(target.rendererUrl).toBe('http://localhost:8080');
     expect(target.isDevelopment).toBe(true);
-    expect(target.productionFile).toContain('/dist/index.html');
+    expect(target.productionFile).toContain('dist');
+    expect(target.productionFile).toContain('index.html');
   });
 
   test('createWindow carga el renderer correcto segun entorno', () => {
@@ -70,7 +90,8 @@ describe('main process bootstrap', () => {
         sandbox: true,
       }),
     }));
-    expect(loadFile).toHaveBeenCalledWith(expect.stringContaining('/dist/index.html'));
+    expect(attachWindowStateSync).toHaveBeenCalled();
+    expect(loadFile).toHaveBeenCalledWith(expect.stringContaining('index.html'));
 
     jest.clearAllMocks();
     process.env.ELECTRON_RENDERER_URL = 'http://localhost:8080';

--- a/tests/unit/main/preload.test.js
+++ b/tests/unit/main/preload.test.js
@@ -3,7 +3,9 @@ jest.mock('electron', () => ({
     exposeInMainWorld: jest.fn(),
   },
   ipcRenderer: {
+    on: jest.fn(),
     invoke: jest.fn(),
+    removeListener: jest.fn(),
   },
 }));
 
@@ -21,6 +23,8 @@ describe('preload security bridge', () => {
       'analysis:previewRepositorySnapshot',
       'analysis:runRepositoryAnalysis',
       'analysis:cancelPullRequestAiReviews',
+      'window-controls:get-state',
+      'window-controls:close',
       'session-secrets:get',
       'session-secrets:has',
     ]));
@@ -35,5 +39,19 @@ describe('preload security bridge', () => {
 
     await expect(preload.electronApiBridge.invoke('session-secrets:get', 'key-a')).resolves.toEqual({ ok: true });
     expect(ipcRenderer.invoke).toHaveBeenCalledWith('session-secrets:get', 'key-a');
+  });
+
+  test('permite suscribirse y desuscribirse a cambios de estado de la ventana', () => {
+    const listener = jest.fn();
+    const unsubscribe = preload.electronApiBridge.onWindowStateChange(listener);
+
+    expect(ipcRenderer.on).toHaveBeenCalledWith('window-controls:state-changed', expect.any(Function));
+
+    const wrappedHandler = ipcRenderer.on.mock.calls[0][1];
+    wrappedHandler({}, { isMaximized: true });
+    expect(listener).toHaveBeenCalledWith({ isMaximized: true });
+
+    unsubscribe();
+    expect(ipcRenderer.removeListener).toHaveBeenCalledWith('window-controls:state-changed', wrappedHandler);
   });
 });


### PR DESCRIPTION
## Resumen
Este PR reemplaza la barra nativa de la ventana de Electron por una title bar custom integrada al layout actual de CheckPR.

La intención no fue solo cambiar los botones de minimizar, maximizar o cerrar, sino hacer que la parte superior de la app se sintiera coherente con el resto del producto: menos como chrome del sistema operativo superpuesto y más como una extensión natural del sidebar y del canvas principal.

## Objetivo
- personalizar la barra superior de la ventana sin romper la experiencia desktop nativa
- integrar los controles de ventana al lenguaje visual actual de la app
- mantener una implementación segura entre renderer y main process
- corregir el problema de permisos de cache que estaba apareciendo en Windows durante el desarrollo

## Cambios Incluidos
- se elimina el frame nativo de Electron y se configura una ventana sin chrome por defecto
- se agrega una title bar custom en renderer, alineada visualmente con la UI actual
- se conectan las acciones de minimizar, maximizar/restaurar y cerrar mediante IPC seguro
- se expone el estado de la ventana desde preload para que el renderer pueda reaccionar a cambios de maximizado
- se reorganiza el App Shell para que la barra superior forme parte de la columna de contenido y no compita con el sidebar
- se ajusta la barra superior en varias iteraciones de UX/UI hasta dejarla más sobria, simple e integrada al layout
- se aíslan los paths de userData y sessionData en Windows para evitar errores de cache y permisos en entorno local
- se actualizan pruebas unitarias del preload y del main process para cubrir la nueva lógica

## Impacto Visual Y De UX
- la barra superior deja de sentirse como un header aparte y pasa a comportarse como parte del layout principal
- los controles de ventana quedan accesibles, compactos y visualmente consistentes con el resto de la app
- se reduce ruido visual en la parte superior eliminando elementos decorativos y labels innecesarios
- el título visible de cada vista pasa a ser el principal punto de referencia de navegación en esa zona

## Consideraciones Técnicas
- la comunicación entre renderer y main process se mantiene encapsulada a través del preload bridge
- solo se exponen los canales estrictamente necesarios para controles de ventana
- se sincroniza el estado de la ventana para reflejar correctamente maximize/restore desde la UI custom
- el ajuste de almacenamiento local en Windows busca evitar conflictos de permisos con cache de Chromium/Electron

## Archivos Relevantes
- `src/main.ts`
- `src/main/ipc/register.ts`
- `src/main/ipc/window-controls.ts`
- `src/preload.ts`
- `src/types/global.d.ts`
- `src/renderer/App.tsx`
- `src/renderer/components/Layout/Sidebar.tsx`
- `src/renderer/components/Layout/TitleBar.tsx`
- `tests/unit/main/main.test.js`
- `tests/unit/main/preload.test.js`

## Validación Realizada
- `npm run typecheck`
- `npx jest tests/unit/main/preload.test.js tests/unit/main/main.test.js --runInBand`
- `npm run build`

## Riesgos O Puntos A Revisar En QA
- validar visualmente la title bar en Windows con distintas escalas de pantalla
- validar comportamiento de drag de ventana y controles en escenarios de maximize/restore
- revisar si en macOS conviene ajustar la posición o convención visual de los controles en una iteración futura