### PR TITLE
feat: integrar controles de ventana custom en la title bar

### DIFF
--- a/src/main/main-window.ts
+++ b/src/main/main-window.ts
@@ -13,7 +13,7 @@ export function buildMainWindowOptions(): Electron.BrowserWindowConstructorOptio
     minWidth: 1080,
     minHeight: 720,
     frame: false,
-    titleBarStyle: process.platform === 'darwin' ? 'hiddenInset' : 'hidden',
+    titleBarStyle: 'hidden',
     titleBarOverlay: false,
     backgroundColor: '#e2e8f0',
     webPreferences: {
@@ -23,6 +23,18 @@ export function buildMainWindowOptions(): Electron.BrowserWindowConstructorOptio
       sandbox: true,
     },
   };
+}
+
+function hideNativeMacWindowControls(mainWindow: BrowserWindow): void {
+  if (process.platform !== 'darwin') {
+    return;
+  }
+
+  const macWindow = mainWindow as BrowserWindow & {
+    setWindowButtonVisibility?: (visible: boolean) => void;
+  };
+
+  macWindow.setWindowButtonVisibility?.(false);
 }
 
 export function resolveRendererTarget() {
@@ -38,6 +50,7 @@ export function resolveRendererTarget() {
 
 export function createWindow() {
   const mainWindow = new BrowserWindow(buildMainWindowOptions());
+  hideNativeMacWindowControls(mainWindow);
   attachWindowStateSync(mainWindow);
 
   const { rendererUrl, isDevelopment, productionFile } = resolveRendererTarget();

--- a/src/renderer/shared/layout/TitleBar.tsx
+++ b/src/renderer/shared/layout/TitleBar.tsx
@@ -39,6 +39,32 @@ const defaultMetadata = {
   title: 'CheckPR',
 };
 
+function detectRendererPlatform(): NodeJS.Platform {
+  if (typeof navigator === 'undefined') {
+    return 'win32';
+  }
+
+  const platformHint = (
+    (navigator as Navigator & { userAgentData?: { platform?: string } }).userAgentData?.platform
+    ?? navigator.platform
+    ?? ''
+  ).toLowerCase();
+
+  if (platformHint.includes('mac')) {
+    return 'darwin';
+  }
+
+  if (platformHint.includes('win')) {
+    return 'win32';
+  }
+
+  if (platformHint.includes('linux')) {
+    return 'linux';
+  }
+
+  return 'win32';
+}
+
 function isWindowControlsState(value: unknown): value is WindowControlsState {
   if (!value || typeof value !== 'object') {
     return false;
@@ -68,13 +94,132 @@ interface TitleBarProps {
   pathname: string;
 }
 
+interface WindowControlButtonsProps {
+  isMaximized: boolean;
+  onMinimize: () => Promise<void>;
+  onToggleMaximize: () => Promise<void>;
+  onClose: () => Promise<void>;
+}
+
+interface TrafficLightButtonProps {
+  label: string;
+  toneClassName: string;
+  onClick: () => Promise<void>;
+}
+
+interface DesktopTitleBarButtonProps {
+  label: string;
+  Icon: React.ComponentType<{ className?: string }>;
+  onClick: () => Promise<void>;
+  className?: string;
+}
+
+const TrafficLightButton = ({ label, toneClassName, onClick }: TrafficLightButtonProps) => (
+  <button
+    type="button"
+    aria-label={label}
+    onClick={() => { void onClick(); }}
+    className={`h-3.5 w-3.5 rounded-full shadow-[inset_0_1px_0_rgba(255,255,255,0.4)] transition duration-150 hover:scale-105 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 ${toneClassName}`}
+  >
+    <span className="sr-only">{label}</span>
+  </button>
+);
+
+const DesktopTitleBarButton = ({
+  label,
+  Icon,
+  onClick,
+  className = '',
+}: DesktopTitleBarButtonProps) => (
+  <button
+    type="button"
+    aria-label={label}
+    onClick={() => { void onClick(); }}
+    className={`rounded-xl p-2 text-slate-500 transition hover:bg-slate-100 hover:text-slate-900 ${className}`.trim()}
+  >
+    <Icon className="h-4 w-4" />
+  </button>
+);
+
+const MacWindowControls = ({
+  isMaximized,
+  onMinimize,
+  onToggleMaximize,
+  onClose,
+}: WindowControlButtonsProps) => {
+  const buttons = [
+    {
+      label: 'Close window',
+      onClick: onClose,
+      toneClassName: 'bg-rose-400 ring-1 ring-rose-500/20 hover:bg-rose-500 focus-visible:outline-rose-500',
+    },
+    {
+      label: 'Minimize window',
+      onClick: onMinimize,
+      toneClassName: 'bg-amber-400 ring-1 ring-amber-500/20 hover:bg-amber-500 focus-visible:outline-amber-500',
+    },
+    {
+      label: isMaximized ? 'Restore window' : 'Maximize window',
+      onClick: onToggleMaximize,
+      toneClassName: 'bg-emerald-400 ring-1 ring-emerald-500/20 hover:bg-emerald-500 focus-visible:outline-emerald-500',
+    },
+  ] satisfies TrafficLightButtonProps[];
+
+  return (
+    <div className="flex items-center" style={noDragRegionStyle}>
+      <div className="inline-flex items-center gap-2 rounded-full border border-slate-200/80 bg-white/80 px-3 py-2 shadow-sm ring-1 ring-white/70 backdrop-blur">
+        {buttons.map((button) => (
+          <TrafficLightButton key={button.label} {...button} />
+        ))}
+      </div>
+    </div>
+  );
+};
+
+const DesktopWindowControls = ({
+  isMaximized,
+  onMinimize,
+  onToggleMaximize,
+  onClose,
+}: WindowControlButtonsProps) => {
+  const MaximizeIcon = isMaximized ? Squares2X2Icon : ArrowsPointingOutIcon;
+  const buttons = [
+    {
+      label: 'Minimize window',
+      onClick: onMinimize,
+      Icon: MinusIcon,
+    },
+    {
+      label: isMaximized ? 'Restore window' : 'Maximize window',
+      onClick: onToggleMaximize,
+      Icon: MaximizeIcon,
+    },
+    {
+      label: 'Close window',
+      onClick: onClose,
+      Icon: XMarkIcon,
+      className: 'hover:bg-rose-100 hover:text-rose-700',
+    },
+  ] satisfies DesktopTitleBarButtonProps[];
+
+  return (
+    <div className="flex items-center" style={noDragRegionStyle}>
+      <div className="flex items-center rounded-2xl border border-slate-200/80 bg-white/80 p-1 shadow-sm ring-1 ring-white/70 backdrop-blur">
+        {buttons.map((button) => (
+          <DesktopTitleBarButton key={button.label} {...button} />
+        ))}
+      </div>
+    </div>
+  );
+};
+
 const TitleBar = ({ pathname }: TitleBarProps) => {
   const metadata = pageMetadata[pathname] ?? defaultMetadata;
   const supportsWindowControls = Boolean(getElectronApi()?.onWindowStateChange);
   const [windowState, setWindowState] = React.useState<WindowControlsState>({
     isMaximized: false,
     isFullScreen: false,
-    platform: 'win32',
+    platform: detectRendererPlatform(),
   });
 
   React.useEffect(() => {
@@ -120,47 +265,34 @@ const TitleBar = ({ pathname }: TitleBarProps) => {
     await invokeWindowControl('window-controls:close');
   }, []);
 
-  const MaximizeIcon = windowState.isMaximized ? Squares2X2Icon : ArrowsPointingOutIcon;
+  const isMacOS = supportsWindowControls && windowState.platform === 'darwin';
 
   return (
     <header
       className="border-b border-slate-200/80 bg-slate-100/95 backdrop-blur"
       style={dragRegionStyle}
     >
-      <div className="flex h-14 items-center justify-between gap-4 px-6 lg:px-10">
-        <div className="min-w-0">
+      <div className={`flex h-14 items-center gap-4 px-6 lg:px-10 ${isMacOS ? 'justify-start' : 'justify-between'}`}>
+        <div className="flex min-w-0 items-center gap-4">
+          {isMacOS ? (
+            <MacWindowControls
+              isMaximized={windowState.isMaximized}
+              onMinimize={handleMinimize}
+              onToggleMaximize={handleToggleMaximize}
+              onClose={handleClose}
+            />
+          ) : null}
+
           <h2 className="truncate text-sm font-semibold tracking-[0.01em] text-slate-900">{metadata.title}</h2>
         </div>
 
-        {supportsWindowControls ? (
-          <div className="flex items-center" style={noDragRegionStyle}>
-            <div className="flex items-center rounded-xl border border-slate-200/80 bg-white/80 p-1">
-              <button
-                type="button"
-                aria-label="Minimize window"
-                onClick={handleMinimize}
-                className="rounded-lg p-2 text-slate-500 transition hover:bg-slate-100 hover:text-slate-900"
-              >
-                <MinusIcon className="h-4 w-4" />
-              </button>
-              <button
-                type="button"
-                aria-label={windowState.isMaximized ? 'Restore window' : 'Maximize window'}
-                onClick={handleToggleMaximize}
-                className="rounded-lg p-2 text-slate-500 transition hover:bg-slate-100 hover:text-slate-900"
-              >
-                <MaximizeIcon className="h-4 w-4" />
-              </button>
-              <button
-                type="button"
-                aria-label="Close window"
-                onClick={handleClose}
-                className="rounded-lg p-2 text-slate-500 transition hover:bg-rose-100 hover:text-rose-700"
-              >
-                <XMarkIcon className="h-4 w-4" />
-              </button>
-            </div>
-          </div>
+        {supportsWindowControls && !isMacOS ? (
+          <DesktopWindowControls
+            isMaximized={windowState.isMaximized}
+            onMinimize={handleMinimize}
+            onToggleMaximize={handleToggleMaximize}
+            onClose={handleClose}
+          />
         ) : null}
       </div>
     </header>

--- a/tests/unit/main/main.test.js
+++ b/tests/unit/main/main.test.js
@@ -1,8 +1,10 @@
 const loadURL = jest.fn();
 const loadFile = jest.fn();
+const setWindowButtonVisibility = jest.fn();
 const browserWindowMock = jest.fn().mockImplementation(() => ({
   loadURL,
   loadFile,
+  setWindowButtonVisibility,
   on: jest.fn(),
 }));
 
@@ -41,6 +43,21 @@ const {
 } = require('../../../src/services/providers/repository-provider.bootstrap');
 const main = require('../../../src/main');
 
+function withPlatform(platform, callback) {
+  const originalDescriptor = Object.getOwnPropertyDescriptor(process, 'platform');
+
+  Object.defineProperty(process, 'platform', {
+    configurable: true,
+    value: platform,
+  });
+
+  try {
+    callback();
+  } finally {
+    Object.defineProperty(process, 'platform', originalDescriptor);
+  }
+}
+
 describe('main process bootstrap', () => {
   beforeEach(() => {
     jest.clearAllMocks();
@@ -62,6 +79,7 @@ describe('main process bootstrap', () => {
 
     expect(options.frame).toBe(false);
     expect(options.titleBarOverlay).toBe(false);
+    expect(options.titleBarStyle).toBe('hidden');
     expect(options.webPreferences).toEqual(expect.objectContaining({
       nodeIntegration: false,
       contextIsolation: true,
@@ -96,6 +114,14 @@ describe('main process bootstrap', () => {
     process.env.ELECTRON_RENDERER_URL = 'http://localhost:8080';
     main.createWindow();
     expect(loadURL).toHaveBeenCalledWith('http://localhost:8080');
+  });
+
+  test('createWindow oculta los controles nativos en macOS', () => {
+    withPlatform('darwin', () => {
+      main.createWindow();
+    });
+
+    expect(setWindowButtonVisibility).toHaveBeenCalledWith(false);
   });
 
   test('bootstrapMainProcess registra providers, ipc y crea ventana', () => {

--- a/tests/unit/renderer/title-bar.dom.test.js
+++ b/tests/unit/renderer/title-bar.dom.test.js
@@ -1,9 +1,16 @@
 const React = require('react');
-const { render, screen } = require('@testing-library/react');
+const { render, screen, waitFor } = require('@testing-library/react');
 
 const TitleBar = require('../../../src/renderer/shared/layout/TitleBar').default;
 
 describe('TitleBar', () => {
+  beforeEach(() => {
+    window.electronApi.invoke.mockReset();
+    window.electronApi.invoke.mockResolvedValue({ ok: true, data: '' });
+    window.electronApi.onWindowStateChange.mockReset();
+    window.electronApi.onWindowStateChange.mockReturnValue(jest.fn());
+  });
+
   test('no explota si el bridge de Electron no esta disponible', () => {
     const originalElectronApi = window.electronApi;
     delete window.electronApi;
@@ -16,5 +23,27 @@ describe('TitleBar', () => {
     } finally {
       window.electronApi = originalElectronApi;
     }
+  });
+
+  test('usa controles tipo traffic light en macOS', async () => {
+    window.electronApi.invoke.mockImplementation(async (channel) => {
+      if (channel === 'window-controls:get-state') {
+        return {
+          isMaximized: false,
+          isFullScreen: false,
+          platform: 'darwin',
+        };
+      }
+
+      return null;
+    });
+
+    render(React.createElement(TitleBar, { pathname: '/' }));
+
+    await waitFor(() => {
+      expect(
+        screen.getAllByRole('button').map((button) => button.getAttribute('aria-label')),
+      ).toEqual(['Close window', 'Minimize window', 'Maximize window']);
+    });
   });
 });


### PR DESCRIPTION
## Resumen

Este PR integra los controles de ventana custom a la `TitleBar` actual y elimina la chrome nativa visible de macOS para que la experiencia se vea consistente dentro de la app.

## Objetivo

Hasta ahora la app ya tenía controles custom, pero en macOS la ventana seguía reservando el comportamiento visual de `hiddenInset`, lo que podía dejar los traffic lights nativos visibles o desalineados respecto del resto del shell.

La idea de este ajuste es dejar una sola capa de controles, integrada al UX/UI actual de CheckPR, sin duplicaciones entre la ventana del sistema y la barra superior de la app.

## Cambios incluidos

- Se unifica la configuración de la ventana en `main` para usar `titleBarStyle: 'hidden'`.
- Se ocultan explícitamente los botones nativos de macOS con `setWindowButtonVisibility(false)`.
- Se refina la `TitleBar` para renderizar controles específicos por plataforma:
  - macOS: botones tipo traffic light integrados a la barra superior.
  - Windows/Linux: grupo compacto de minimizar, maximizar/restaurar y cerrar alineado al shell actual.
- Se mejora la detección inicial de plataforma en el renderer para evitar saltos visuales durante el primer render.
- Se extraen piezas reutilizables en la `TitleBar` para evitar duplicación interna y mantener el componente más claro.

## Impacto UX/UI

- La barra superior se siente más integrada al layout general de la app.
- En macOS ya no deberían verse los controles por defecto del sistema.
- Los controles custom mantienen un lenguaje visual coherente con el sidebar y el resto del shell.
- Se preserva el comportamiento actual en Windows/Linux, pero con una presentación más compacta y consistente.

## Archivos relevantes

- `src/main/main-window.ts`
- `src/renderer/shared/layout/TitleBar.tsx`
- `tests/unit/main/main.test.js`
- `tests/unit/renderer/title-bar.dom.test.js`

## Validación realizada

- `npm run quality:check`

## QA sugerido

- En macOS, confirmar que la ventana no muestra traffic lights nativos y que solo se ven los controles custom.
- Verificar que minimizar, maximizar/restaurar y cerrar siguen funcionando desde la `TitleBar`.
- En Windows/Linux, revisar que los controles mantienen el comportamiento esperado y que la barra superior no pierde alineación visual.
