### PR TITLE
feat: simplificar Settings y homologar cards reutilizables

### DIFF
--- a/src/renderer/features/settings/components/CodexIntegrationCard.tsx
+++ b/src/renderer/features/settings/components/CodexIntegrationCard.tsx
@@ -6,10 +6,12 @@ import {
   SettingsModal,
   SettingsSectionCard,
   SettingsSelectField,
+  SettingsSurfaceCard,
   SettingsStatTile,
   SettingsStatusBadge,
   SettingsTextAreaField,
   SettingsToggleCard,
+  settingsButtonClassName,
 } from './SettingsPrimitives';
 
 interface CodexIntegrationCardProps {
@@ -23,9 +25,10 @@ const CodexIntegrationCard = ({ config, isReady, onChange }: CodexIntegrationCar
 
   return (
     <SettingsSectionCard
-      eyebrow="AI Integration"
+      eyebrow="Codex"
       title="Codex"
       description="Configuracion base para analisis AI sobre repositorios y sobre la cola priorizada de PRs. La API key vive solo en sesion y las reglas avanzadas quedan fuera de la vista principal."
+      tone="subtle"
       badge={(
         <SettingsStatusBadge
           tone={isReady ? 'emerald' : 'amber'}
@@ -41,7 +44,7 @@ const CodexIntegrationCard = ({ config, isReady, onChange }: CodexIntegrationCar
           <button
             type="button"
             onClick={() => setIsAdvancedModalOpen(true)}
-            className="inline-flex w-full items-center justify-center rounded-full border border-slate-300 px-4 py-2 text-sm font-medium text-slate-700 transition hover:border-sky-500 hover:text-sky-600 sm:w-auto"
+            className={`w-full sm:w-auto ${settingsButtonClassName}`}
           >
             Politicas avanzadas
           </button>
@@ -181,7 +184,7 @@ const CodexIntegrationCard = ({ config, isReady, onChange }: CodexIntegrationCar
         />
       </div>
 
-      <div className="mt-6 rounded-3xl border border-slate-200 bg-slate-50/70 p-5">
+      <SettingsSurfaceCard className="mt-6">
         <div className="flex flex-wrap items-center justify-between gap-3">
           <div>
             <h3 className="text-base font-semibold text-slate-900">Politicas avanzadas</h3>
@@ -194,7 +197,7 @@ const CodexIntegrationCard = ({ config, isReady, onChange }: CodexIntegrationCar
         <p className="mt-3 text-sm leading-6 text-slate-600">
           Las reglas textuales viven en un modal dedicado para que la vista principal se mantenga operativa y no se transforme en un formulario gigante.
         </p>
-      </div>
+      </SettingsSurfaceCard>
 
       <SettingsModal
         isOpen={isAdvancedModalOpen}
@@ -206,7 +209,7 @@ const CodexIntegrationCard = ({ config, isReady, onChange }: CodexIntegrationCar
             <button
               type="button"
               onClick={() => setIsAdvancedModalOpen(false)}
-              className="inline-flex items-center justify-center rounded-full border border-slate-300 px-4 py-2 text-sm font-medium text-slate-700 transition hover:border-sky-500 hover:text-sky-600"
+              className={settingsButtonClassName}
             >
               Listo
             </button>

--- a/src/renderer/features/settings/components/GlobalSnapshotPolicyCard.tsx
+++ b/src/renderer/features/settings/components/GlobalSnapshotPolicyCard.tsx
@@ -4,9 +4,11 @@ import {
   SettingsSectionCard,
   SettingsModal,
   SettingsNotice,
+  SettingsSurfaceCard,
   SettingsStatusBadge,
   SettingsTextAreaField,
   SettingsToggleCard,
+  settingsButtonClassName,
 } from './SettingsPrimitives';
 
 interface GlobalSnapshotPolicyCardProps {
@@ -54,9 +56,10 @@ const GlobalSnapshotPolicyCard = ({ snapshotPolicy, onChange }: GlobalSnapshotPo
 
   return (
     <SettingsSectionCard
-      eyebrow="Global Snapshot Policy"
+      eyebrow="Snapshots"
       title="Reglas globales de snapshot"
       description="Estas exclusiones y el modo estricto aplican a cualquier snapshot del producto: preflight de Repository Analysis, PR AI Review y futuras corridas que reutilicen el pipeline."
+      tone="subtle"
       badge={(
         <SettingsStatusBadge
           tone="sky"
@@ -67,7 +70,7 @@ const GlobalSnapshotPolicyCard = ({ snapshotPolicy, onChange }: GlobalSnapshotPo
         <button
           type="button"
           onClick={() => setIsModalOpen(true)}
-          className="inline-flex w-full items-center justify-center rounded-full border border-slate-300 px-4 py-2 text-sm font-medium text-slate-700 transition hover:border-sky-500 hover:text-sky-600 sm:w-auto"
+          className={`w-full sm:w-auto ${settingsButtonClassName}`}
         >
           Editar reglas
         </button>
@@ -84,20 +87,20 @@ const GlobalSnapshotPolicyCard = ({ snapshotPolicy, onChange }: GlobalSnapshotPo
           })}
         />
 
-        <div className="rounded-2xl border border-slate-200 bg-slate-50/80 px-4 py-4 text-sm leading-6 text-slate-600">
+        <SettingsSurfaceCard className="text-sm leading-6 text-slate-600">
           <p className="font-medium text-slate-900">Cobertura global</p>
           <p className="mt-2">
             Las reglas definidas aqui se aplican antes de cualquier preflight y antes de cualquier envio remoto.
             Las exclusiones temporales siguen existiendo, pero se suman a esta base global y no la reemplazan.
           </p>
-        </div>
-        <div className="rounded-2xl border border-slate-200 bg-white px-4 py-4 text-sm leading-6 text-slate-600 sm:col-span-2">
+        </SettingsSurfaceCard>
+        <SettingsSurfaceCard className="text-sm leading-6 text-slate-600 sm:col-span-2">
           <p className="font-medium text-slate-900">Preset disponible</p>
           <p className="mt-2">
             Por ahora la pantalla incluye un preset recomendado para <span className="font-medium">Node</span>.
             Puedes aplicarlo y luego ajustarlo desde el editor avanzado.
           </p>
-        </div>
+        </SettingsSurfaceCard>
       </div>
 
       <SettingsModal
@@ -110,7 +113,7 @@ const GlobalSnapshotPolicyCard = ({ snapshotPolicy, onChange }: GlobalSnapshotPo
             <button
               type="button"
               onClick={() => setIsModalOpen(false)}
-              className="inline-flex items-center justify-center rounded-full border border-slate-300 px-4 py-2 text-sm font-medium text-slate-700 transition hover:border-sky-500 hover:text-sky-600"
+              className={settingsButtonClassName}
             >
               Listo
             </button>
@@ -128,7 +131,7 @@ const GlobalSnapshotPolicyCard = ({ snapshotPolicy, onChange }: GlobalSnapshotPo
             })}
           />
 
-          <div className="rounded-2xl border border-slate-200 bg-white px-4 py-4">
+          <SettingsSurfaceCard>
             <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
               <div className="text-sm leading-6 text-slate-600">
                 <p className="font-medium text-slate-900">Preset rapido</p>
@@ -139,12 +142,12 @@ const GlobalSnapshotPolicyCard = ({ snapshotPolicy, onChange }: GlobalSnapshotPo
               <button
                 type="button"
                 onClick={() => onChange(applySnapshotPreset(snapshotPolicy, 'node'))}
-                className="inline-flex items-center justify-center rounded-full border border-slate-300 px-4 py-2 text-sm font-medium text-slate-700 transition hover:border-sky-500 hover:text-sky-600"
+                className={settingsButtonClassName}
               >
                 Aplicar preset Node
               </button>
             </div>
-          </div>
+          </SettingsSurfaceCard>
 
           <SettingsTextAreaField
             label="Patrones de paths excluidos"

--- a/src/renderer/features/settings/components/RepositoryProviderCard.tsx
+++ b/src/renderer/features/settings/components/RepositoryProviderCard.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { ArrowRightIcon, CheckCircleIcon, ChevronDownIcon, ChevronUpIcon, CircleStackIcon } from '@heroicons/react/24/outline';
 import type { RepositoryProviderDefinition } from '../../../../types/repository';
-import { SettingsSectionCard, SettingsStatusBadge } from './SettingsPrimitives';
+import { SettingsSectionCard, SettingsStatusBadge, SettingsSurfaceCard, settingsButtonClassName } from './SettingsPrimitives';
 
 interface RepositoryProviderCardProps {
   provider: RepositoryProviderDefinition;
@@ -42,9 +42,10 @@ const RepositoryProviderCard = ({
 
   return (
     <SettingsSectionCard
-      eyebrow="Repository Provider"
+      eyebrow="Provider"
       title={provider.name}
       description={provider.description}
+      tone="subtle"
       badge={<SettingsStatusBadge tone={badgeTone} label={statusLabel[provider.status]} />}
       actions={(
         <>
@@ -62,7 +63,7 @@ const RepositoryProviderCard = ({
             <button
               type="button"
               onClick={onActivate}
-              className="inline-flex w-full items-center justify-center gap-2 rounded-full border border-slate-300 px-4 py-2 text-sm font-medium text-slate-700 transition hover:border-sky-500 hover:text-sky-600 sm:w-auto"
+              className={`w-full gap-2 sm:w-auto ${settingsButtonClassName}`}
             >
               Usar este provider
               <ArrowRightIcon className="h-4 w-4" />
@@ -72,7 +73,7 @@ const RepositoryProviderCard = ({
             <button
               type="button"
               onClick={onToggleExpand}
-              className="inline-flex w-full items-center justify-center gap-2 rounded-full border border-slate-300 px-4 py-2 text-sm font-medium text-slate-700 transition hover:border-sky-500 hover:text-sky-600 sm:w-auto"
+              className={`w-full gap-2 sm:w-auto ${settingsButtonClassName}`}
             >
               {expanded ? 'Ocultar configuracion' : 'Configurar'}
               {expanded ? <ChevronUpIcon className="h-4 w-4" /> : <ChevronDownIcon className="h-4 w-4" />}
@@ -81,7 +82,7 @@ const RepositoryProviderCard = ({
         </>
       )}
     >
-      <div className="flex flex-col gap-4 rounded-2xl bg-slate-50/80 p-4 sm:flex-row sm:items-start">
+      <SettingsSurfaceCard className="flex flex-col gap-4 sm:flex-row sm:items-start">
         <div className="rounded-2xl bg-sky-50 p-3 text-sky-700">
           <CircleStackIcon className="h-6 w-6" />
         </div>
@@ -89,7 +90,7 @@ const RepositoryProviderCard = ({
           <p className="text-sm font-medium text-slate-900">Scope y autenticacion</p>
           <p className="mt-1 text-sm leading-6 text-slate-500">{provider.helperText}</p>
         </div>
-      </div>
+      </SettingsSurfaceCard>
 
       {expanded ? (
         <div className="mt-6 border-t border-slate-100 pt-6">

--- a/src/renderer/features/settings/components/SettingsHeroSection.tsx
+++ b/src/renderer/features/settings/components/SettingsHeroSection.tsx
@@ -13,14 +13,13 @@ export function SettingsHero({
   const configuredIntegrations = Number(isConnectionReady) + Number(isCodexReady);
 
   return (
-    <section className="overflow-hidden rounded-[28px] bg-[radial-gradient(circle_at_top_left,_rgba(56,189,248,0.24),_transparent_28%),linear-gradient(135deg,_#020617,_#0f172a_55%,_#111827)] p-6 text-white shadow-[0_35px_100px_-45px_rgba(2,6,23,0.95)] sm:p-8 lg:p-10">
-      <div className="grid gap-6 lg:gap-8 xl:grid-cols-[minmax(0,1.4fr)_minmax(280px,0.9fr)]">
+    <section className="overflow-hidden rounded-[28px] border border-slate-200 bg-[radial-gradient(circle_at_top_left,_rgba(56,189,248,0.16),_transparent_28%),linear-gradient(180deg,_rgba(255,255,255,0.98),_rgba(248,250,252,0.98))] p-6 shadow-[0_20px_70px_-45px_rgba(15,23,42,0.35)] sm:p-8">
+      <div className="grid gap-6 lg:gap-8 xl:grid-cols-[minmax(0,1.35fr)_minmax(280px,0.95fr)]">
         <div>
-          <p className="text-xs font-semibold uppercase tracking-[0.3em] text-sky-300">Settings</p>
-          <h1 className="mt-3 text-3xl font-semibold tracking-tight sm:text-4xl lg:text-[2.75rem]">Configuracion de fuentes e integraciones</h1>
-          <p className="mt-3 max-w-3xl text-sm leading-6 text-slate-300 sm:text-[15px]">
-            Este es el hub para providers de repositorios e integraciones transversales. Azure DevOps, GitHub y GitLab quedan operativos;
-            Bitbucket entra al backlog futuro.
+          <p className="text-xs font-semibold uppercase tracking-[0.3em] text-sky-700">Settings</p>
+          <h1 className="mt-3 text-3xl font-semibold tracking-tight text-slate-950 sm:text-4xl">Configuracion simple del workspace</h1>
+          <p className="mt-3 max-w-3xl text-sm leading-6 text-slate-600 sm:text-[15px]">
+            Esta vista deja solo el estado general y los accesos importantes. El detalle de providers, Codex y politicas vive en modales para mantener la pantalla principal liviana.
           </p>
         </div>
         <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-1">
@@ -55,13 +54,13 @@ function HeroMetric({ icon, label, value, detail }: {
   detail: string;
 }) {
   return (
-    <article className="rounded-2xl border border-white/10 bg-white/5 p-4 backdrop-blur">
-      <div className="flex items-center gap-2 text-sky-300">
+    <article className="rounded-2xl border border-slate-200 bg-white/80 p-4 backdrop-blur">
+      <div className="flex items-center gap-2 text-sky-700">
         {icon}
         <p className="text-[11px] font-semibold uppercase tracking-[0.24em]">{label}</p>
       </div>
-      <p className="mt-3 text-2xl font-semibold text-white">{value}</p>
-      <p className="mt-2 text-sm leading-6 text-slate-300">{detail}</p>
+      <p className="mt-3 text-2xl font-semibold text-slate-950">{value}</p>
+      <p className="mt-2 text-sm leading-6 text-slate-500">{detail}</p>
     </article>
   );
 }

--- a/src/renderer/features/settings/components/SettingsIntegrationsPanel.tsx
+++ b/src/renderer/features/settings/components/SettingsIntegrationsPanel.tsx
@@ -6,7 +6,7 @@ import { repositoryProviders } from '../../repository-source/providers';
 import CodexIntegrationCard from './CodexIntegrationCard';
 import GlobalSnapshotPolicyCard from './GlobalSnapshotPolicyCard';
 import RepositoryProviderCard from './RepositoryProviderCard';
-import { SettingsSectionCard, SettingsStatusBadge } from './SettingsPrimitives';
+import { SettingsActionCard, SettingsModal, SettingsSectionCard, SettingsStatusBadge } from './SettingsPrimitives';
 
 export function SettingsIntegrationsSection({
   activeProvider,
@@ -54,73 +54,140 @@ export function SettingsIntegrationsSection({
   updateCodexConfig: <K extends keyof CodexIntegrationConfig>(name: K, value: CodexIntegrationConfig[K]) => void;
 }) {
   const [expandedProviderKind, setExpandedProviderKind] = React.useState<RepositoryProviderKind | ''>(config.provider);
+  const [isProviderModalOpen, setIsProviderModalOpen] = React.useState(false);
+  const [isCodexModalOpen, setIsCodexModalOpen] = React.useState(false);
+  const [isSnapshotModalOpen, setIsSnapshotModalOpen] = React.useState(false);
 
   React.useEffect(() => {
     setExpandedProviderKind(config.provider);
   }, [config.provider]);
 
+  const activeProviderLabel = config.provider ? activeProviderName : 'No seleccionado';
+  const snapshotRulesCount = codexConfig.snapshotPolicy.excludedPathPatterns
+    .split('\n')
+    .map((pattern) => pattern.trim())
+    .filter(Boolean)
+    .length;
+
   return (
     <section className="space-y-6">
-        <SettingsSectionCard
-          eyebrow="Prioridad 2"
-          title="Provider activo y fuentes disponibles"
-          description="Primero configura la fuente principal del workspace. Despues puedes cambiar de provider sin salir de Settings."
-          badge={<SettingsStatusBadge tone="sky" label={`${repositoryProviders.length} fuentes modeladas`} />}
-        >
-          <div className="grid gap-4">
-            {repositoryProviders.map((provider) => (
-              <RepositoryProviderCard
-                key={provider.kind}
-                provider={provider}
-                isActive={provider.kind === activeProvider?.kind}
-                isConfigured={provider.kind === activeProvider?.kind && isConnectionReady}
-                expanded={provider.kind === activeProvider?.kind && expandedProviderKind === provider.kind}
-                onToggleExpand={provider.status === 'available' && provider.kind === activeProvider?.kind
-                  ? () => setExpandedProviderKind((current) => (current === provider.kind ? '' : provider.kind))
-                  : undefined}
-                onActivate={provider.status === 'available' && provider.kind !== activeProvider?.kind
-                  ? () => {
-                    updateConfig('provider', provider.kind);
-                    setExpandedProviderKind(provider.kind);
-                  }
-                  : undefined}
-              >
-                {provider.kind === activeProvider?.kind ? (
-                  <ConnectionPanel
-                    providerName={activeProviderName}
-                    providerKind={provider.kind}
-                    isConnected={isConnectionReady}
-                    config={config}
-                    error={error}
-                    projectDiscoveryWarning={projectDiscoveryWarning}
-                    isLoading={isLoading}
-                    projects={projects}
-                    projectsLoading={projectsLoading}
-                    repositories={repositories}
-                    repositoriesLoading={repositoriesLoading}
-                    onDiscoverProjects={() => void discoverProjects()}
-                    onSelectProject={(project) => void selectProject(project)}
-                    onConfigChange={updateConfig}
-                    onRefresh={() => void refreshPullRequests()}
-                  />
-                ) : null}
-              </RepositoryProviderCard>
-            ))}
-          </div>
-        </SettingsSectionCard>
-
-        <div className="grid gap-6 2xl:grid-cols-2">
-          <GlobalSnapshotPolicyCard
-            snapshotPolicy={codexConfig.snapshotPolicy}
-            onChange={(value) => updateCodexConfig('snapshotPolicy', value)}
+      <SettingsSectionCard
+        eyebrow="Configuracion"
+        title="Integraciones y reglas"
+        description="La vista principal muestra solo el estado actual. Abre cada modal cuando necesites editar providers, integracion AI o politicas globales."
+        badge={<SettingsStatusBadge tone="sky" label="Experiencia simplificada" />}
+      >
+        <div className="grid gap-4 lg:auto-rows-fr lg:grid-cols-3">
+          <SettingsActionCard
+            eyebrow="Provider"
+            title="Fuente principal"
+            description="Selecciona el provider activo y ajusta alcance o conexion solo cuando realmente lo necesites."
+            badge={<SettingsStatusBadge tone={isConnectionReady ? 'emerald' : 'amber'} label={isConnectionReady ? 'Conectado' : 'Pendiente'} />}
+            summaryLabel="Activo"
+            summaryValue={activeProviderLabel}
+            summaryDescription={selectedRepositoryName || selectedProjectName || summary.scopeLabel}
+            actionLabel="Abrir configuracion"
+            onAction={() => setIsProviderModalOpen(true)}
           />
 
-          <CodexIntegrationCard
-            config={codexConfig}
-            isReady={isCodexReady}
-            onChange={updateCodexConfig}
+          <SettingsActionCard
+            eyebrow="Codex"
+            title="Analisis AI"
+            description="Mantiene a mano el estado de la integracion sin exponer todos los campos en la vista principal."
+            badge={<SettingsStatusBadge tone={isCodexReady ? 'emerald' : 'amber'} label={isCodexReady ? 'Listo' : 'Pendiente'} />}
+            summaryLabel="Modelo"
+            summaryValue={codexConfig.model}
+            summaryDescription={codexConfig.enabled ? 'Integracion habilitada para analisis.' : 'Integracion deshabilitada en esta sesion.'}
+            actionLabel="Abrir configuracion"
+            onAction={() => setIsCodexModalOpen(true)}
+          />
+
+          <SettingsActionCard
+            eyebrow="Snapshots"
+            title="Politica global"
+            description="Agrupa reglas base y modo estricto sin mezclar este detalle con la operacion diaria."
+            badge={<SettingsStatusBadge tone="sky" label={`${snapshotRulesCount} reglas`} />}
+            summaryLabel="Modo"
+            summaryValue={codexConfig.snapshotPolicy.strictMode ? 'Estricto' : 'Flexible'}
+            summaryDescription="Base comun para Repository Analysis y PR AI Review."
+            actionLabel="Editar reglas"
+            onAction={() => setIsSnapshotModalOpen(true)}
           />
         </div>
+      </SettingsSectionCard>
+
+      <SettingsModal
+        isOpen={isProviderModalOpen}
+        onClose={() => setIsProviderModalOpen(false)}
+        title="Configuracion de provider"
+        description="Selecciona la fuente principal del workspace y completa su conexion sin cargar la vista principal."
+      >
+        <div className="grid gap-4">
+          {repositoryProviders.map((provider) => (
+            <RepositoryProviderCard
+              key={provider.kind}
+              provider={provider}
+              isActive={provider.kind === activeProvider?.kind}
+              isConfigured={provider.kind === activeProvider?.kind && isConnectionReady}
+              expanded={provider.kind === activeProvider?.kind && expandedProviderKind === provider.kind}
+              onToggleExpand={provider.status === 'available' && provider.kind === activeProvider?.kind
+                ? () => setExpandedProviderKind((current) => (current === provider.kind ? '' : provider.kind))
+                : undefined}
+              onActivate={provider.status === 'available' && provider.kind !== activeProvider?.kind
+                ? () => {
+                  updateConfig('provider', provider.kind);
+                  setExpandedProviderKind(provider.kind);
+                }
+                : undefined}
+            >
+              {provider.kind === activeProvider?.kind ? (
+                <ConnectionPanel
+                  providerName={activeProviderName}
+                  providerKind={provider.kind}
+                  isConnected={isConnectionReady}
+                  config={config}
+                  error={error}
+                  projectDiscoveryWarning={projectDiscoveryWarning}
+                  isLoading={isLoading}
+                  projects={projects}
+                  projectsLoading={projectsLoading}
+                  repositories={repositories}
+                  repositoriesLoading={repositoriesLoading}
+                  onDiscoverProjects={() => void discoverProjects()}
+                  onSelectProject={(project) => void selectProject(project)}
+                  onConfigChange={updateConfig}
+                  onRefresh={() => void refreshPullRequests()}
+                />
+              ) : null}
+            </RepositoryProviderCard>
+          ))}
+        </div>
+      </SettingsModal>
+
+      <SettingsModal
+        isOpen={isCodexModalOpen}
+        onClose={() => setIsCodexModalOpen(false)}
+        title="Configuracion de Codex"
+        description="Toda la configuracion de analisis AI vive aqui para mantener Settings simple y enfocada."
+      >
+        <CodexIntegrationCard
+          config={codexConfig}
+          isReady={isCodexReady}
+          onChange={updateCodexConfig}
+        />
+      </SettingsModal>
+
+      <SettingsModal
+        isOpen={isSnapshotModalOpen}
+        onClose={() => setIsSnapshotModalOpen(false)}
+        title="Reglas globales de snapshot"
+        description="Ajusta exclusiones base y modo estricto sin mezclar este detalle con la vista principal."
+      >
+        <GlobalSnapshotPolicyCard
+          snapshotPolicy={codexConfig.snapshotPolicy}
+          onChange={(value) => updateCodexConfig('snapshotPolicy', value)}
+        />
+      </SettingsModal>
     </section>
   );
 }

--- a/src/renderer/features/settings/components/SettingsOperationalPanel.tsx
+++ b/src/renderer/features/settings/components/SettingsOperationalPanel.tsx
@@ -2,8 +2,7 @@ import React from 'react';
 import type { RepositoryProviderDefinition } from '../../../../types/repository';
 import ConnectionSummary from '../../dashboard/components/ConnectionSummary';
 import type { DashboardSummary, SavedConnectionConfig } from '../../dashboard/types';
-import { BoltIcon, WrenchScrewdriverIcon } from '@heroicons/react/24/outline';
-import { SettingsSectionCard, SettingsStatTile, SettingsStatusBadge } from './SettingsPrimitives';
+import { SettingsSectionCard, SettingsStatTile, SettingsStatusBadge, SettingsSurfaceCard } from './SettingsPrimitives';
 
 export function SettingsOperationalSection({
   activeProvider,
@@ -26,24 +25,12 @@ export function SettingsOperationalSection({
 }) {
   return (
     <SettingsSectionCard
-      eyebrow="Prioridad 1"
+      eyebrow="Resumen"
       title="Resumen operativo"
-      description="Empieza aqui: esta vista resume el estado del workspace y deja el detalle tecnico fuera del camino principal."
+      description="El estado esencial del workspace vive aqui. Todo lo demas se abre bajo demanda para que Settings no se convierta en un formulario gigante."
       badge={<SettingsStatusBadge tone={isConnectionReady ? 'emerald' : 'amber'} label={isConnectionReady ? 'Workspace operativo' : 'Faltan pasos'} />}
-      actions={(
-        <div className="flex w-full flex-wrap gap-2 sm:w-auto">
-          <span className="inline-flex items-center gap-2 rounded-full border border-slate-200 bg-slate-50 px-3 py-2 text-sm text-slate-600">
-            <BoltIcon className="h-4 w-4 text-sky-600" />
-            Secrets solo en sesion
-          </span>
-          <span className="inline-flex items-center gap-2 rounded-full border border-slate-200 bg-slate-50 px-3 py-2 text-sm text-slate-600">
-            <WrenchScrewdriverIcon className="h-4 w-4 text-sky-600" />
-            Diagnostico en panel lateral
-          </span>
-        </div>
-      )}
     >
-      <div className="grid gap-6 2xl:grid-cols-[minmax(0,1.3fr)_minmax(320px,0.9fr)]">
+      <div className="grid gap-6 xl:grid-cols-[minmax(0,1.2fr)_minmax(300px,0.8fr)]">
         <div className="space-y-4">
           <div className="grid gap-4 sm:grid-cols-2">
             <SettingsStatTile label="Provider activo" value={config.provider ? activeProviderName : 'No seleccionado'} description="Fuente primaria de repositorios y PRs para esta sesion." />
@@ -51,8 +38,8 @@ export function SettingsOperationalSection({
             <SettingsStatTile label="Scope actual" value={selectedRepositoryName || selectedProjectName || 'Global'} description={summary.scopeLabel} />
             <SettingsStatTile label="Codex" value={isCodexReady ? 'Listo' : 'Pendiente'} description="Disponibilidad de analisis AI sobre ramas exactas y PRs." />
           </div>
-          <div className="rounded-3xl border border-slate-200 bg-slate-50/80 p-5">
-            <p className="text-[11px] font-semibold uppercase tracking-[0.24em] text-slate-400">Siguiente accion</p>
+          <SettingsSurfaceCard className="bg-slate-50/80">
+            <p className="text-[11px] font-semibold uppercase tracking-[0.24em] text-slate-400">Siguiente paso</p>
             <p className="mt-3 text-lg font-semibold text-slate-950">
               {!config.provider
                 ? 'Selecciona un provider'
@@ -68,10 +55,10 @@ export function SettingsOperationalSection({
                 : !isConnectionReady
                   ? 'Autentica el provider activo y ejecuta una sincronizacion inicial.'
                   : !isCodexReady
-                    ? 'Configura la API key y las reglas base de Codex para habilitar PR AI Review y Repository Analysis.'
+                  ? 'Configura la API key y las reglas base de Codex para habilitar PR AI Review y Repository Analysis.'
                     : 'Puedes ir al dashboard para operar la cola de PRs o lanzar un analisis profundo de repositorio.'}
             </p>
-          </div>
+          </SettingsSurfaceCard>
         </div>
 
         <ConnectionSummary

--- a/src/renderer/features/settings/components/SettingsPrimitives.tsx
+++ b/src/renderer/features/settings/components/SettingsPrimitives.tsx
@@ -20,6 +20,7 @@ interface SettingsSectionCardProps {
   actions?: React.ReactNode;
   children?: React.ReactNode;
   className?: string;
+  tone?: 'default' | 'subtle';
 }
 
 export const SettingsSectionCard = ({
@@ -30,8 +31,13 @@ export const SettingsSectionCard = ({
   actions,
   children,
   className = '',
+  tone = 'default',
 }: SettingsSectionCardProps) => (
-  <section className={`rounded-[24px] border border-slate-200 bg-white/95 p-5 shadow-[0_20px_70px_-45px_rgba(15,23,42,0.45)] backdrop-blur sm:rounded-[28px] sm:p-6 ${className}`}>
+  <section className={`${
+    tone === 'subtle'
+      ? 'rounded-[24px] border border-slate-200/80 bg-slate-50/70 p-5 shadow-none sm:rounded-[28px] sm:p-6'
+      : 'rounded-[24px] border border-slate-200 bg-white/95 p-5 shadow-[0_20px_70px_-45px_rgba(15,23,42,0.45)] backdrop-blur sm:rounded-[28px] sm:p-6'
+  } ${className}`}>
     <div className="flex flex-col gap-4 lg:flex-row lg:items-start lg:justify-between">
       <div className="min-w-0 flex-1">
         {eyebrow ? (
@@ -51,6 +57,22 @@ export const SettingsSectionCard = ({
     {children ? <div className="mt-6">{children}</div> : null}
   </section>
 );
+
+interface SettingsSurfaceCardProps {
+  children: React.ReactNode;
+  className?: string;
+}
+
+export const SettingsSurfaceCard = ({
+  children,
+  className = '',
+}: SettingsSurfaceCardProps) => (
+  <article className={`rounded-[24px] border border-slate-200/90 bg-slate-50/70 p-5 ${className}`}>
+    {children}
+  </article>
+);
+
+export const settingsButtonClassName = 'inline-flex items-center justify-center rounded-full border border-slate-300 px-4 py-2.5 text-sm font-medium text-slate-700 transition hover:border-sky-500 hover:text-sky-600';
 
 interface SettingsStatusBadgeProps {
   tone: BadgeTone;
@@ -205,14 +227,65 @@ interface SettingsStatTileProps {
   label: string;
   value: string;
   description: string;
+  className?: string;
 }
 
-export const SettingsStatTile = ({ label, value, description }: SettingsStatTileProps) => (
-  <article className="min-w-0 rounded-2xl border border-slate-200 bg-white/70 p-4">
+export const SettingsStatTile = ({ label, value, description, className = '' }: SettingsStatTileProps) => (
+  <article className={`min-w-0 rounded-2xl border border-slate-200 bg-white/70 p-4 ${className}`}>
     <p className="text-[11px] font-semibold uppercase tracking-[0.24em] text-slate-400">{label}</p>
     <p className="mt-3 break-words text-2xl font-semibold text-slate-950">{value}</p>
     <p className="mt-2 text-sm leading-6 text-slate-500">{description}</p>
   </article>
+);
+
+interface SettingsActionCardProps {
+  eyebrow: string;
+  title: string;
+  description: string;
+  badge?: React.ReactNode;
+  summaryLabel: string;
+  summaryValue: string;
+  summaryDescription: string;
+  actionLabel: string;
+  onAction: () => void;
+}
+
+export const SettingsActionCard = ({
+  eyebrow,
+  title,
+  description,
+  badge,
+  summaryLabel,
+  summaryValue,
+  summaryDescription,
+  actionLabel,
+  onAction,
+}: SettingsActionCardProps) => (
+  <SettingsSurfaceCard className="flex h-full flex-col">
+    <div className="flex items-start justify-between gap-3">
+      <div className="min-w-0">
+        <p className="text-[11px] font-semibold uppercase tracking-[0.24em] text-slate-400">{eyebrow}</p>
+        <h3 className="mt-2 text-lg font-semibold text-slate-950">{title}</h3>
+      </div>
+      {badge}
+    </div>
+    <p className="mt-3 min-h-[4.5rem] text-sm leading-6 text-slate-500">{description}</p>
+    <div className="mt-4 flex-1">
+      <SettingsStatTile
+        label={summaryLabel}
+        value={summaryValue}
+        description={summaryDescription}
+        className="h-full"
+      />
+    </div>
+    <button
+      type="button"
+      onClick={onAction}
+      className={`mt-4 w-full ${settingsButtonClassName}`}
+    >
+      {actionLabel}
+    </button>
+  </SettingsSurfaceCard>
 );
 
 interface SettingsNoticeProps {
@@ -304,7 +377,7 @@ export const SettingsModal = ({
             <button
               type="button"
               onClick={onClose}
-              className="rounded-full border border-slate-300 px-3 py-1.5 text-sm font-medium text-slate-700 transition hover:border-sky-500 hover:text-sky-600"
+              className={settingsButtonClassName}
             >
               Cerrar
             </button>

--- a/src/renderer/features/settings/components/SettingsSections.tsx
+++ b/src/renderer/features/settings/components/SettingsSections.tsx
@@ -1,4 +1,4 @@
 export { SettingsHero } from './SettingsHeroSection';
 export { SettingsOperationalSection } from './SettingsOperationalPanel';
 export { SettingsIntegrationsSection } from './SettingsIntegrationsPanel';
-export { SettingsDiagnosticsSection, SettingsRoadmapSection } from './SettingsSupportPanels';
+export { SettingsDiagnosticsSection } from './SettingsSupportPanels';

--- a/src/renderer/features/settings/components/SettingsSupportPanels.tsx
+++ b/src/renderer/features/settings/components/SettingsSupportPanels.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import type { AzureDiagnostics, SavedConnectionConfig } from '../../dashboard/types';
-import { SettingsModal, SettingsSectionCard, SettingsStatusBadge } from './SettingsPrimitives';
+import { SettingsModal, SettingsSectionCard, SettingsStatusBadge, SettingsSurfaceCard, settingsButtonClassName } from './SettingsPrimitives';
 
 export function SettingsDiagnosticsSection({
   activeProviderName,
@@ -19,15 +19,15 @@ export function SettingsDiagnosticsSection({
 
   return (
     <SettingsSectionCard
-      eyebrow="Prioridad 3"
+      eyebrow="Soporte"
       title="Diagnostico del provider"
-      description="La vista principal queda limpia y el detalle tecnico vive en un modal dedicado."
+      description="El detalle tecnico vive en un modal dedicado para no contaminar la configuracion diaria."
       badge={<SettingsStatusBadge tone={diagnostics.lastError ? 'rose' : 'slate'} label={diagnostics.lastError ? 'Con error' : 'Sin error activo'} />}
       actions={(
         <button
           type="button"
           onClick={() => setIsModalOpen(true)}
-          className="inline-flex w-full items-center justify-center rounded-full border border-slate-300 px-4 py-2 text-sm font-medium text-slate-700 transition hover:border-sky-500 hover:text-sky-600 sm:w-auto"
+          className={`w-full sm:w-auto ${settingsButtonClassName}`}
         >
           Abrir diagnostico
         </button>
@@ -40,14 +40,14 @@ export function SettingsDiagnosticsSection({
             : 'No hay errores activos. Abre el diagnostico solo cuando necesites revisar autenticacion, scope o request path.'}
         </p>
         <div className="grid gap-3 sm:grid-cols-2">
-          <div className="rounded-2xl border border-slate-200 bg-slate-50 px-4 py-3">
+          <SettingsSurfaceCard className="px-4 py-3">
             <p className="text-xs font-semibold uppercase tracking-[0.2em] text-slate-400">Operacion</p>
             <p className="mt-2 font-medium text-slate-900">{diagnostics.operation || 'sin ejecucion'}</p>
-          </div>
-          <div className="rounded-2xl border border-slate-200 bg-slate-50 px-4 py-3">
+          </SettingsSurfaceCard>
+          <SettingsSurfaceCard className="px-4 py-3">
             <p className="text-xs font-semibold uppercase tracking-[0.2em] text-slate-400">Sesion</p>
             <p className="mt-2 font-medium text-slate-900">{hasCredentialsInSession ? 'Credenciales cargadas' : 'Sin credenciales'}</p>
-          </div>
+          </SettingsSurfaceCard>
         </div>
       </div>
       {diagnostics.lastError ? (
@@ -66,7 +66,7 @@ export function SettingsDiagnosticsSection({
             <button
               type="button"
               onClick={() => setIsModalOpen(false)}
-              className="inline-flex items-center justify-center rounded-full border border-slate-300 px-4 py-2 text-sm font-medium text-slate-700 transition hover:border-sky-500 hover:text-sky-600"
+              className={settingsButtonClassName}
             >
               Cerrar
             </button>
@@ -85,11 +85,11 @@ export function SettingsDiagnosticsSection({
             <p><span className="font-medium text-slate-900">Conexion exitosa:</span> {hasSuccessfulConnection ? 'si' : 'no'}</p>
           </div>
 
-          <div className="rounded-2xl border border-slate-200 bg-slate-50/80 px-4 py-4 text-sm leading-6 text-slate-600">
+          <SettingsSurfaceCard className="text-sm leading-6 text-slate-600">
             <p className="font-medium text-slate-900">Persistencia y sesion</p>
             <p className="mt-2">Las fuentes de repositorios no persisten organizacion, proyecto ni repositorio al cerrar la app.</p>
             <p>Se guarda solo en sesion el token del provider activo y la API key de Codex para no persistir secretos en disco.</p>
-          </div>
+          </SettingsSurfaceCard>
 
           {diagnostics.lastError ? (
             <div className="rounded-2xl border border-rose-200 bg-rose-50 px-4 py-3 text-sm leading-6 text-rose-700">
@@ -99,36 +99,5 @@ export function SettingsDiagnosticsSection({
         </div>
       </SettingsModal>
     </SettingsSectionCard>
-  );
-}
-
-export function SettingsRoadmapSection() {
-  return (
-    <SettingsSectionCard
-      eyebrow="Roadmap"
-      title="Integraciones futuras"
-      description="Lo que venga despues debe caer aqui sin competir con la configuracion operativa del dia a dia."
-    >
-      <div className="space-y-4">
-        <IntegrationCard title="Security Providers" description="Conectores a scanners externos, SAST/DAST y fuentes de vulnerabilidades." status="Planned" />
-        <IntegrationCard title="Notifications" description="Canales como Teams, Slack o email con reglas por riesgo y SLA." status="Planned" />
-      </div>
-    </SettingsSectionCard>
-  );
-}
-
-function IntegrationCard({ title, description, status }: {
-  title: string;
-  description: string;
-  status: string;
-}) {
-  return (
-    <article className="rounded-2xl border border-slate-200 bg-slate-50 p-4">
-      <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
-        <h3 className="font-semibold text-slate-900">{title}</h3>
-        <span className="rounded-full bg-amber-100 px-3 py-1 text-xs font-medium text-amber-700">{status}</span>
-      </div>
-      <p className="mt-2 text-sm text-slate-600">{description}</p>
-    </article>
   );
 }

--- a/src/renderer/pages/Settings.tsx
+++ b/src/renderer/pages/Settings.tsx
@@ -7,7 +7,6 @@ import {
   SettingsHero,
   SettingsIntegrationsSection,
   SettingsOperationalSection,
-  SettingsRoadmapSection,
 } from '../features/settings/components/SettingsSections';
 
 const Settings = () => {
@@ -44,62 +43,57 @@ const Settings = () => {
     <motion.div
       initial={{ opacity: 0, y: 16 }}
       animate={{ opacity: 1, y: 0 }}
-      className="mx-auto max-w-[1520px] space-y-6 lg:space-y-8"
+      className="mx-auto max-w-[1220px] space-y-6 lg:space-y-8"
     >
       <SettingsHero
         isConnectionReady={isConnectionReady}
         isCodexReady={isCodexReady}
       />
 
-      <section className="grid gap-6 xl:grid-cols-[minmax(0,1.45fr)_minmax(320px,0.85fr)]">
-        <div className="space-y-6">
-          <SettingsOperationalSection
-            activeProvider={activeProvider}
-            activeProviderName={activeProviderName}
-            config={config}
-            selectedProjectName={selectedProjectName}
-            selectedRepositoryName={selectedRepositoryName}
-            summary={summary}
-            isConnectionReady={isConnectionReady}
-            isCodexReady={isCodexReady}
-          />
+      <div className="space-y-6">
+        <SettingsOperationalSection
+          activeProvider={activeProvider}
+          activeProviderName={activeProviderName}
+          config={config}
+          selectedProjectName={selectedProjectName}
+          selectedRepositoryName={selectedRepositoryName}
+          summary={summary}
+          isConnectionReady={isConnectionReady}
+          isCodexReady={isCodexReady}
+        />
 
-          <SettingsIntegrationsSection
-            activeProvider={activeProvider}
-            activeProviderName={activeProviderName}
-            config={config}
-            summary={summary}
-            selectedProjectName={selectedProjectName}
-            selectedRepositoryName={selectedRepositoryName}
-            error={error}
-            isConnectionReady={isConnectionReady}
-            isLoading={isLoading}
-            projects={projects}
-            projectsLoading={projectsLoading}
-            projectDiscoveryWarning={projectDiscoveryWarning}
-            repositories={repositories}
-            repositoriesLoading={repositoriesLoading}
-            discoverProjects={() => void discoverProjects()}
-            selectProject={(project) => void selectProject(project)}
-            updateConfig={updateConfig}
-            refreshPullRequests={() => void refreshPullRequests()}
-            codexConfig={codexConfig}
-            isCodexReady={isCodexReady}
-            updateCodexConfig={updateCodexConfig}
-          />
-        </div>
+        <SettingsIntegrationsSection
+          activeProvider={activeProvider}
+          activeProviderName={activeProviderName}
+          config={config}
+          summary={summary}
+          selectedProjectName={selectedProjectName}
+          selectedRepositoryName={selectedRepositoryName}
+          error={error}
+          isConnectionReady={isConnectionReady}
+          isLoading={isLoading}
+          projects={projects}
+          projectsLoading={projectsLoading}
+          projectDiscoveryWarning={projectDiscoveryWarning}
+          repositories={repositories}
+          repositoriesLoading={repositoriesLoading}
+          discoverProjects={() => void discoverProjects()}
+          selectProject={(project) => void selectProject(project)}
+          updateConfig={updateConfig}
+          refreshPullRequests={() => void refreshPullRequests()}
+          codexConfig={codexConfig}
+          isCodexReady={isCodexReady}
+          updateCodexConfig={updateCodexConfig}
+        />
 
-        <div className="space-y-6 xl:sticky xl:top-6 xl:self-start">
-          <SettingsDiagnosticsSection
-            activeProviderName={activeProviderName}
-            config={config}
-            diagnostics={diagnostics}
-            hasCredentialsInSession={hasCredentialsInSession}
-            hasSuccessfulConnection={hasSuccessfulConnection}
-          />
-          <SettingsRoadmapSection />
-        </div>
-      </section>
+        <SettingsDiagnosticsSection
+          activeProviderName={activeProviderName}
+          config={config}
+          diagnostics={diagnostics}
+          hasCredentialsInSession={hasCredentialsInSession}
+          hasSuccessfulConnection={hasSuccessfulConnection}
+        />
+      </div>
     </motion.div>
   );
 };

--- a/tests/integration/renderer/settings.page.dom.test.js
+++ b/tests/integration/renderer/settings.page.dom.test.js
@@ -25,7 +25,7 @@ function renderWithRouter(element) {
 }
 
 describe('Settings page', () => {
-  test('muestra el resumen operativo y abre modales de soporte y politicas avanzadas', async () => {
+  test('muestra un hub simple y abre modales de configuracion y soporte', async () => {
     const user = userEvent.setup();
     useRepositorySourceContext.mockReturnValue(createRepositorySourceContext({
       activeProvider: { kind: 'github' },
@@ -89,9 +89,20 @@ describe('Settings page', () => {
     expect(screen.getByText('Resumen operativo')).toBeInTheDocument();
     expect(screen.getByText('Workspace operativo')).toBeInTheDocument();
     expect(screen.getAllByText('GitHub').length).toBeGreaterThan(0);
-    expect(screen.getByText('Provider activo y fuentes disponibles')).toBeInTheDocument();
-    expect(screen.getByText('Reglas globales de snapshot')).toBeInTheDocument();
+    expect(screen.getByText('Configuracion simple del workspace')).toBeInTheDocument();
+    expect(screen.getByText('Integraciones y reglas')).toBeInTheDocument();
+    expect(screen.getAllByRole('button', { name: /abrir configuracion/i }).length).toBe(2);
+    expect(screen.getByRole('button', { name: /editar reglas/i })).toBeInTheDocument();
+
+    await user.click(screen.getAllByRole('button', { name: /abrir configuracion/i })[0]);
+    expect(screen.getByRole('dialog', { name: /configuracion de provider/i })).toBeInTheDocument();
+    expect(screen.getAllByText(/^provider$/i).length).toBeGreaterThan(0);
+    await user.click(screen.getByRole('button', { name: /^cerrar$/i }));
+
+    await user.click(screen.getAllByRole('button', { name: /abrir configuracion/i })[1]);
+    expect(screen.getByRole('dialog', { name: /configuracion de codex/i })).toBeInTheDocument();
     expect(screen.getAllByText(/politicas avanzadas/i).length).toBeGreaterThan(0);
+    await user.click(screen.getByRole('button', { name: /^cerrar$/i }));
 
     await user.click(screen.getByRole('button', { name: /abrir diagnostico/i }));
     expect(screen.getByRole('dialog', { name: /diagnostico del provider/i })).toBeInTheDocument();
@@ -100,9 +111,13 @@ describe('Settings page', () => {
 
     await user.click(screen.getByRole('button', { name: /editar reglas/i }));
     expect(screen.getByRole('dialog', { name: /reglas globales de snapshot/i })).toBeInTheDocument();
+    await user.click(screen.getAllByRole('button', { name: /editar reglas/i })[1]);
     expect(screen.getByRole('button', { name: /aplicar preset node/i })).toBeInTheDocument();
     await user.click(screen.getByRole('button', { name: /^listo$/i }));
+    await user.click(screen.getAllByRole('button', { name: /^cerrar$/i })[0]);
 
+    await user.click(screen.getAllByRole('button', { name: /abrir configuracion/i })[1]);
+    expect(screen.getByRole('dialog', { name: /configuracion de codex/i })).toBeInTheDocument();
     await user.click(screen.getByRole('button', { name: /politicas avanzadas/i }));
     expect(screen.getByRole('dialog', { name: /politicas avanzadas de codex/i })).toBeInTheDocument();
     expect(screen.getByLabelText(/focus areas para pr ai review/i)).toBeInTheDocument();


### PR DESCRIPTION
## Resumen

Este PR simplifica la experiencia de `Settings` para que la vista principal funcione como un hub liviano y operativo, moviendo la configuración detallada a modales dedicados. Además, normaliza el sistema visual de cards para que la página y sus modales compartan una misma gramática de UI.

## Objetivo

La vista de configuración estaba demasiado cargada y mezclaba estado operativo, configuración avanzada y soporte técnico en una sola pantalla. Eso hacía que la jerarquía visual se sintiera pesada y que varios bloques no obedecieran el mismo lenguaje visual.

Con este cambio buscamos:
- dejar `Settings` como una vista simple y fácil de escanear
- mover la configuración detallada a modales enfocados
- homologar cards, superficies y CTAs para que la experiencia se vea consistente
- mejorar la estabilidad visual de las cards de integraciones aunque cambie el largo del texto

## Cambios incluidos

- Se simplifica la vista principal de `Settings` para que actúe como hub de estado y acceso.
- Se separa la configuración detallada de provider, Codex y snapshot policy en modales dedicados.
- Se elimina ruido visual y se reduce la densidad del contenido principal.
- Se normalizan primitives reutilizables para la experiencia de configuración.
- Se agrega una variante visual más sutil para cards anidadas dentro de modales.
- Se unifican botones y superficies auxiliares para evitar diferencias entre secciones.
- Se homologan las cards de provider, Codex, snapshot policy y diagnóstico con el mismo sistema visual.
- Se estabiliza la composición de las cards en `Integraciones y reglas` para que mantengan una altura más consistente aunque cambie el copy.
- Se actualizan los tests DOM de `Settings` para reflejar el nuevo flujo con modales.

## Impacto UX/UI

- `Settings` se siente más liviana y enfocada.
- La vista principal muestra solo el contexto esencial y los accesos más importantes.
- Los modales concentran el detalle sin convertir la página en un formulario gigante.
- Las cards ahora comparten mejor jerarquía, espaciado, tratamiento visual y comportamiento.
- La sección `Integraciones y reglas` queda más equilibrada visualmente y con CTAs alineados.

## Consideraciones técnicas

- La homologación se apoyó en primitives reutilizables para evitar duplicación de estilos.
- Se reutiliza el mismo sistema de cards tanto en la vista principal como dentro de modales, con una variante `subtle` para contextos anidados.
- Se mantuvo el comportamiento funcional existente de configuración; el foco del PR está en simplificación estructural y consistencia visual.

## Archivos relevantes

- `src/renderer/pages/Settings.tsx`
- `src/renderer/features/settings/components/SettingsPrimitives.tsx`
- `src/renderer/features/settings/components/SettingsIntegrationsPanel.tsx`
- `src/renderer/features/settings/components/SettingsOperationalPanel.tsx`
- `src/renderer/features/settings/components/SettingsSupportPanels.tsx`
- `src/renderer/features/settings/components/RepositoryProviderCard.tsx`
- `src/renderer/features/settings/components/CodexIntegrationCard.tsx`
- `src/renderer/features/settings/components/GlobalSnapshotPolicyCard.tsx`
- `tests/integration/renderer/settings.page.dom.test.js`

## Validación realizada

- `npm run typecheck`
- `npx jest tests/integration/renderer/settings.page.dom.test.js tests/unit/renderer/codex-integration-card.dom.test.js tests/unit/renderer/global-snapshot-policy-card.dom.test.js --runInBand`
- `npm run build`

## QA sugerido

- Revisar la vista principal de `Settings` en desktop validando jerarquía y densidad visual.
- Abrir los modales de provider, Codex, snapshot policy y diagnóstico para confirmar consistencia visual entre niveles.
- Verificar que las tres cards de `Integraciones y reglas` mantengan una altura equilibrada con distintos estados y textos.
- Confirmar que los CTA y badges sigan alineados correctamente en resoluciones intermedias.