### PR TITLE
test: endurecer cobertura de regresion y edge cases

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
     "dev": "npm run start",
     "build:prod": "cross-env NODE_ENV=production electron-builder build",
     "test": "npm run build && jest --runInBand",
-    "test:prod": "npm run build && jest --coverage --runInBand",
+    "test:coverage": "jest --coverage --runInBand",
+    "test:prod": "npm run build && npm run test:coverage",
     "test:e2e": "npm run build && playwright test",
     "test:all": "npm run test && npm run test:e2e",
     "lint": "eslint . --ext .ts,.tsx",
@@ -30,7 +31,7 @@
     "analyze:all": "npm run lint && npm run analyze:complexity && npm run analyze:architecture && npm run analyze:solid && npm run analyze:security",
     "guard:commit": "npm run lint && npm run typecheck && npm run analyze:architecture && npm run analyze:solid && jest --runInBand",
     "guard:push": "npm run quality:check",
-    "quality:check": "npm run lint && npm run typecheck && npm run analyze:architecture && npm run analyze:solid && jest --runInBand && npm run build"
+    "quality:check": "npm run lint && npm run typecheck && npm run analyze:architecture && npm run analyze:solid && npm run test:coverage && npm run build"
   },
   "author": "",
   "license": "ISC",

--- a/src/renderer/features/repository-analysis/presentation/hooks/useRepositoryBranches.ts
+++ b/src/renderer/features/repository-analysis/presentation/hooks/useRepositoryBranches.ts
@@ -32,20 +32,37 @@ export function useRepositoryBranches({
 
     setIsLoadingBranches(true);
     setBranchError(null);
+    let cancelled = false;
     void fetchBranches(activeConfig)
       .then((nextBranches) => {
+        if (cancelled) {
+          return;
+        }
+
         setBranches(nextBranches);
         const defaultBranch = nextBranches.find((branch) => branch.isDefault)?.name || nextBranches[0]?.name || '';
         setBranchName(defaultBranch);
       })
       .catch((nextError) => {
+        if (cancelled) {
+          return;
+        }
+
         setBranches([]);
         setBranchName('');
         setBranchError(nextError instanceof Error ? nextError.message : 'No fue posible cargar las ramas.');
       })
       .finally(() => {
+        if (cancelled) {
+          return;
+        }
+
         setIsLoadingBranches(false);
       });
+
+    return () => {
+      cancelled = true;
+    };
   }, [config, isConnectionReady, repositoryId]);
 
   return {

--- a/src/services/analysis/repository-analysis.service.ts
+++ b/src/services/analysis/repository-analysis.service.ts
@@ -63,65 +63,66 @@ export class RepositoryAnalysisService {
       timeoutId: null,
     });
 
-    const snapshot = await this.snapshotProvider.getSnapshot(request);
-    this.assertRunNotCancelled(request.requestId);
-    if (snapshot.files.length === 0) {
-      this.cleanupRun(request.requestId);
-      throw new Error('No se encontraron archivos de codigo legibles para analizar en el scope seleccionado.');
-    }
-
-    const prompt = this.promptBuilder.build(request, snapshot);
-    const timeoutMs = request.timeoutMs ?? DEFAULT_ANALYSIS_TIMEOUT_MS;
-    const controller = new AbortController();
-    const timeoutId = setTimeout(() => controller.abort('timeout'), timeoutMs);
-    const activeRun = this.activeRuns.get(request.requestId);
-    if (activeRun) {
-      activeRun.controller = controller;
-      activeRun.timeoutId = timeoutId;
-    }
-
     try {
-      const rawText = await this.analysisClient.analyze({
-        request,
-        prompt,
-        signal: controller.signal,
-      });
-      const analysis = this.responseParser.parse(rawText);
-
-      return {
-        provider: request.source.provider,
-        repository: snapshot.repository,
-        branch: request.branchName,
-        model: request.model,
-        analyzedAt: new Date().toISOString(),
-        summary: analysis.summary,
-        score: Math.max(0, Math.min(100, Math.round(analysis.score))),
-        riskLevel: analysis.riskLevel,
-        topConcerns: analysis.topConcerns,
-        recommendations: analysis.recommendations,
-        findings: analysis.findings,
-        snapshot: {
-          totalFilesDiscovered: snapshot.totalFilesDiscovered,
-          filesAnalyzed: snapshot.files.length,
-          truncated: snapshot.truncated,
-          partialReason: snapshot.partialReason,
-          durationMs: snapshot.metrics?.durationMs,
-          retryCount: snapshot.metrics?.retryCount,
-          discardedByPrioritization: snapshot.metrics?.discardedByPrioritization,
-          discardedBySize: snapshot.metrics?.discardedBySize,
-          discardedByBinaryDetection: snapshot.metrics?.discardedByBinaryDetection,
-        },
-      };
-    } catch (error) {
-      if (controller.signal.aborted) {
-        if (controller.signal.reason === 'timeout') {
-          throw new Error(`El analisis remoto excedio el timeout de ${Math.round(timeoutMs / 1000)} segundos. Reintenta o reduce el scope.`);
-        }
-
-        throw new Error('El analisis fue cancelado antes de completarse.');
+      const snapshot = await this.snapshotProvider.getSnapshot(request);
+      this.assertRunNotCancelled(request.requestId);
+      if (snapshot.files.length === 0) {
+        throw new Error('No se encontraron archivos de codigo legibles para analizar en el scope seleccionado.');
       }
 
-      throw error;
+      const prompt = this.promptBuilder.build(request, snapshot);
+      const timeoutMs = request.timeoutMs ?? DEFAULT_ANALYSIS_TIMEOUT_MS;
+      const controller = new AbortController();
+      const timeoutId = setTimeout(() => controller.abort('timeout'), timeoutMs);
+      const activeRun = this.activeRuns.get(request.requestId);
+      if (activeRun) {
+        activeRun.controller = controller;
+        activeRun.timeoutId = timeoutId;
+      }
+
+      try {
+        const rawText = await this.analysisClient.analyze({
+          request,
+          prompt,
+          signal: controller.signal,
+        });
+        const analysis = this.responseParser.parse(rawText);
+
+        return {
+          provider: request.source.provider,
+          repository: snapshot.repository,
+          branch: request.branchName,
+          model: request.model,
+          analyzedAt: new Date().toISOString(),
+          summary: analysis.summary,
+          score: Math.max(0, Math.min(100, Math.round(analysis.score))),
+          riskLevel: analysis.riskLevel,
+          topConcerns: analysis.topConcerns,
+          recommendations: analysis.recommendations,
+          findings: analysis.findings,
+          snapshot: {
+            totalFilesDiscovered: snapshot.totalFilesDiscovered,
+            filesAnalyzed: snapshot.files.length,
+            truncated: snapshot.truncated,
+            partialReason: snapshot.partialReason,
+            durationMs: snapshot.metrics?.durationMs,
+            retryCount: snapshot.metrics?.retryCount,
+            discardedByPrioritization: snapshot.metrics?.discardedByPrioritization,
+            discardedBySize: snapshot.metrics?.discardedBySize,
+            discardedByBinaryDetection: snapshot.metrics?.discardedByBinaryDetection,
+          },
+        };
+      } catch (error) {
+        if (controller.signal.aborted) {
+          if (controller.signal.reason === 'timeout') {
+            throw new Error(`El analisis remoto excedio el timeout de ${Math.round(timeoutMs / 1000)} segundos. Reintenta o reduce el scope.`);
+          }
+
+          throw new Error('El analisis fue cancelado antes de completarse.');
+        }
+
+        throw error;
+      }
     } finally {
       this.cleanupRun(request.requestId);
     }
@@ -134,8 +135,10 @@ export class RepositoryAnalysisService {
     }
 
     activeRun.cancelled = true;
-    activeRun.controller?.abort('cancelled');
-    this.cleanupRun(requestId);
+    if (activeRun.controller) {
+      activeRun.controller.abort('cancelled');
+      this.cleanupRun(requestId);
+    }
   }
 
   private assertRunNotCancelled(requestId: string): void {

--- a/src/services/gitlab/gitlab.api.ts
+++ b/src/services/gitlab/gitlab.api.ts
@@ -97,10 +97,10 @@ export function normalizeNamespace(value: string): string {
   return value.toLowerCase();
 }
 
-export function buildProject(project: { path_with_namespace: string }): RepositoryProject {
+export function buildProject(project: { path_with_namespace: string; name?: string }): RepositoryProject {
   return {
     id: project.path_with_namespace,
-    name: project.path_with_namespace,
+    name: project.name || project.path_with_namespace,
     state: 'active',
   };
 }

--- a/src/services/gitlab/gitlab.repositories.ts
+++ b/src/services/gitlab/gitlab.repositories.ts
@@ -24,7 +24,10 @@ export async function getGitLabRepositories(config: RepositoryConnectionConfig):
 
 export async function getGitLabProjects(config: RepositoryConnectionConfig): Promise<RepositoryProject[]> {
   const repositories = await getGitLabRepositories(config);
-  return repositories.map((repository) => buildProject({ path_with_namespace: repository.id }));
+  return repositories.map((repository) => buildProject({
+    path_with_namespace: repository.id,
+    name: repository.name,
+  }));
 }
 
 export async function getGitLabBranches(config: RepositoryConnectionConfig): Promise<RepositoryBranch[]> {

--- a/tests/integration/renderer/use-repository-analysis.dom.test.js
+++ b/tests/integration/renderer/use-repository-analysis.dom.test.js
@@ -58,6 +58,19 @@ describe('useRepositoryAnalysis', () => {
     expect(result.current.result).toEqual({ summary: 'ok' });
   });
 
+  test('propaga un error controlado cuando falla el analisis', async () => {
+    ipc.runRepositoryAnalysis.mockRejectedValue(new Error('analysis failed'));
+    const { result } = renderHook(() => useRepositoryAnalysis());
+
+    await act(async () => {
+      await result.current.execute({ requestId: 'req-error' });
+    });
+
+    expect(result.current.phase).toBe('error');
+    expect(result.current.error).toBe('analysis failed');
+    expect(result.current.result).toBeNull();
+  });
+
   test('cancela request activa y resetea el estado', async () => {
     ipc.runRepositoryAnalysis.mockImplementation(() => new Promise(() => {}));
     ipc.cancelRepositoryAnalysis.mockResolvedValue(undefined);
@@ -74,5 +87,25 @@ describe('useRepositoryAnalysis', () => {
     expect(ipc.cancelRepositoryAnalysis).toHaveBeenCalledWith('req-2');
     expect(result.current.phase).toBe('idle');
     expect(result.current.result).toBeNull();
+  });
+
+  test('reset limpia preview, resultado y error sin requerir una request activa', async () => {
+    ipc.previewRepositorySnapshot.mockResolvedValue({ repository: 'repo-a', branch: 'main' });
+    const { result } = renderHook(() => useRepositoryAnalysis());
+
+    await act(async () => {
+      await result.current.preparePreview({ requestId: 'req-preview-reset' });
+    });
+
+    expect(result.current.preview).toEqual({ repository: 'repo-a', branch: 'main' });
+
+    act(() => {
+      result.current.reset();
+    });
+
+    expect(result.current.phase).toBe('idle');
+    expect(result.current.preview).toBeNull();
+    expect(result.current.result).toBeNull();
+    expect(result.current.error).toBeNull();
   });
 });

--- a/tests/integration/renderer/use-repository-source-hooks.dom.test.js
+++ b/tests/integration/renderer/use-repository-source-hooks.dom.test.js
@@ -96,6 +96,26 @@ describe('repository source hooks', () => {
       result.current.markProjectSelection('repo-a');
     });
     expect(result.current.shouldLoadRepositories).toBe(true);
+
+    act(() => {
+      result.current.resetForConfigChange('project', '');
+    });
+    expect(result.current.repositories).toEqual([]);
+    expect(result.current.shouldLoadRepositories).toBe(false);
+
+    act(() => {
+      result.current.resetForConfigChange('provider', 'gitlab');
+    });
+    expect(result.current.projects).toEqual([]);
+    expect(result.current.repositories).toEqual([]);
+    expect(result.current.projectDiscoveryWarning).toBeNull();
+
+    act(() => {
+      result.current.resetDisconnectedState();
+    });
+    expect(result.current.projects).toEqual([]);
+    expect(result.current.repositories).toEqual([]);
+    expect(result.current.hasSuccessfulConnection).toBe(false);
   });
 
   test('useRepositoryDiagnostics actualiza request path y limpia error', () => {
@@ -124,6 +144,18 @@ describe('repository source hooks', () => {
       result.current.resetDiagnosticsError();
     });
     expect(result.current.diagnostics.lastError).toBeNull();
+
+    act(() => {
+      result.current.updateDiagnostics(null, {
+        provider: '',
+        organization: '',
+        project: '',
+        repositoryId: '',
+        personalAccessToken: '',
+        targetReviewer: '',
+      });
+    });
+    expect(result.current.diagnostics.requestPath).toBe('');
   });
 
   test('useRepositorySourceActions delega en state y diagnostics', () => {
@@ -210,6 +242,31 @@ describe('repository source hooks', () => {
     renderHook(() => actualEffectsModule.useRepositorySourceEffects({ config, configRef, state, refreshRepositories }));
     await Promise.resolve();
     expect(refreshRepositories).toHaveBeenCalled();
+    expect(state.setShouldLoadRepositories).toHaveBeenCalledWith(false);
+  });
+
+  test('useRepositorySourceEffects apaga la carga pendiente si falta config minima', () => {
+    const state = createStateMock();
+    state.shouldLoadRepositories = true;
+    const refreshRepositories = jest.fn();
+    const config = {
+      provider: 'azure-devops',
+      organization: 'acme',
+      project: '',
+      repositoryId: '',
+      personalAccessToken: '',
+      targetReviewer: '',
+    };
+
+    renderHook(() => actualEffectsModule.useRepositorySourceEffects({
+      config,
+      configRef: { current: { ...config } },
+      state,
+      refreshRepositories,
+    }));
+
+    expect(refreshRepositories).not.toHaveBeenCalled();
+    expect(state.setShouldLoadRepositories).toHaveBeenCalledWith(false);
   });
 
   test('useRepositorySourceOperations compone estado, acciones y api', () => {

--- a/tests/unit/main/analysis.shared.test.js
+++ b/tests/unit/main/analysis.shared.test.js
@@ -1,0 +1,45 @@
+const {
+  readRequiredString,
+  normalizeProvider,
+  normalizeOptionalString,
+  clampNumber,
+  readSnapshotPolicy,
+} = require('../../../src/main/ipc/analysis.shared');
+
+describe('analysis shared helpers', () => {
+  test('readRequiredString exige strings con contenido', () => {
+    expect(readRequiredString('  value  ', 'field')).toBe('value');
+    expect(() => readRequiredString('', 'field')).toThrow('field es obligatorio.');
+    expect(() => readRequiredString(null, 'field')).toThrow('field es obligatorio.');
+  });
+
+  test('normalizeProvider solo acepta providers soportados', () => {
+    expect(normalizeProvider('azure-devops', 'provider')).toBe('azure-devops');
+    expect(normalizeProvider('github', 'provider')).toBe('github');
+    expect(normalizeProvider('gitlab', 'provider')).toBe('gitlab');
+    expect(() => normalizeProvider('bitbucket', 'provider')).toThrow('provider no es valido.');
+  });
+
+  test('normalizeOptionalString y clampNumber aplican normalizacion defensiva', () => {
+    expect(normalizeOptionalString(' reviewer@example.com ')).toBe('reviewer@example.com');
+    expect(normalizeOptionalString('   ')).toBeUndefined();
+    expect(clampNumber(250, 10, 200, 0)).toBe(200);
+    expect(clampNumber(-4, 10, 200, 0)).toBe(10);
+    expect(clampNumber('42.9', 10, 200, 0)).toBe(42);
+    expect(clampNumber(undefined, 10, 200, 15)).toBe(15);
+  });
+
+  test('readSnapshotPolicy limita longitud y convierte strictMode a booleano', () => {
+    const policy = readSnapshotPolicy({
+      excludedPathPatterns: 'x'.repeat(4500),
+      strictMode: 1,
+    });
+
+    expect(policy.excludedPathPatterns).toHaveLength(4000);
+    expect(policy.strictMode).toBe(true);
+    expect(readSnapshotPolicy(null)).toEqual({
+      excludedPathPatterns: '',
+      strictMode: false,
+    });
+  });
+});

--- a/tests/unit/main/ipc.analysis.test.js
+++ b/tests/unit/main/ipc.analysis.test.js
@@ -3,6 +3,7 @@ jest.mock('../../../src/main/ipc/shared', () => ({
 }));
 
 const { registerHandle } = require('../../../src/main/ipc/shared');
+const analysisShared = require('../../../src/main/ipc/analysis.shared');
 const {
   sanitizeAnalysisPayload,
   sanitizePullRequestAnalysisPayload,
@@ -12,6 +13,24 @@ const {
 describe('analysis ipc', () => {
   beforeEach(() => {
     registerHandle.mockReset();
+  });
+
+  test('sanitizeAnalysisPayload y sanitizePullRequestAnalysisPayload rechazan payloads invalidos', () => {
+    expect(() => sanitizeAnalysisPayload(null)).toThrow('El payload de analisis es invalido.');
+    expect(() => sanitizeAnalysisPayload({
+      requestId: 'req-1',
+      repositoryId: 'repo-a',
+      branchName: 'main',
+      model: 'gpt-5.2-codex',
+      apiKey: 'sk',
+    })).toThrow('La fuente del analisis es obligatoria.');
+
+    expect(() => sanitizePullRequestAnalysisPayload(null)).toThrow('El payload de PR analysis es invalido.');
+    expect(() => sanitizePullRequestAnalysisPayload({
+      model: 'gpt-5.2-codex',
+      apiKey: 'sk',
+      items: [],
+    })).toThrow('La fuente del PR analysis es obligatoria.');
   });
 
   test('sanitizeAnalysisPayload normaliza limites y directivas', () => {
@@ -48,6 +67,53 @@ describe('analysis ipc', () => {
     expect(payload.snapshotPolicy.excludedPathPatterns).toContain('.env');
     expect(payload.snapshotPolicy.strictMode).toBe(true);
     expect(payload.promptDirectives.architecturePattern).toBe('hexagonal');
+  });
+
+  test('sanitizeAnalysisPayload usa el apiKey de sesion y valida Azure DevOps', () => {
+    const payload = sanitizeAnalysisPayload({
+      requestId: 'req-azure',
+      source: {
+        provider: 'azure-devops',
+        organization: 'acme',
+        project: 'platform-team',
+        repositoryId: 'repo-a',
+        personalAccessToken: 'pat',
+        targetReviewer: ' review@example.com ',
+      },
+      repositoryId: 'repo-a',
+      branchName: 'main',
+      model: 'gpt-5.2-codex',
+      apiKey: '   ',
+      analysisDepth: 'standard',
+      maxFilesPerRun: 2,
+      includeTests: false,
+      timeoutMs: 1000,
+      promptDirectives: {
+        architectureReviewEnabled: 1,
+        requiredPractices: 'x'.repeat(2500),
+      },
+    }, 'sk-session');
+
+    expect(payload.apiKey).toBe('sk-session');
+    expect(payload.timeoutMs).toBe(15000);
+    expect(payload.maxFilesPerRun).toBe(10);
+    expect(payload.source.targetReviewer).toBe('review@example.com');
+    expect(payload.promptDirectives.requiredPractices).toHaveLength(2000);
+
+    expect(() => sanitizeAnalysisPayload({
+      requestId: 'req-invalid-azure',
+      source: {
+        provider: 'azure-devops',
+        organization: 'acme',
+        project: '   ',
+        repositoryId: 'repo-a',
+        personalAccessToken: 'pat',
+      },
+      repositoryId: 'repo-a',
+      branchName: 'main',
+      model: 'gpt-5.2-codex',
+      analysisDepth: 'standard',
+    }, 'sk-session')).toThrow('Azure DevOps requiere un project valido para ejecutar el analisis.');
   });
 
   test('registerAnalysisIpc registra run y cancel', async () => {
@@ -227,5 +293,53 @@ describe('analysis ipc', () => {
     expect(payload.snapshotPolicy.strictMode).toBe(true);
     expect(payload.promptDirectives.focusAreas).toBe('arquitectura');
     expect(payload.items).toHaveLength(1);
+  });
+
+  test('sanitizePullRequestAnalysisPayload aplica fallbacks y recorta prompt directives', () => {
+    const payload = sanitizePullRequestAnalysisPayload({
+      requestId: '  req-pr  ',
+      source: {
+        provider: 'gitlab',
+        organization: ' acme ',
+        project: ' ',
+        repositoryId: ' repo-a ',
+        personalAccessToken: ' pat ',
+      },
+      apiKey: '',
+      model: ' gpt-5.2-codex ',
+      analysisDepth: 'whatever',
+      timeoutMs: 999999,
+      promptDirectives: {
+        focusAreas: 'x'.repeat(2500),
+        customInstructions: 'y'.repeat(3000),
+      },
+      items: [{ invalid: true }],
+    }, 'sk-session');
+
+    expect(payload.requestId).toBe('req-pr');
+    expect(payload.apiKey).toBe('sk-session');
+    expect(payload.analysisDepth).toBe('standard');
+    expect(payload.timeoutMs).toBe(120000);
+    expect(payload.promptDirectives.focusAreas).toHaveLength(2000);
+    expect(payload.promptDirectives.customInstructions).toHaveLength(2500);
+    expect(payload.items).toEqual([]);
+  });
+
+  test('analysis.shared helpers validan campos y normalizan policy', () => {
+    expect(analysisShared.readRequiredString('  value  ', 'field')).toBe('value');
+    expect(() => analysisShared.readRequiredString('   ', 'field')).toThrow('field es obligatorio.');
+    expect(analysisShared.normalizeProvider('github', 'provider')).toBe('github');
+    expect(() => analysisShared.normalizeProvider('bitbucket', 'provider')).toThrow('provider no es valido.');
+    expect(analysisShared.normalizeOptionalString('  reviewer  ')).toBe('reviewer');
+    expect(analysisShared.normalizeOptionalString('   ')).toBeUndefined();
+    expect(analysisShared.clampNumber('45.8', 10, 50, 20)).toBe(45);
+    expect(analysisShared.clampNumber('nope', 10, 50, 20)).toBe(20);
+    expect(analysisShared.readSnapshotPolicy({
+      excludedPathPatterns: 'x'.repeat(5000),
+      strictMode: 'truthy',
+    })).toEqual({
+      excludedPathPatterns: 'x'.repeat(4000),
+      strictMode: true,
+    });
   });
 });

--- a/tests/unit/main/ipc.repository-providers.test.js
+++ b/tests/unit/main/ipc.repository-providers.test.js
@@ -21,9 +21,9 @@ describe('repository providers ipc', () => {
   test('registra handlers para gateway de providers y enlaces externos', async () => {
     const provider = {
       getPullRequests: jest.fn().mockResolvedValue([]),
-      getProjects: jest.fn().mockResolvedValue([]),
-      getRepositories: jest.fn().mockResolvedValue([]),
-      getBranches: jest.fn().mockResolvedValue([]),
+      getProjects: jest.fn().mockResolvedValue([{ id: 'project-a' }]),
+      getRepositories: jest.fn().mockResolvedValue([{ id: 'repo-a' }]),
+      getBranches: jest.fn().mockResolvedValue([{ name: 'main' }]),
     };
     const providerRegistry = {
       get: jest.fn().mockReturnValue(provider),
@@ -33,13 +33,22 @@ describe('repository providers ipc', () => {
 
     expect(registerHandle).toHaveBeenCalledTimes(5);
     const pullRequestsHandler = registerHandle.mock.calls[0][1];
+    const projectsHandler = registerHandle.mock.calls[1][1];
+    const repositoriesHandler = registerHandle.mock.calls[2][1];
+    const branchesHandler = registerHandle.mock.calls[3][1];
     const openExternalHandler = registerHandle.mock.calls[4][1];
 
     await pullRequestsHandler({ provider: 'github' });
+    await expect(projectsHandler({ provider: 'github' })).resolves.toEqual([{ id: 'project-a' }]);
+    await expect(repositoriesHandler({ provider: 'github' })).resolves.toEqual([{ id: 'repo-a' }]);
+    await expect(branchesHandler({ provider: 'github' })).resolves.toEqual([{ name: 'main' }]);
     await openExternalHandler('https://github.com/acme/repo/pull/1');
 
     expect(providerRegistry.get).toHaveBeenCalledWith('github');
     expect(provider.getPullRequests).toHaveBeenCalledWith({ provider: 'github' });
+    expect(provider.getProjects).toHaveBeenCalledWith({ provider: 'github' });
+    expect(provider.getRepositories).toHaveBeenCalledWith({ provider: 'github' });
+    expect(provider.getBranches).toHaveBeenCalledWith({ provider: 'github' });
     expect(shell.openExternal).toHaveBeenCalledWith('https://github.com/acme/repo/pull/1');
   });
 
@@ -48,5 +57,13 @@ describe('repository providers ipc', () => {
     const pullRequestsHandler = registerHandle.mock.calls[0][1];
 
     await expect(pullRequestsHandler({ provider: '' })).rejects.toThrow('Selecciona un provider');
+  });
+
+  test('openExternal rechaza URLs no validas', async () => {
+    registerRepositoryProviderIpc({ get: jest.fn() });
+    const openExternalHandler = registerHandle.mock.calls[4][1];
+
+    await expect(openExternalHandler('javascript:alert(1)')).rejects.toThrow('Solo se permiten URLs externas con https.');
+    expect(shell.openExternal).not.toHaveBeenCalled();
   });
 });

--- a/tests/unit/main/ipc.session-secrets.test.js
+++ b/tests/unit/main/ipc.session-secrets.test.js
@@ -14,8 +14,10 @@ describe('session secrets ipc', () => {
     const store = new SessionSecretsStore();
     store.set('key', 'value');
     expect(store.get('key')).toBe('value');
+    expect(store.has('key')).toBe(true);
     store.set('key', '');
     expect(store.get('key')).toBe('');
+    expect(store.has('key')).toBe(false);
   });
 
   test('registerSessionSecretsIpc registra canales get/has/set', async () => {
@@ -23,9 +25,15 @@ describe('session secrets ipc', () => {
     registerSessionSecretsIpc(store);
 
     expect(registerHandle).toHaveBeenCalledTimes(3);
+    const getHandler = registerHandle.mock.calls[0][1];
     const hasHandler = registerHandle.mock.calls[1][1];
     const setHandler = registerHandle.mock.calls[2][1];
+
+    await expect(getHandler('key')).resolves.toBe('');
     await expect(hasHandler('key')).resolves.toBe(false);
+    await expect(setHandler({ key: 'api-key', value: 'secret' })).resolves.toBeUndefined();
+    await expect(getHandler('api-key')).resolves.toBe('secret');
+    await expect(hasHandler('api-key')).resolves.toBe(true);
     await expect(setHandler({ key: '', value: 'x' })).rejects.toThrow('Secret key is required.');
   });
 });

--- a/tests/unit/main/ipc.shared.test.js
+++ b/tests/unit/main/ipc.shared.test.js
@@ -15,6 +15,7 @@ describe('main ipc shared', () => {
   test('safeIpcResponse envuelve errores', async () => {
     await expect(safeIpcResponse(async () => 'ok')).resolves.toEqual({ ok: true, data: 'ok' });
     await expect(safeIpcResponse(async () => { throw new Error('boom'); })).resolves.toEqual({ ok: false, error: 'boom' });
+    await expect(safeIpcResponse(async () => { throw 'boom'; })).resolves.toEqual({ ok: false, error: 'Unknown IPC error.' });
   });
 
   test('registerHandle registra handler seguro', async () => {

--- a/tests/unit/main/main.test.js
+++ b/tests/unit/main/main.test.js
@@ -1,6 +1,15 @@
 const loadURL = jest.fn();
 const loadFile = jest.fn();
 const setWindowButtonVisibility = jest.fn();
+const registeredAppEvents = new Map();
+let readyCallback;
+const appOn = jest.fn((eventName, handler) => {
+  registeredAppEvents.set(eventName, handler);
+});
+const appQuit = jest.fn();
+const whenReadyThen = jest.fn((callback) => {
+  readyCallback = callback;
+});
 const browserWindowMock = jest.fn().mockImplementation(() => ({
   loadURL,
   loadFile,
@@ -13,9 +22,9 @@ jest.mock('electron', () => ({
     getPath: jest.fn(() => 'C:\\Users\\ianst\\AppData\\Roaming'),
     setPath: jest.fn(),
     setAppUserModelId: jest.fn(),
-    whenReady: jest.fn(() => ({ then: jest.fn() })),
-    on: jest.fn(),
-    quit: jest.fn(),
+    whenReady: jest.fn(() => ({ then: whenReadyThen })),
+    on: appOn,
+    quit: appQuit,
   },
   BrowserWindow: Object.assign(browserWindowMock, {
     getAllWindows: jest.fn(() => []),
@@ -42,6 +51,7 @@ const {
   registerDefaultRepositoryProviders,
 } = require('../../../src/services/providers/repository-provider.bootstrap');
 const main = require('../../../src/main');
+const { app, BrowserWindow } = require('electron');
 
 function withPlatform(platform, callback) {
   const originalDescriptor = Object.getOwnPropertyDescriptor(process, 'platform');
@@ -72,6 +82,16 @@ describe('main process bootstrap', () => {
     expect(storage.userDataPath).toContain('AppData\\Local');
     expect(storage.userDataPath).toContain('CheckPR');
     expect(storage.sessionDataPath).toContain('SessionData');
+  });
+
+  test('resolveAppStoragePaths usa appData cuando LOCALAPPDATA no esta disponible', () => {
+    process.env.LOCALAPPDATA = '   ';
+
+    const storage = main.resolveAppStoragePaths();
+
+    expect(app.getPath).toHaveBeenCalledWith('appData');
+    expect(storage.userDataPath).toContain('AppData\\Roaming');
+    expect(storage.userDataPath).toContain('CheckPR');
   });
 
   test('buildMainWindowOptions endurece webPreferences', () => {
@@ -131,5 +151,43 @@ describe('main process bootstrap', () => {
     expect(registerDefaultRepositoryProviders).not.toHaveBeenCalled();
     expect(registerIpcHandlers).toHaveBeenCalled();
     expect(browserWindowMock).toHaveBeenCalled();
+  });
+
+  test('cuando app esta lista ejecuta bootstrapMainProcess', () => {
+    readyCallback();
+
+    expect(buildDefaultRepositoryProviderPorts).toHaveBeenCalled();
+    expect(registerIpcHandlers).toHaveBeenCalled();
+  });
+
+  test('window-all-closed cierra la app fuera de macOS', () => {
+    const windowAllClosedHandler = registeredAppEvents.get('window-all-closed');
+    windowAllClosedHandler();
+
+    expect(appQuit).toHaveBeenCalled();
+  });
+
+  test('window-all-closed no cierra la app en macOS', () => {
+    const windowAllClosedHandler = registeredAppEvents.get('window-all-closed');
+
+    withPlatform('darwin', () => {
+      windowAllClosedHandler();
+    });
+
+    expect(appQuit).not.toHaveBeenCalled();
+  });
+
+  test('activate crea una ventana solo cuando no hay ventanas abiertas', () => {
+    const activateHandler = registeredAppEvents.get('activate');
+
+    BrowserWindow.getAllWindows.mockReturnValue([]);
+    activateHandler();
+    expect(browserWindowMock).toHaveBeenCalledTimes(1);
+
+    browserWindowMock.mockClear();
+    BrowserWindow.getAllWindows.mockClear();
+    BrowserWindow.getAllWindows.mockReturnValue([{}]);
+    activateHandler();
+    expect(browserWindowMock).not.toHaveBeenCalled();
   });
 });

--- a/tests/unit/main/window-controls.test.js
+++ b/tests/unit/main/window-controls.test.js
@@ -1,0 +1,186 @@
+const registeredHandlers = {};
+
+const ipcMain = {
+  handle: jest.fn((channel, handler) => {
+    registeredHandlers[channel] = handler;
+  }),
+};
+
+const fromWebContents = jest.fn();
+
+jest.mock('electron', () => ({
+  ipcMain,
+  BrowserWindow: {
+    fromWebContents,
+  },
+}));
+
+const {
+  attachWindowStateSync,
+  registerWindowControlsIpc,
+} = require('../../../src/main/ipc/window-controls');
+
+function createTargetWindow(overrides = {}) {
+  const listeners = {};
+  const targetWindow = {
+    on: jest.fn((eventName, handler) => {
+      listeners[eventName] = handler;
+    }),
+    isMaximized: jest.fn(() => false),
+    isFullScreen: jest.fn(() => false),
+    isDestroyed: jest.fn(() => false),
+    minimize: jest.fn(),
+    maximize: jest.fn(),
+    unmaximize: jest.fn(),
+    close: jest.fn(),
+    webContents: {
+      send: jest.fn(),
+    },
+    ...overrides,
+  };
+
+  return { targetWindow, listeners };
+}
+
+describe('window controls ipc', () => {
+  beforeEach(() => {
+    Object.keys(registeredHandlers).forEach((key) => delete registeredHandlers[key]);
+    jest.clearAllMocks();
+  });
+
+  test('attachWindowStateSync registra listeners y sincroniza el estado', () => {
+    const { targetWindow, listeners } = createTargetWindow({
+      isMaximized: jest.fn(() => true),
+    });
+
+    attachWindowStateSync(targetWindow);
+
+    expect(targetWindow.on).toHaveBeenCalledWith('maximize', expect.any(Function));
+    expect(targetWindow.on).toHaveBeenCalledWith('unmaximize', expect.any(Function));
+    expect(targetWindow.on).toHaveBeenCalledWith('enter-full-screen', expect.any(Function));
+    expect(targetWindow.on).toHaveBeenCalledWith('leave-full-screen', expect.any(Function));
+    expect(targetWindow.on).toHaveBeenCalledWith('ready-to-show', expect.any(Function));
+
+    listeners.maximize();
+
+    expect(targetWindow.webContents.send).toHaveBeenCalledWith('window-controls:state-changed', {
+      isMaximized: true,
+      isFullScreen: false,
+      platform: process.platform,
+    });
+  });
+
+  test('attachWindowStateSync no emite cuando la ventana ya fue destruida', () => {
+    const { targetWindow, listeners } = createTargetWindow({
+      isDestroyed: jest.fn(() => true),
+    });
+
+    attachWindowStateSync(targetWindow);
+    listeners['ready-to-show']();
+
+    expect(targetWindow.webContents.send).not.toHaveBeenCalled();
+  });
+
+  test('registerWindowControlsIpc registra handlers para todas las acciones', () => {
+    const { targetWindow } = createTargetWindow();
+    fromWebContents.mockReturnValue(targetWindow);
+
+    registerWindowControlsIpc();
+
+    expect(Object.keys(registeredHandlers).sort()).toEqual([
+      'window-controls:close',
+      'window-controls:get-state',
+      'window-controls:minimize',
+      'window-controls:toggle-maximize',
+    ]);
+  });
+
+  test('get-state devuelve el estado de la ventana del sender', () => {
+    const { targetWindow } = createTargetWindow({
+      isMaximized: jest.fn(() => true),
+      isFullScreen: jest.fn(() => true),
+    });
+    fromWebContents.mockReturnValue(targetWindow);
+
+    registerWindowControlsIpc();
+    const state = registeredHandlers['window-controls:get-state']({ sender: {} });
+
+    expect(state).toEqual({
+      isMaximized: true,
+      isFullScreen: true,
+      platform: process.platform,
+    });
+  });
+
+  test('minimize invoca minimize y devuelve el estado actualizado', () => {
+    const { targetWindow } = createTargetWindow();
+    fromWebContents.mockReturnValue(targetWindow);
+
+    registerWindowControlsIpc();
+    const state = registeredHandlers['window-controls:minimize']({ sender: {} });
+
+    expect(targetWindow.minimize).toHaveBeenCalled();
+    expect(state).toEqual({
+      isMaximized: false,
+      isFullScreen: false,
+      platform: process.platform,
+    });
+  });
+
+  test('toggle-maximize maximiza cuando la ventana no esta maximizada', () => {
+    const { targetWindow } = createTargetWindow({
+      isMaximized: jest.fn(() => false),
+    });
+    fromWebContents.mockReturnValue(targetWindow);
+
+    registerWindowControlsIpc();
+    const state = registeredHandlers['window-controls:toggle-maximize']({ sender: {} });
+
+    expect(targetWindow.maximize).toHaveBeenCalled();
+    expect(targetWindow.unmaximize).not.toHaveBeenCalled();
+    expect(state).toEqual({
+      isMaximized: false,
+      isFullScreen: false,
+      platform: process.platform,
+    });
+  });
+
+  test('toggle-maximize restaura cuando la ventana ya esta maximizada', () => {
+    const { targetWindow } = createTargetWindow({
+      isMaximized: jest.fn(() => true),
+    });
+    fromWebContents.mockReturnValue(targetWindow);
+
+    registerWindowControlsIpc();
+    const state = registeredHandlers['window-controls:toggle-maximize']({ sender: {} });
+
+    expect(targetWindow.unmaximize).toHaveBeenCalled();
+    expect(targetWindow.maximize).not.toHaveBeenCalled();
+    expect(state).toEqual({
+      isMaximized: true,
+      isFullScreen: false,
+      platform: process.platform,
+    });
+  });
+
+  test('close cierra la ventana y responde null', () => {
+    const { targetWindow } = createTargetWindow();
+    fromWebContents.mockReturnValue(targetWindow);
+
+    registerWindowControlsIpc();
+    const result = registeredHandlers['window-controls:close']({ sender: {} });
+
+    expect(targetWindow.close).toHaveBeenCalled();
+    expect(result).toBeNull();
+  });
+
+  test('lanza un error claro cuando no puede resolver la ventana del sender', () => {
+    fromWebContents.mockReturnValue(null);
+
+    registerWindowControlsIpc();
+
+    expect(() => registeredHandlers['window-controls:get-state']({ sender: {} })).toThrow(
+      'Unable to resolve the BrowserWindow for the sender.',
+    );
+  });
+});

--- a/tests/unit/renderer/dashboard-indicators.test.js
+++ b/tests/unit/renderer/dashboard-indicators.test.js
@@ -1,0 +1,278 @@
+const {
+  buildMetrics,
+  buildDeliveryIndicators,
+  buildReviewIndicators,
+  buildGovernanceAlerts,
+} = require('../../../src/renderer/shared/dashboard/summary-indicators');
+const { prioritizePullRequests } = require('../../../src/renderer/shared/dashboard/summary-core');
+
+function createPullRequest(overrides = {}) {
+  return {
+    id: Math.floor(Math.random() * 10000),
+    repository: 'repo-a',
+    createdAt: '2026-03-10T00:00:00.000Z',
+    updatedAt: '2026-03-11T00:00:00.000Z',
+    title: 'PR',
+    description: 'Contexto suficiente',
+    url: 'https://example.com/pr/1',
+    status: 'active',
+    isDraft: false,
+    mergeStatus: 'succeeded',
+    sourceBranch: 'feature/auth',
+    targetBranch: 'main',
+    createdBy: { displayName: 'Ian' },
+    reviewers: [],
+    ageHours: 0,
+    approvals: 0,
+    pendingReviewers: 0,
+    riskScore: 0,
+    ...overrides,
+  };
+}
+
+describe('dashboard indicators', () => {
+  beforeEach(() => {
+    jest.spyOn(Date, 'now').mockReturnValue(new Date('2026-03-16T00:00:00.000Z').getTime());
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  function buildPrioritized() {
+    return prioritizePullRequests([
+      createPullRequest({
+        id: 1,
+        repository: 'repo-a',
+        createdAt: '2026-03-10T00:00:00.000Z',
+        description: 'No description provided.',
+        mergeStatus: 'merge conflict',
+        reviewers: [
+          { displayName: 'Ian Reviewer', uniqueName: 'ian@example.com', vote: 0, isRequired: true },
+          { displayName: 'Ana', uniqueName: 'ana@example.com', vote: 0, isRequired: false },
+        ],
+        sourceBranch: 'hotfix/auth',
+        targetBranch: 'main',
+        isDraft: false,
+      }),
+      createPullRequest({
+        id: 2,
+        repository: 'repo-b',
+        createdAt: '2026-03-14T00:00:00.000Z',
+        reviewers: [
+          { displayName: 'Bob', uniqueName: 'bob@example.com', vote: 10, isRequired: false },
+        ],
+        sourceBranch: 'feature/settings',
+        targetBranch: 'develop',
+        isDraft: true,
+      }),
+      createPullRequest({
+        id: 3,
+        repository: 'repo-c',
+        createdAt: '2026-03-13T00:00:00.000Z',
+        reviewers: [
+          { displayName: 'Carla', uniqueName: 'carla@example.com', vote: 0, isRequired: true },
+          { displayName: 'Diego', uniqueName: 'diego@example.com', vote: 0, isRequired: false },
+          { displayName: 'Ema', uniqueName: 'ema@example.com', vote: 0, isRequired: false },
+        ],
+        sourceBranch: 'hotfix/payments',
+        targetBranch: 'master',
+        isDraft: false,
+      }),
+    ]);
+  }
+
+  test('buildMetrics resume volumen, riesgo y carga por reviewer', () => {
+    const prioritized = buildPrioritized();
+    const metrics = buildMetrics(prioritized, 'ian');
+
+    expect(metrics).toEqual(expect.arrayContaining([
+      expect.objectContaining({ id: 'active-prs', value: 3 }),
+      expect.objectContaining({ id: 'blocked', value: 1 }),
+      expect.objectContaining({ id: 'drafts', value: 1 }),
+      expect.objectContaining({ id: 'repositories', value: 3 }),
+      expect.objectContaining({ id: 'reviewer-workload', value: 1, title: 'Pendientes del reviewer' }),
+    ]));
+
+    const teamMetrics = buildMetrics(prioritized);
+    expect(teamMetrics.find((metric) => metric.id === 'reviewer-workload')).toEqual(expect.objectContaining({
+      value: 2,
+      title: 'Esperando review',
+    }));
+  });
+
+  test('buildDeliveryIndicators calcula stale ratio, mainline targeting y hotfix pressure', () => {
+    const prioritized = buildPrioritized();
+    const indicators = buildDeliveryIndicators(prioritized);
+
+    expect(indicators).toEqual(expect.arrayContaining([
+      expect.objectContaining({ id: 'avg-age', tone: expect.any(String) }),
+      expect.objectContaining({ id: 'stale-ratio', value: '67%' }),
+      expect.objectContaining({ id: 'mainline-targeting', value: '100%', tone: 'amber' }),
+      expect.objectContaining({ id: 'hotfix-pressure', value: '67%', tone: 'rose' }),
+    ]));
+
+    const empty = buildDeliveryIndicators([]);
+    expect(empty.find((indicator) => indicator.id === 'stale-ratio')).toEqual(expect.objectContaining({
+      value: '0%',
+      tone: 'emerald',
+    }));
+  });
+
+  test('buildReviewIndicators resume cobertura, backlog y cuellos de botella requeridos', () => {
+    const prioritized = buildPrioritized();
+    const indicators = buildReviewIndicators(prioritized);
+
+    expect(indicators).toEqual(expect.arrayContaining([
+      expect.objectContaining({ id: 'coverage', value: '67%', tone: 'amber' }),
+      expect.objectContaining({ id: 'pending-load', value: '5', tone: 'amber' }),
+      expect.objectContaining({ id: 'avg-reviewers', value: '2.0', tone: 'emerald' }),
+      expect.objectContaining({ id: 'required-bottleneck', value: '2', tone: 'amber' }),
+    ]));
+  });
+
+  test('buildGovernanceAlerts detecta contexto ausente, presión de producción y drift', () => {
+    const prioritized = buildPrioritized();
+    const alerts = buildGovernanceAlerts(prioritized);
+
+    expect(alerts).toEqual(expect.arrayContaining([
+      expect.objectContaining({ id: 'missing-context', detail: '1 de 3 sin descripción suficiente.', tone: 'amber' }),
+      expect.objectContaining({ id: 'oversized-risk', tone: 'amber' }),
+      expect.objectContaining({ id: 'prod-pressure', detail: '2 hotfixes yendo directo a main/master.', tone: 'rose' }),
+      expect.objectContaining({ id: 'draft-drift', detail: '1 drafts abiertos por más de 48 horas.', tone: 'sky' }),
+    ]));
+  });
+
+  test('buildIndicators cubre escenarios vacios y thresholds altos de presión', () => {
+    const emptyMetrics = buildMetrics([], undefined);
+    expect(emptyMetrics.find((metric) => metric.id === 'average-age')).toEqual(expect.objectContaining({
+      value: '0h',
+    }));
+
+    const emptyReviewIndicators = buildReviewIndicators([]);
+    expect(emptyReviewIndicators.find((indicator) => indicator.id === 'coverage')).toEqual(expect.objectContaining({
+      value: '0%',
+      tone: 'emerald',
+    }));
+
+    const overloaded = prioritizePullRequests([
+      createPullRequest({
+        id: 10,
+        createdAt: '2026-03-01T00:00:00.000Z',
+        description: 'No description provided.',
+        mergeStatus: 'merge conflict',
+        sourceBranch: 'hotfix/a',
+        targetBranch: 'main',
+        reviewers: [
+          { displayName: 'A', uniqueName: 'a@example.com', vote: 0, isRequired: true },
+          { displayName: 'B', uniqueName: 'b@example.com', vote: 0, isRequired: false },
+          { displayName: 'C', uniqueName: 'c@example.com', vote: 0, isRequired: false },
+          { displayName: 'D', uniqueName: 'd@example.com', vote: 0, isRequired: false },
+        ],
+      }),
+      createPullRequest({
+        id: 11,
+        createdAt: '2026-03-02T00:00:00.000Z',
+        description: 'No description provided.',
+        mergeStatus: 'merge conflict',
+        sourceBranch: 'hotfix/b',
+        targetBranch: 'master',
+        reviewers: [
+          { displayName: 'E', uniqueName: 'e@example.com', vote: 0, isRequired: true },
+          { displayName: 'F', uniqueName: 'f@example.com', vote: 0, isRequired: false },
+          { displayName: 'G', uniqueName: 'g@example.com', vote: 0, isRequired: false },
+          { displayName: 'H', uniqueName: 'h@example.com', vote: 0, isRequired: false },
+        ],
+      }),
+      createPullRequest({
+        id: 12,
+        createdAt: '2026-03-03T00:00:00.000Z',
+        description: 'No description provided.',
+        mergeStatus: 'merge conflict',
+        sourceBranch: 'feature/c',
+        targetBranch: 'main',
+        reviewers: [
+          { displayName: 'I', uniqueName: 'i@example.com', vote: 0, isRequired: true },
+          { displayName: 'J', uniqueName: 'j@example.com', vote: 0, isRequired: false },
+          { displayName: 'K', uniqueName: 'k@example.com', vote: 0, isRequired: false },
+          { displayName: 'L', uniqueName: 'l@example.com', vote: 0, isRequired: false },
+        ],
+      }),
+      createPullRequest({
+        id: 13,
+        createdAt: '2026-03-04T00:00:00.000Z',
+        description: 'No description provided.',
+        mergeStatus: 'succeeded',
+        sourceBranch: 'feature/d',
+        targetBranch: 'develop',
+        reviewers: [],
+        isDraft: true,
+      }),
+      createPullRequest({
+        id: 14,
+        createdAt: '2026-03-05T00:00:00.000Z',
+        description: 'No description provided.',
+        mergeStatus: 'succeeded',
+        sourceBranch: 'feature/e',
+        targetBranch: 'develop',
+        reviewers: [],
+        isDraft: true,
+      }),
+      createPullRequest({
+        id: 15,
+        createdAt: '2026-03-06T00:00:00.000Z',
+        description: 'No description provided.',
+        mergeStatus: 'succeeded',
+        sourceBranch: 'feature/f',
+        targetBranch: 'main',
+        reviewers: [],
+        isDraft: false,
+      }),
+      createPullRequest({
+        id: 16,
+        createdAt: '2026-03-07T00:00:00.000Z',
+        description: 'No description provided.',
+        mergeStatus: 'succeeded',
+        sourceBranch: 'feature/g',
+        targetBranch: 'develop',
+        reviewers: [],
+        isDraft: false,
+      }),
+    ]);
+
+    const delivery = buildDeliveryIndicators(overloaded);
+    expect(delivery.find((indicator) => indicator.id === 'avg-age')).toEqual(expect.objectContaining({ tone: 'rose' }));
+    expect(delivery.find((indicator) => indicator.id === 'stale-ratio')).toEqual(expect.objectContaining({ tone: 'rose' }));
+    expect(delivery.find((indicator) => indicator.id === 'hotfix-pressure')).toEqual(expect.objectContaining({ tone: 'rose' }));
+
+    const review = buildReviewIndicators(overloaded);
+    expect(review.find((indicator) => indicator.id === 'coverage')).toEqual(expect.objectContaining({ tone: 'rose' }));
+    expect(review.find((indicator) => indicator.id === 'pending-load')).toEqual(expect.objectContaining({ tone: 'rose' }));
+    expect(review.find((indicator) => indicator.id === 'avg-reviewers')).toEqual(expect.objectContaining({ tone: 'emerald' }));
+    expect(review.find((indicator) => indicator.id === 'required-bottleneck')).toEqual(expect.objectContaining({ tone: 'rose' }));
+
+    const alerts = buildGovernanceAlerts(overloaded);
+    expect(alerts.find((alert) => alert.id === 'missing-context')).toEqual(expect.objectContaining({ tone: 'rose' }));
+    expect(alerts.find((alert) => alert.id === 'oversized-risk')).toEqual(expect.objectContaining({ tone: 'amber' }));
+    expect(alerts.find((alert) => alert.id === 'draft-drift')).toEqual(expect.objectContaining({ tone: 'amber' }));
+
+    const sparseReview = buildReviewIndicators(prioritizePullRequests([
+      createPullRequest({ id: 20, createdAt: '2026-03-10T00:00:00.000Z', reviewers: [] }),
+      createPullRequest({ id: 21, createdAt: '2026-03-10T00:00:00.000Z', reviewers: [] }),
+    ]));
+    expect(sparseReview.find((indicator) => indicator.id === 'avg-reviewers')).toEqual(expect.objectContaining({
+      tone: 'amber',
+      value: '0.0',
+    }));
+
+    const overloadedAlerts = buildGovernanceAlerts(prioritizePullRequests([
+      createPullRequest({ id: 30, createdAt: '2026-03-10T00:00:00.000Z', description: 'No description provided.', mergeStatus: 'merge conflict', reviewers: [{ displayName: 'A', uniqueName: 'a@example.com', vote: 0 }, { displayName: 'A2', uniqueName: 'a2@example.com', vote: 0 }, { displayName: 'A3', uniqueName: 'a3@example.com', vote: 0 }] }),
+      createPullRequest({ id: 31, createdAt: '2026-03-10T00:00:00.000Z', description: 'No description provided.', mergeStatus: 'merge conflict', reviewers: [{ displayName: 'B', uniqueName: 'b@example.com', vote: 0 }, { displayName: 'B2', uniqueName: 'b2@example.com', vote: 0 }, { displayName: 'B3', uniqueName: 'b3@example.com', vote: 0 }] }),
+      createPullRequest({ id: 32, createdAt: '2026-03-10T00:00:00.000Z', description: 'No description provided.', mergeStatus: 'merge conflict', reviewers: [{ displayName: 'C', uniqueName: 'c@example.com', vote: 0 }, { displayName: 'C2', uniqueName: 'c2@example.com', vote: 0 }, { displayName: 'C3', uniqueName: 'c3@example.com', vote: 0 }] }),
+      createPullRequest({ id: 33, createdAt: '2026-03-10T00:00:00.000Z', description: 'No description provided.', mergeStatus: 'merge conflict', reviewers: [{ displayName: 'D', uniqueName: 'd@example.com', vote: 0 }, { displayName: 'D2', uniqueName: 'd2@example.com', vote: 0 }, { displayName: 'D3', uniqueName: 'd3@example.com', vote: 0 }] }),
+    ]));
+    expect(overloadedAlerts.find((alert) => alert.id === 'oversized-risk')).toEqual(expect.objectContaining({
+      tone: 'rose',
+    }));
+  });
+});

--- a/tests/unit/renderer/dashboard-summary.test.js
+++ b/tests/unit/renderer/dashboard-summary.test.js
@@ -1,0 +1,201 @@
+const {
+  getAgeHours,
+  getApprovals,
+  getPendingReviewers,
+  hasMergeConflict,
+  hasEmptyDescription,
+  getRiskScore,
+  prioritizePullRequests,
+  formatHours,
+  formatPercentage,
+  countPullRequestsOlderThan,
+  getAverageAgeHours,
+  classifyBranch,
+  formatLastUpdate,
+} = require('../../../src/renderer/shared/dashboard/summary-core');
+const {
+  buildRepositoryInsights,
+  buildBranchInsights,
+  buildReviewerInsights,
+} = require('../../../src/renderer/shared/dashboard/summary-insights');
+
+function createPullRequest(overrides = {}) {
+  return {
+    repository: 'repo-a',
+    createdAt: '2026-03-12T00:00:00.000Z',
+    description: 'Implement auth',
+    isDraft: false,
+    mergeStatus: 'succeeded',
+    sourceBranch: 'feature/auth',
+    reviewers: [
+      { displayName: 'Alice', uniqueName: 'alice@example.com', vote: 0 },
+      { displayName: 'Bob', uniqueName: 'bob@example.com', vote: 10 },
+    ],
+    ...overrides,
+  };
+}
+
+describe('dashboard summary helpers', () => {
+  beforeEach(() => {
+    jest.spyOn(Date, 'now').mockReturnValue(new Date('2026-03-16T00:00:00.000Z').getTime());
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  test('summary-core calcula edad, aprobaciones, reviewers pendientes y riesgo', () => {
+    const pr = createPullRequest({
+      createdAt: '2026-03-12T00:00:00.000Z',
+      mergeStatus: 'merge conflict',
+      description: 'No description provided.',
+      reviewers: [
+        { displayName: 'Alice', uniqueName: 'alice@example.com', vote: 0 },
+        { displayName: 'Bob', uniqueName: 'bob@example.com', vote: 0 },
+        { displayName: 'Charlie', uniqueName: 'charlie@example.com', vote: 5 },
+      ],
+    });
+
+    expect(getAgeHours(pr.createdAt)).toBe(96);
+    expect(getApprovals(pr)).toBe(1);
+    expect(getPendingReviewers(pr)).toBe(2);
+    expect(hasMergeConflict(pr)).toBe(true);
+    expect(hasEmptyDescription(pr)).toBe(true);
+    expect(getRiskScore(pr)).toBe(9);
+  });
+
+  test('summary-core cubre ramas utilitarias y formato', () => {
+    expect(getAgeHours('3026-03-16T00:00:00.000Z')).toBe(0);
+    expect(hasMergeConflict(createPullRequest({ mergeStatus: 'succeeded' }))).toBe(false);
+    expect(hasEmptyDescription(createPullRequest({ description: '' }))).toBe(true);
+    expect(hasEmptyDescription(createPullRequest({ description: 'Lista para merge' }))).toBe(false);
+
+    const recent = createPullRequest({
+      createdAt: '2026-03-15T06:00:00.000Z',
+      mergeStatus: 'queued',
+      isDraft: true,
+      reviewers: [
+        { displayName: 'Alice', uniqueName: 'alice@example.com', vote: 0 },
+      ],
+    });
+    const mediumAge = createPullRequest({
+      createdAt: '2026-03-14T00:00:00.000Z',
+      reviewers: [],
+      mergeStatus: 'succeeded',
+      description: 'Healthy PR',
+    });
+
+    expect(getRiskScore(recent)).toBe(0);
+    expect(getRiskScore(mediumAge)).toBe(1);
+    expect(formatHours(5)).toBe('5h');
+    expect(formatHours(48)).toBe('2.0d');
+    expect(formatPercentage(55.7)).toBe('56%');
+    expect(classifyBranch('feature/auth')).toBe('feature/*');
+    expect(classifyBranch('bugfix/login')).toBe('bugfix/*');
+    expect(classifyBranch('fix/header')).toBe('bugfix/*');
+    expect(classifyBranch('hotfix/security')).toBe('hotfix/*');
+    expect(classifyBranch('release/1.2.0')).toBe('release/*');
+    expect(classifyBranch('chore/cleanup')).toBe('other');
+    expect(formatLastUpdate(null)).toBe('Not synced yet');
+
+    jest.spyOn(Date.prototype, 'toLocaleDateString').mockReturnValue('16/03/2026');
+    jest.spyOn(Date.prototype, 'toLocaleTimeString').mockReturnValue('12:00:00');
+    expect(formatLastUpdate(new Date('2026-03-16T12:00:00.000Z'))).toBe('16/03/2026 12:00:00');
+  });
+
+  test('prioriza PRs, cuenta antiguedad y calcula promedios', () => {
+    const prioritized = prioritizePullRequests([
+      createPullRequest({
+        repository: 'repo-a',
+        createdAt: '2026-03-13T00:00:00.000Z',
+        reviewers: [
+          { displayName: 'Alice', uniqueName: 'alice@example.com', vote: 0 },
+          { displayName: 'Bob', uniqueName: 'bob@example.com', vote: 0 },
+        ],
+        description: 'No description provided.',
+        mergeStatus: 'conflicts detected',
+      }),
+      createPullRequest({
+        repository: 'repo-b',
+        createdAt: '2026-03-14T00:00:00.000Z',
+        reviewers: [],
+        sourceBranch: 'release/1.0.0',
+      }),
+      createPullRequest({
+        repository: 'repo-c',
+        createdAt: '2026-03-15T00:00:00.000Z',
+        reviewers: [],
+        sourceBranch: 'hotfix/session',
+      }),
+    ]);
+
+    expect(prioritized[0]).toEqual(expect.objectContaining({
+      repository: 'repo-a',
+      riskScore: 9,
+      approvals: 0,
+      pendingReviewers: 2,
+    }));
+    expect(countPullRequestsOlderThan(prioritized, 24)).toBe(3);
+    expect(getAverageAgeHours(prioritized)).toBeGreaterThan(0);
+    expect(getAverageAgeHours([])).toBe(0);
+  });
+
+  test('summary-insights agrupa repositorios, ramas y reviewers pendientes', () => {
+    const prioritized = prioritizePullRequests([
+      createPullRequest({
+        repository: 'repo-a',
+        createdAt: '2026-03-12T00:00:00.000Z',
+        reviewers: [
+          { displayName: 'Alice', uniqueName: 'alice@example.com', vote: 0 },
+          { displayName: 'Bob', uniqueName: 'bob@example.com', vote: 0 },
+        ],
+        description: 'No description provided.',
+        mergeStatus: 'merge conflict',
+        sourceBranch: 'feature/auth',
+      }),
+      createPullRequest({
+        repository: 'repo-a',
+        createdAt: '2026-03-14T00:00:00.000Z',
+        reviewers: [
+          { displayName: '', uniqueName: 'backend@example.com', vote: 0 },
+        ],
+        sourceBranch: 'bugfix/login',
+      }),
+      createPullRequest({
+        repository: 'repo-b',
+        createdAt: '2026-03-15T00:00:00.000Z',
+        reviewers: [
+          { displayName: '', uniqueName: '', vote: 0 },
+          { displayName: 'Merged Reviewer', uniqueName: 'merged@example.com', vote: 10 },
+        ],
+        sourceBranch: 'release/1.0.0',
+      }),
+      createPullRequest({
+        repository: 'repo-c',
+        createdAt: '2026-03-15T12:00:00.000Z',
+        reviewers: [],
+        sourceBranch: 'chore/cleanup',
+      }),
+    ]);
+
+    expect(buildRepositoryInsights(prioritized)).toEqual([
+      { name: 'repo-a', total: 2, highRisk: 1, blocked: 1 },
+      { name: 'repo-b', total: 1, highRisk: 0, blocked: 0 },
+      { name: 'repo-c', total: 1, highRisk: 0, blocked: 0 },
+    ]);
+
+    expect(buildBranchInsights(prioritized)).toEqual(expect.arrayContaining([
+      { label: 'feature/*', total: 1 },
+      { label: 'bugfix/*', total: 1 },
+      { label: 'release/*', total: 1 },
+      { label: 'other', total: 1 },
+    ]));
+
+    expect(buildReviewerInsights(prioritized)).toEqual([
+      { reviewer: 'Alice', pending: 1 },
+      { reviewer: 'Bob', pending: 1 },
+      { reviewer: 'backend@example.com', pending: 1 },
+      { reviewer: 'Unknown reviewer', pending: 1 },
+    ]);
+  });
+});

--- a/tests/unit/renderer/electron-bridge.dom.test.js
+++ b/tests/unit/renderer/electron-bridge.dom.test.js
@@ -1,0 +1,59 @@
+const {
+  getElectronApi,
+  hasElectronApi,
+  invokeElectronApi,
+  subscribeToWindowStateChange,
+  getElectronBridgeUnavailableMessage,
+} = require('../../../src/renderer/shared/electron/electronBridge');
+
+describe('electron bridge helpers', () => {
+  beforeEach(() => {
+    window.electronApi = {
+      invoke: jest.fn().mockResolvedValue('ok'),
+      onWindowStateChange: jest.fn(() => jest.fn()),
+    };
+  });
+
+  test('getElectronApi y hasElectronApi detectan el bridge disponible', () => {
+    expect(getElectronApi()).toBe(window.electronApi);
+    expect(hasElectronApi()).toBe(true);
+  });
+
+  test('invokeElectronApi usa invoke del bridge', async () => {
+    await expect(invokeElectronApi('demo:channel', { work: true })).resolves.toBe('ok');
+
+    expect(window.electronApi.invoke).toHaveBeenCalledWith('demo:channel', { work: true });
+  });
+
+  test('subscribeToWindowStateChange delega al bridge cuando existe', () => {
+    const listener = jest.fn();
+    const unsubscribe = jest.fn();
+    window.electronApi.onWindowStateChange.mockReturnValue(unsubscribe);
+
+    const returned = subscribeToWindowStateChange(listener);
+
+    expect(window.electronApi.onWindowStateChange).toHaveBeenCalledWith(listener);
+    expect(returned).toBe(unsubscribe);
+  });
+
+  test('si el bridge no existe entrega un error claro y un unsubscribe seguro', async () => {
+    delete window.electronApi;
+
+    expect(getElectronApi()).toBeNull();
+    expect(hasElectronApi()).toBe(false);
+    expect(subscribeToWindowStateChange(jest.fn())()).toBeUndefined();
+    await expect(invokeElectronApi('demo:channel')).rejects.toThrow(
+      'No se detecto el bridge de Electron. Esta app requiere ejecutarse dentro de Electron.',
+    );
+    expect(getElectronBridgeUnavailableMessage()).toContain('Esta app requiere ejecutarse dentro de Electron');
+  });
+
+  test('ignora objetos incompletos que no son un bridge valido', () => {
+    window.electronApi = {
+      onWindowStateChange: jest.fn(),
+    };
+
+    expect(getElectronApi()).toBeNull();
+    expect(hasElectronApi()).toBe(false);
+  });
+});

--- a/tests/unit/renderer/history.dom.test.js
+++ b/tests/unit/renderer/history.dom.test.js
@@ -9,6 +9,11 @@ describe('dashboard history storage', () => {
     expect(history.loadDashboardHistory()).toEqual([]);
   });
 
+  test('loadDashboardHistory devuelve vacio si el storage esta corrupto', () => {
+    window.localStorage.setItem('checkpr.dashboard.history', '{broken-json');
+    expect(history.loadDashboardHistory()).toEqual([]);
+  });
+
   test('persistDashboardSnapshot agrega al inicio y limita el historial', () => {
     for (let index = 0; index < 125; index += 1) {
       history.persistDashboardSnapshot({

--- a/tests/unit/renderer/repository-analysis-guards.test.js
+++ b/tests/unit/renderer/repository-analysis-guards.test.js
@@ -1,0 +1,164 @@
+const {
+  canPrepareRepositoryAnalysisPreview,
+  isRepositoryAnalysisStrictModeBlocked,
+  canRunRepositoryAnalysis,
+} = require('../../../src/renderer/features/repository-analysis/application/repositoryAnalysisGuards');
+
+function createPreview(overrides = {}) {
+  return {
+    provider: 'github',
+    repository: 'repo-a',
+    branch: 'main',
+    includedFiles: ['src/app.ts'],
+    filesPrepared: 1,
+    totalFilesDiscovered: 1,
+    truncated: false,
+    exclusions: {
+      omittedByPrioritization: [],
+      omittedBySize: [],
+      omittedByBinaryDetection: [],
+    },
+    sensitivity: {
+      findings: [],
+      hasSensitiveConfigFiles: false,
+      hasSecretPatterns: false,
+      noSensitiveConfigFilesDetected: true,
+      summary: 'Sin hallazgos.',
+    },
+    disclaimer: 'preview',
+    ...overrides,
+  };
+}
+
+function createCodexConfig(overrides = {}) {
+  return {
+    snapshotPolicy: {
+      excludedPathPatterns: '',
+      strictMode: false,
+    },
+    ...overrides,
+  };
+}
+
+describe('repositoryAnalysisGuards', () => {
+  test('canPrepareRepositoryAnalysisPreview exige todos los prerequisitos', () => {
+    expect(canPrepareRepositoryAnalysisPreview({
+      providerKind: 'github',
+      activeProvider: { kind: 'github' },
+      isConnectionReady: true,
+      isCodexReady: true,
+      repositoryId: 'repo-a',
+      branchName: 'main',
+      isRunning: false,
+      isPreviewing: false,
+    })).toBe(true);
+
+    expect(canPrepareRepositoryAnalysisPreview({
+      providerKind: 'github',
+      activeProvider: { kind: 'github' },
+      isConnectionReady: true,
+      isCodexReady: true,
+      repositoryId: 'repo-a',
+      branchName: 'main',
+      isRunning: true,
+      isPreviewing: false,
+    })).toBe(false);
+
+    expect(canPrepareRepositoryAnalysisPreview({
+      providerKind: '',
+      activeProvider: null,
+      isConnectionReady: false,
+      isCodexReady: false,
+      repositoryId: '',
+      branchName: '',
+      isRunning: false,
+      isPreviewing: true,
+    })).toBe(false);
+  });
+
+  test('isRepositoryAnalysisStrictModeBlocked solo bloquea con strict mode y sensibilidad', () => {
+    expect(isRepositoryAnalysisStrictModeBlocked(
+      createPreview({
+        sensitivity: {
+          findings: [],
+          hasSensitiveConfigFiles: true,
+          hasSecretPatterns: false,
+          noSensitiveConfigFilesDetected: false,
+          summary: 'Hay hallazgos.',
+        },
+      }),
+      createCodexConfig({
+        snapshotPolicy: {
+          excludedPathPatterns: '',
+          strictMode: true,
+        },
+      }),
+    )).toBe(true);
+
+    expect(isRepositoryAnalysisStrictModeBlocked(
+      createPreview(),
+      createCodexConfig({
+        snapshotPolicy: {
+          excludedPathPatterns: '',
+          strictMode: true,
+        },
+      }),
+    )).toBe(false);
+  });
+
+  test('canRunRepositoryAnalysis valida branch, provider y acknowledgement del snapshot', () => {
+    const preview = createPreview();
+
+    expect(canRunRepositoryAnalysis({
+      providerKind: 'github',
+      activeProvider: { kind: 'github' },
+      isConnectionReady: true,
+      isCodexReady: true,
+      repositoryId: 'repo-a',
+      branchName: 'main',
+      preview,
+      snapshotAcknowledged: true,
+      isStrictModeBlocked: false,
+      isRunning: false,
+    })).toBe(true);
+
+    expect(canRunRepositoryAnalysis({
+      providerKind: 'github',
+      activeProvider: { kind: 'github' },
+      isConnectionReady: true,
+      isCodexReady: true,
+      repositoryId: 'repo-a',
+      branchName: 'develop',
+      preview,
+      snapshotAcknowledged: true,
+      isStrictModeBlocked: false,
+      isRunning: false,
+    })).toBe(false);
+
+    expect(canRunRepositoryAnalysis({
+      providerKind: 'github',
+      activeProvider: { kind: 'gitlab' },
+      isConnectionReady: true,
+      isCodexReady: true,
+      repositoryId: 'repo-a',
+      branchName: 'main',
+      preview,
+      snapshotAcknowledged: true,
+      isStrictModeBlocked: false,
+      isRunning: false,
+    })).toBe(false);
+
+    expect(canRunRepositoryAnalysis({
+      providerKind: 'github',
+      activeProvider: { kind: 'github' },
+      isConnectionReady: true,
+      isCodexReady: true,
+      repositoryId: 'repo-a',
+      branchName: 'main',
+      preview,
+      snapshotAcknowledged: false,
+      isStrictModeBlocked: false,
+      isRunning: false,
+    })).toBe(false);
+  });
+});

--- a/tests/unit/renderer/repository-analysis-payload.test.js
+++ b/tests/unit/renderer/repository-analysis-payload.test.js
@@ -1,0 +1,125 @@
+const { buildRepositoryAnalysisPayload } = require('../../../src/renderer/features/repository-analysis/application/repositoryAnalysisPayload');
+
+function createConfig(overrides = {}) {
+  return {
+    provider: 'github',
+    organization: 'acme',
+    project: 'repo-a',
+    repositoryId: 'repo-a',
+    personalAccessToken: 'pat',
+    targetReviewer: '',
+    ...overrides,
+  };
+}
+
+function createCodexConfig(overrides = {}) {
+  return {
+    enabled: true,
+    model: 'gpt-5.2-codex',
+    analysisDepth: 'deep',
+    maxFilesPerRun: 42,
+    includeTests: true,
+    repositoryScope: 'selected',
+    apiKey: 'sk-live',
+    snapshotPolicy: {
+      excludedPathPatterns: 'dist/**',
+      strictMode: true,
+    },
+    prReview: {
+      enabled: true,
+      maxPullRequests: 2,
+      selectionMode: 'top-risk',
+      analysisDepth: 'standard',
+      promptDirectives: {
+        focusAreas: '',
+        customInstructions: '',
+      },
+    },
+    promptDirectives: {
+      architectureReviewEnabled: true,
+      architecturePattern: 'clean',
+      requiredPractices: 'tests',
+      forbiddenPractices: 'any',
+      domainContext: 'repo',
+      customInstructions: 'be strict',
+    },
+    ...overrides,
+  };
+}
+
+describe('repositoryAnalysisPayload', () => {
+  beforeEach(() => {
+    jest.spyOn(Date, 'now').mockReturnValue(1234567890);
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  test('construye un payload GitHub con secretos omitidos y exclusiones fusionadas', () => {
+    const payload = buildRepositoryAnalysisPayload({
+      activeProvider: {
+        kind: 'github',
+        name: 'GitHub',
+        status: 'available',
+        description: 'GitHub Cloud',
+        helperText: '',
+      },
+      config: createConfig(),
+      repositoryId: 'repo-a',
+      branchName: 'main',
+      codexConfig: createCodexConfig(),
+      pendingExcludedPaths: ['src/generated.ts', 'src/generated.ts', 'src/legacy.ts'],
+    });
+
+    expect(payload).toEqual(expect.objectContaining({
+      requestId: '1234567890-repo-a-main',
+      repositoryId: 'repo-a',
+      branchName: 'main',
+      apiKey: '',
+      model: 'gpt-5.2-codex',
+      analysisDepth: 'deep',
+      maxFilesPerRun: 42,
+      includeTests: true,
+      timeoutMs: 90000,
+      source: expect.objectContaining({
+        provider: 'github',
+        project: 'repo-a',
+        repositoryId: 'repo-a',
+      }),
+    }));
+
+    expect(payload.snapshotPolicy).toEqual(expect.objectContaining({
+      strictMode: true,
+    }));
+    expect(payload.snapshotPolicy.excludedPathPatterns).toContain('dist/**');
+    expect(payload.snapshotPolicy.excludedPathPatterns).toContain('src/generated.ts');
+    expect(payload.snapshotPolicy.excludedPathPatterns).toContain('src/legacy.ts');
+    expect(payload.promptDirectives.customInstructions).toBe('be strict');
+  });
+
+  test('preserva el project original cuando el provider es Azure DevOps', () => {
+    const payload = buildRepositoryAnalysisPayload({
+      activeProvider: {
+        kind: 'azure-devops',
+        name: 'Azure DevOps',
+        status: 'available',
+        description: 'Azure',
+        helperText: '',
+      },
+      config: createConfig({
+        provider: 'azure-devops',
+        project: 'platform-team',
+        repositoryId: 'legacy-repo',
+      }),
+      repositoryId: 'repo-from-selector',
+      branchName: 'release',
+      codexConfig: createCodexConfig(),
+      pendingExcludedPaths: [],
+    });
+
+    expect(payload.source.project).toBe('platform-team');
+    expect(payload.source.repositoryId).toBe('repo-from-selector');
+    expect(payload.source.provider).toBe('azure-devops');
+  });
+});

--- a/tests/unit/renderer/repository-analysis-scope.dom.test.js
+++ b/tests/unit/renderer/repository-analysis-scope.dom.test.js
@@ -1,0 +1,321 @@
+const { renderHook, act } = require('@testing-library/react');
+
+const mockUseRepositoryBranches = jest.fn();
+
+jest.mock('../../../src/renderer/features/repository-analysis/presentation/hooks/useRepositoryBranches', () => ({
+  useRepositoryBranches: (...args) => mockUseRepositoryBranches(...args),
+}));
+
+const { useRepositoryAnalysisScope } = require('../../../src/renderer/features/repository-analysis/presentation/hooks/useRepositoryAnalysisScope');
+
+function createPreview(overrides = {}) {
+  return {
+    provider: 'github',
+    repository: 'repo-a',
+    branch: 'main',
+    includedFiles: ['src/app.ts'],
+    filesPrepared: 1,
+    totalFilesDiscovered: 1,
+    truncated: false,
+    exclusions: {
+      omittedByPrioritization: [],
+      omittedBySize: [],
+      omittedByBinaryDetection: [],
+    },
+    sensitivity: {
+      findings: [],
+      hasSensitiveConfigFiles: false,
+      hasSecretPatterns: false,
+      noSensitiveConfigFilesDetected: true,
+      summary: 'Sin hallazgos.',
+    },
+    disclaimer: 'preview',
+    ...overrides,
+  };
+}
+
+function createConfig(overrides = {}) {
+  return {
+    provider: 'github',
+    organization: 'acme',
+    project: 'repo-a',
+    repositoryId: 'repo-a',
+    personalAccessToken: 'pat',
+    targetReviewer: '',
+    ...overrides,
+  };
+}
+
+function createCodexConfig(overrides = {}) {
+  return {
+    enabled: true,
+    model: 'gpt-5.2-codex',
+    analysisDepth: 'standard',
+    maxFilesPerRun: 50,
+    includeTests: false,
+    repositoryScope: 'selected',
+    apiKey: 'sk-live',
+    snapshotPolicy: {
+      excludedPathPatterns: 'dist/**',
+      strictMode: false,
+    },
+    prReview: {
+      enabled: true,
+      maxPullRequests: 2,
+      selectionMode: 'top-risk',
+      analysisDepth: 'standard',
+      promptDirectives: {
+        focusAreas: '',
+        customInstructions: '',
+      },
+    },
+    promptDirectives: {
+      architectureReviewEnabled: true,
+      architecturePattern: 'clean',
+      requiredPractices: 'tests',
+      forbiddenPractices: 'any',
+      domainContext: 'repo',
+      customInstructions: '',
+    },
+    ...overrides,
+  };
+}
+
+function createOptions(overrides = {}) {
+  return {
+    activeProvider: {
+      kind: 'github',
+      name: 'GitHub',
+      status: 'available',
+      description: 'GitHub Cloud',
+      helperText: '',
+    },
+    config: createConfig(),
+    repositories: [
+      { id: 'repo-a', name: 'Repo A' },
+      { id: 'repo-b', name: 'Repo B' },
+    ],
+    isConnectionReady: true,
+    isCodexReady: true,
+    codexConfig: createCodexConfig(),
+    preview: null,
+    isRunning: false,
+    isPreviewing: false,
+    preparePreview: jest.fn(),
+    execute: jest.fn(),
+    reset: jest.fn(),
+    ...overrides,
+  };
+}
+
+describe('useRepositoryAnalysisScope', () => {
+  beforeEach(() => {
+    mockUseRepositoryBranches.mockReturnValue({
+      branches: [
+        { name: 'main', objectId: '1', isDefault: true },
+        { name: 'develop', objectId: '2', isDefault: false },
+      ],
+      branchName: 'main',
+      setBranchName: jest.fn(),
+      isLoadingBranches: false,
+      branchError: null,
+    });
+    jest.spyOn(Date, 'now').mockReturnValue(1234567890);
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  test('prepara preview con el payload correcto y limpia acknowledgement previo', () => {
+    const options = createOptions();
+    const { result } = renderHook((props) => useRepositoryAnalysisScope(props), {
+      initialProps: options,
+    });
+
+    act(() => {
+      result.current.setSnapshotAcknowledged(true);
+    });
+
+    act(() => {
+      result.current.handlePreparePreview();
+    });
+
+    expect(options.preparePreview).toHaveBeenCalledWith(expect.objectContaining({
+      requestId: '1234567890-repo-a-main',
+      repositoryId: 'repo-a',
+      branchName: 'main',
+      source: expect.objectContaining({
+        provider: 'github',
+        repositoryId: 'repo-a',
+        project: 'repo-a',
+      }),
+    }));
+    expect(result.current.snapshotAcknowledged).toBe(false);
+    expect(result.current.selectedRepository).toEqual({ id: 'repo-a', name: 'Repo A' });
+  });
+
+  test('no prepara preview ni regenera si faltan prerequisitos o no hay exclusiones pendientes', () => {
+    const options = createOptions({
+      isConnectionReady: false,
+      preview: createPreview(),
+    });
+    const { result } = renderHook((props) => useRepositoryAnalysisScope(props), {
+      initialProps: options,
+    });
+
+    act(() => {
+      result.current.handlePreparePreview();
+      result.current.handleRegenerateWithExclusions();
+    });
+
+    expect(options.preparePreview).not.toHaveBeenCalled();
+  });
+
+  test('mantiene exclusiones pendientes sin duplicados y permite regenerar el snapshot', () => {
+    const options = createOptions({
+      preview: createPreview(),
+    });
+    const { result } = renderHook((props) => useRepositoryAnalysisScope(props), {
+      initialProps: options,
+    });
+
+    act(() => {
+      result.current.handleToggleExcludedPath('src/generated.ts', true);
+      result.current.handleToggleExcludedPath('src/generated.ts', true);
+      result.current.handleToggleExcludedPath('src/legacy.ts', true);
+    });
+
+    expect(result.current.pendingExcludedPaths).toEqual(['src/generated.ts', 'src/legacy.ts']);
+
+    act(() => {
+      result.current.handleRegenerateWithExclusions();
+    });
+
+    const payload = options.preparePreview.mock.calls[0][0];
+    expect(payload.snapshotPolicy.excludedPathPatterns).toContain('dist/**');
+    expect(payload.snapshotPolicy.excludedPathPatterns).toContain('src/generated.ts');
+    expect(payload.snapshotPolicy.excludedPathPatterns).toContain('src/legacy.ts');
+
+    act(() => {
+      result.current.handleToggleExcludedPath('src/generated.ts', false);
+    });
+
+    expect(result.current.pendingExcludedPaths).toEqual(['src/legacy.ts']);
+  });
+
+  test('cambiar repositorio o rama limpia estado transitorio y dispara reset', () => {
+    const branchState = {
+      branches: [
+        { name: 'main', objectId: '1', isDefault: true },
+      ],
+      branchName: 'main',
+      setBranchName: jest.fn(),
+      isLoadingBranches: false,
+      branchError: null,
+    };
+    mockUseRepositoryBranches.mockReturnValue(branchState);
+
+    const options = createOptions();
+    const { result } = renderHook((props) => useRepositoryAnalysisScope(props), {
+      initialProps: options,
+    });
+
+    act(() => {
+      result.current.setSnapshotAcknowledged(true);
+      result.current.handleToggleExcludedPath('src/legacy.ts', true);
+    });
+
+    act(() => {
+      result.current.handleRepositoryChange('repo-b');
+    });
+
+    expect(options.reset).toHaveBeenCalledTimes(1);
+    expect(result.current.repositoryId).toBe('repo-b');
+    expect(result.current.pendingExcludedPaths).toEqual([]);
+    expect(result.current.snapshotAcknowledged).toBe(false);
+
+    act(() => {
+      result.current.handleBranchChange('develop');
+    });
+
+    expect(branchState.setBranchName).toHaveBeenCalledWith('develop');
+    expect(options.reset).toHaveBeenCalledTimes(2);
+  });
+
+  test('bloquea la ejecucion en strict mode y solo corre cuando el preview coincide y fue confirmado', () => {
+    const blockedExecute = jest.fn();
+    const { result, rerender } = renderHook((props) => useRepositoryAnalysisScope(props), {
+      initialProps: createOptions({
+        execute: blockedExecute,
+        preview: createPreview({
+          sensitivity: {
+            findings: [],
+            hasSensitiveConfigFiles: true,
+            hasSecretPatterns: false,
+            noSensitiveConfigFilesDetected: false,
+            summary: 'Hay riesgo.',
+          },
+        }),
+        codexConfig: createCodexConfig({
+          snapshotPolicy: {
+            excludedPathPatterns: 'dist/**',
+            strictMode: true,
+          },
+        }),
+      }),
+    });
+
+    act(() => {
+      result.current.setSnapshotAcknowledged(true);
+      result.current.handleRun();
+    });
+
+    expect(result.current.isStrictModeBlocked).toBe(true);
+    expect(result.current.canRunAnalysis).toBe(false);
+    expect(blockedExecute).not.toHaveBeenCalled();
+
+    const execute = jest.fn();
+    rerender(createOptions({
+      execute,
+      preview: createPreview(),
+      codexConfig: createCodexConfig(),
+    }));
+
+    act(() => {
+      result.current.setSnapshotAcknowledged(true);
+    });
+
+    act(() => {
+      result.current.handleRun();
+    });
+
+    expect(result.current.canRunAnalysis).toBe(true);
+    expect(execute).toHaveBeenCalledWith(expect.objectContaining({
+      repositoryId: 'repo-a',
+      branchName: 'main',
+    }));
+  });
+
+  test('sincroniza repositoryId cuando cambia la configuracion persistida', () => {
+    const options = createOptions({
+      config: createConfig({
+        repositoryId: 'repo-a',
+      }),
+    });
+    const { result, rerender } = renderHook((props) => useRepositoryAnalysisScope(props), {
+      initialProps: options,
+    });
+
+    expect(result.current.repositoryId).toBe('repo-a');
+
+    rerender(createOptions({
+      config: createConfig({
+        repositoryId: 'repo-b',
+      }),
+    }));
+
+    expect(result.current.repositoryId).toBe('repo-b');
+    expect(result.current.selectedRepository).toEqual({ id: 'repo-b', name: 'Repo B' });
+  });
+});

--- a/tests/unit/renderer/repository-providers.test.js
+++ b/tests/unit/renderer/repository-providers.test.js
@@ -1,0 +1,19 @@
+const { repositoryProviders, getRepositoryProvider } = require('../../../src/renderer/features/repository-source/providers');
+
+describe('repository providers', () => {
+  test('expone providers soportados y devuelve null para selecciones invalidas', () => {
+    expect(repositoryProviders.map((provider) => provider.kind)).toEqual([
+      'azure-devops',
+      'github',
+      'gitlab',
+      'bitbucket',
+    ]);
+
+    expect(getRepositoryProvider('github')).toEqual(expect.objectContaining({
+      kind: 'github',
+      status: 'available',
+    }));
+    expect(getRepositoryProvider('')).toBeNull();
+    expect(getRepositoryProvider('unknown')).toBeNull();
+  });
+});

--- a/tests/unit/renderer/repository-source-config-hooks.dom.test.js
+++ b/tests/unit/renderer/repository-source-config-hooks.dom.test.js
@@ -92,6 +92,83 @@ describe('repository source config hooks', () => {
     expect(result.current.configRef.current.repositoryId).toBe('repo-a');
   });
 
+  test('useRepositorySourceConfig resetea project y repositoryId al cambiar organization', async () => {
+    storage.loadConnectionConfig.mockReturnValue({
+      provider: 'azure-devops',
+      organization: 'acme',
+      project: 'platform',
+      repositoryId: 'repo-a',
+      personalAccessToken: '',
+      targetReviewer: '',
+    });
+
+    const handlers = {
+      onConfigChangeStart: jest.fn(),
+      onProjectSelected: jest.fn(),
+    };
+
+    const { result } = renderHook(() => useRepositorySourceConfig(handlers));
+
+    await act(async () => {
+      result.current.updateConfig('organization', 'other-org');
+    });
+
+    expect(result.current.config).toEqual({
+      provider: 'azure-devops',
+      organization: 'other-org',
+      project: '',
+      repositoryId: '',
+      personalAccessToken: '',
+      targetReviewer: '',
+    });
+  });
+
+  test('useRepositorySourceConfig limpia solo repositoryId al cambiar project', async () => {
+    storage.loadConnectionConfig.mockReturnValue({
+      provider: 'azure-devops',
+      organization: 'acme',
+      project: 'platform',
+      repositoryId: 'repo-a',
+      personalAccessToken: '',
+      targetReviewer: '',
+    });
+
+    const { result } = renderHook(() => useRepositorySourceConfig({
+      onConfigChangeStart: jest.fn(),
+      onProjectSelected: jest.fn(),
+    }));
+
+    await act(async () => {
+      result.current.updateConfig('project', 'platform-v2');
+    });
+
+    expect(result.current.config.project).toBe('platform-v2');
+    expect(result.current.config.repositoryId).toBe('');
+  });
+
+  test('useRepositorySourceConfig mantiene repositoryId vacio al seleccionar proyecto en azure', async () => {
+    storage.loadConnectionConfig.mockReturnValue({
+      provider: 'azure-devops',
+      organization: 'acme',
+      project: '',
+      repositoryId: 'repo-a',
+      personalAccessToken: '',
+      targetReviewer: '',
+    });
+
+    const { result } = renderHook(() => useRepositorySourceConfig({
+      onConfigChangeStart: jest.fn(),
+      onProjectSelected: jest.fn(),
+    }));
+
+    await act(async () => {
+      result.current.selectProjectConfig('platform');
+    });
+
+    expect(result.current.config.project).toBe('platform');
+    expect(result.current.config.repositoryId).toBe('');
+  });
+
   test('useRepositorySourceConfig hidrata el secreto desde storage', async () => {
     storage.hydrateConnectionSecret.mockResolvedValue('pat-session');
 
@@ -159,6 +236,61 @@ describe('repository source config hooks', () => {
     expect(refreshPullRequests).not.toHaveBeenCalled();
   });
 
+  test('useRepositorySourceBootstrap no actualiza ni refresca si el secreto no existe', async () => {
+    const refreshPullRequests = jest.fn();
+    const updateConfig = jest.fn();
+
+    renderHook(() => useRepositorySourceBootstrap({
+      configRef: {
+        current: {
+          provider: 'github',
+          organization: 'acme',
+          project: '',
+          repositoryId: '',
+          personalAccessToken: '',
+          targetReviewer: '',
+        },
+      },
+      hydrateSecret: jest.fn().mockResolvedValue(''),
+      updateConfig,
+      refreshPullRequests,
+    }));
+
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    expect(updateConfig).not.toHaveBeenCalled();
+    expect(refreshPullRequests).not.toHaveBeenCalled();
+  });
+
+  test('useRepositorySourceBootstrap restaura secreto pero no refresca si falta config minima', async () => {
+    const refreshPullRequests = jest.fn();
+    const updateConfig = jest.fn();
+
+    renderHook(() => useRepositorySourceBootstrap({
+      configRef: {
+        current: {
+          provider: 'azure-devops',
+          organization: 'acme',
+          project: '',
+          repositoryId: '',
+          personalAccessToken: '',
+          targetReviewer: '',
+        },
+      },
+      hydrateSecret: jest.fn().mockResolvedValue('pat-restored'),
+      updateConfig,
+      refreshPullRequests,
+    }));
+
+    await waitFor(() => {
+      expect(updateConfig).toHaveBeenCalledWith('personalAccessToken', 'pat-restored');
+    });
+
+    expect(refreshPullRequests).not.toHaveBeenCalled();
+  });
+
   test('useRepositorySourceDerived calcula nombres seleccionados y readiness', () => {
     const { result } = renderHook(() => useRepositorySourceDerived({
       config: {
@@ -182,5 +314,31 @@ describe('repository source config hooks', () => {
     expect(result.current.selectedProjectName).toBe('Platform API');
     expect(result.current.selectedRepositoryName).toBe('Platform API');
     expect(result.current.scopeLabel).toContain('acme/platform');
+  });
+
+  test('useRepositorySourceDerived usa fallbacks cuando no hay provider o match seleccionado', () => {
+    const { result } = renderHook(() => useRepositorySourceDerived({
+      config: {
+        provider: '',
+        organization: '',
+        project: 'manual-project',
+        repositoryId: 'manual-repo',
+        personalAccessToken: '',
+        targetReviewer: '',
+      },
+      projects: [],
+      repositories: [],
+      pullRequests: [],
+      lastUpdatedAt: null,
+      hasSuccessfulConnection: false,
+    }));
+
+    expect(result.current.activeProvider).toBeNull();
+    expect(result.current.activeProviderName).toBe('Sin provider seleccionado');
+    expect(result.current.hasCredentialsInSession).toBe(false);
+    expect(result.current.isConnectionReady).toBe(false);
+    expect(result.current.selectedProjectName).toBe('manual-project');
+    expect(result.current.selectedRepositoryName).toBe('manual-repo');
+    expect(result.current.scopeLabel).toBe('Selecciona un provider en Settings');
   });
 });

--- a/tests/unit/renderer/repository-source-helpers.test.js
+++ b/tests/unit/renderer/repository-source-helpers.test.js
@@ -1,4 +1,5 @@
 const diagnostics = require('../../../src/renderer/features/repository-source/application/repositorySourceDiagnostics');
+const rules = require('../../../src/renderer/features/repository-source/application/repositorySourceRules');
 
 describe('repository source helpers', () => {
   test('buildScopeLabel soporta github/gitlab y azure', () => {
@@ -41,9 +42,87 @@ describe('repository source helpers', () => {
 
     expect(github.requestPath).toContain('api.github.com/repos/acme/repo-a/pulls');
     expect(azure.requestPath).toContain('dev.azure.com/org/proj/_apis/git/repositories');
+
+    const gitlab = diagnostics.buildDiagnostics('pullRequests', {
+      provider: 'gitlab',
+      organization: 'acme/platform',
+      project: '',
+      repositoryId: 'acme/platform/repo-a',
+      personalAccessToken: '',
+      targetReviewer: '',
+    });
+    const noProvider = diagnostics.buildDiagnostics(null, {
+      provider: '',
+      organization: 'acme',
+      project: '',
+      repositoryId: '',
+      personalAccessToken: '',
+      targetReviewer: '',
+    });
+
+    expect(gitlab.requestPath).toContain(encodeURIComponent('acme/platform/repo-a'));
+    expect(noProvider.requestPath).toBe('');
   });
 
   test('getProviderDisplayName devuelve fallback si no hay provider', () => {
     expect(diagnostics.getProviderDisplayName(null)).toBe('Sin provider seleccionado');
+  });
+
+  test('buildScopeLabel cubre fallbacks por provider y seleccion', () => {
+    expect(diagnostics.buildScopeLabel({
+      provider: 'gitlab',
+      organization: '',
+      project: '',
+      repositoryId: '',
+      personalAccessToken: '',
+      targetReviewer: '',
+    }, null, null)).toBe('No organization / Todos los repositorios');
+
+    expect(diagnostics.buildScopeLabel({
+      provider: 'azure-devops',
+      organization: 'org',
+      project: '',
+      repositoryId: '',
+      personalAccessToken: '',
+      targetReviewer: '',
+    }, null, null)).toBe('org / Sin proyecto / Todos los repositorios');
+  });
+
+  test('hasMinimumProjectDiscoveryConfig y hasMinimumRepositoryConfig validan por provider', () => {
+    expect(rules.hasMinimumProjectDiscoveryConfig({
+      provider: 'github',
+      organization: ' acme ',
+      project: '',
+      repositoryId: '',
+      personalAccessToken: ' pat ',
+      targetReviewer: '',
+    })).toBe(true);
+
+    expect(rules.hasMinimumProjectDiscoveryConfig({
+      provider: 'github',
+      organization: '   ',
+      project: '',
+      repositoryId: '',
+      personalAccessToken: 'pat',
+      targetReviewer: '',
+    })).toBe(false);
+
+    expect(rules.hasMinimumRepositoryConfig({
+      provider: 'gitlab',
+      organization: 'acme',
+      project: '',
+      repositoryId: '',
+      personalAccessToken: 'pat',
+      targetReviewer: '',
+    })).toBe(true);
+
+    expect(rules.hasMinimumRepositoryConfig({
+      provider: 'azure-devops',
+      organization: 'acme',
+      project: '',
+      repositoryId: '',
+      personalAccessToken: 'pat',
+      targetReviewer: '',
+    })).toBe(false);
   });
 });

--- a/tests/unit/renderer/repository-source-ipc.test.js
+++ b/tests/unit/renderer/repository-source-ipc.test.js
@@ -11,7 +11,9 @@ describe('repository source ipc gateway', () => {
 
   test('resuelve canales genericos del gateway de repository source', () => {
     expect(repositorySourceIpc.getRepositorySourceChannel('pullRequests')).toBe('repository-source:fetchPullRequests');
+    expect(repositorySourceIpc.getRepositorySourceChannel('projects')).toBe('repository-source:fetchProjects');
     expect(repositorySourceIpc.getRepositorySourceChannel('repositories')).toBe('repository-source:fetchRepositories');
+    expect(repositorySourceIpc.getRepositorySourceChannel('branches')).toBe('repository-source:fetchBranches');
     expect(repositorySourceIpc.getRepositorySourceChannel('openExternal')).toBe('repository-source:openExternal');
   });
 
@@ -44,6 +46,36 @@ describe('repository source ipc gateway', () => {
       project: '',
       personalAccessToken: '',
     })).rejects.toThrow('Selecciona un provider');
+  });
+
+  test('fetchRepositories y fetchBranches usan los canales correctos', async () => {
+    window.electronApi.invoke
+      .mockResolvedValueOnce({
+        ok: true,
+        data: [{ id: 'repo-a', name: 'Repo A' }],
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        data: [{ name: 'main', objectId: '1', isDefault: true }],
+      });
+
+    const config = {
+      provider: 'github',
+      organization: 'acme',
+      project: 'repo-a',
+      repositoryId: 'repo-a',
+      personalAccessToken: 'secret',
+    };
+
+    await expect(repositorySourceIpc.fetchRepositories(config)).resolves.toEqual([
+      { id: 'repo-a', name: 'Repo A' },
+    ]);
+    await expect(repositorySourceIpc.fetchBranches(config)).resolves.toEqual([
+      { name: 'main', objectId: '1', isDefault: true },
+    ]);
+
+    expect(window.electronApi.invoke).toHaveBeenNthCalledWith(1, 'repository-source:fetchRepositories', config);
+    expect(window.electronApi.invoke).toHaveBeenNthCalledWith(2, 'repository-source:fetchBranches', config);
   });
 
   test('openReviewItem propaga errores del canal IPC', async () => {

--- a/tests/unit/renderer/repository-source-snapshot-persistence.dom.test.js
+++ b/tests/unit/renderer/repository-source-snapshot-persistence.dom.test.js
@@ -1,0 +1,60 @@
+const { renderHook } = require('@testing-library/react');
+
+jest.mock('../../../src/renderer/features/history/data/historyStorage', () => ({
+  persistDashboardSnapshot: jest.fn(),
+}));
+
+jest.mock('../../../src/renderer/features/repository-source/data/repositorySourceStorage', () => ({
+  persistSavedAzureContext: jest.fn(),
+}));
+
+jest.mock('../../../src/renderer/shared/dashboard/summary', () => ({
+  buildDashboardSummary: jest.fn(() => ({
+    activePRs: 3,
+    highRiskPRs: 1,
+    blockedPRs: 0,
+    reviewBacklog: 1,
+    averageAgeHours: 4,
+    stalePRs: 0,
+    repositoryCount: 1,
+    hotfixPRs: 0,
+  })),
+}));
+
+const { persistDashboardSnapshot } = require('../../../src/renderer/features/history/data/historyStorage');
+const { persistSavedAzureContext } = require('../../../src/renderer/features/repository-source/data/repositorySourceStorage');
+const { useRepositorySourceSnapshotPersistence } = require('../../../src/renderer/features/repository-source/presentation/hooks/useRepositorySourceSnapshotPersistence');
+
+describe('useRepositorySourceSnapshotPersistence', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  test('usa el configRef actual al persistir el snapshot', () => {
+    const timestamp = new Date('2026-03-11T12:00:00.000Z');
+    const configRef = {
+      current: {
+        provider: 'azure-devops',
+        organization: 'org-a',
+        project: 'platform',
+        repositoryId: 'repo-a',
+        personalAccessToken: '',
+        targetReviewer: '',
+      },
+    };
+
+    const { result } = renderHook(() => useRepositorySourceSnapshotPersistence(configRef));
+
+    result.current([{ id: 1, title: 'PR', url: 'https://example.com/pr/1' }], timestamp, 'ignored', 'ian');
+
+    expect(persistSavedAzureContext).toHaveBeenCalledWith(expect.objectContaining({
+      organization: 'org-a',
+      project: 'platform',
+      repositoryId: 'repo-a',
+    }));
+    expect(persistDashboardSnapshot).toHaveBeenCalledWith(expect.objectContaining({
+      scopeLabel: 'org-a / platform / Todos los repositorios',
+      activePRs: 3,
+    }));
+  });
+});

--- a/tests/unit/renderer/repository-source-use-cases.test.js
+++ b/tests/unit/renderer/repository-source-use-cases.test.js
@@ -5,6 +5,7 @@ const {
   createDiscoverProjectsUseCase,
   createOpenExternalLinkUseCase,
 } = require('../../../src/renderer/features/repository-source/application/repositorySourceUseCases');
+const diagnosticsService = require('../../../src/renderer/features/repository-source/application/repositorySourceDiagnosticsService');
 
 function createStateMock() {
   return {
@@ -137,6 +138,41 @@ describe('repositorySourceUseCases', () => {
     expect(state.setHasSuccessfulConnection).toHaveBeenCalledWith(false);
   });
 
+  test('syncPullRequests captura errores operativos y limpia loading', async () => {
+    const state = createStateMock();
+    const diagnostics = createDiagnosticsMock();
+    const useCase = createSyncPullRequestsUseCase({
+      fetcher: { fetchPullRequests: jest.fn().mockRejectedValue(new Error('sync fail')) },
+      state,
+      diagnostics,
+      snapshot: { persistSnapshot: jest.fn() },
+      activeProviderName: 'GitHub',
+      scopeLabel: 'acme / repo-a',
+    });
+
+    await useCase(
+      {
+        provider: 'github',
+        organization: 'acme',
+        project: 'repo-a',
+        repositoryId: 'repo-a',
+        personalAccessToken: 'pat',
+        targetReviewer: 'ian',
+      },
+      jest.fn().mockResolvedValue([]),
+      jest.fn().mockResolvedValue([]),
+    );
+
+    expect(diagnostics.updateDiagnostics).toHaveBeenLastCalledWith(
+      'pullRequests',
+      expect.objectContaining({ repositoryId: 'repo-a' }),
+      'sync fail',
+    );
+    expect(state.setPullRequests).toHaveBeenCalledWith([]);
+    expect(state.setHasSuccessfulConnection).toHaveBeenCalledWith(false);
+    expect(state.setIsLoading).toHaveBeenLastCalledWith(false);
+  });
+
   test('discoverProjects valida credenciales minimas', async () => {
     const state = createStateMock();
     const diagnostics = createDiagnosticsMock();
@@ -158,6 +194,32 @@ describe('repositorySourceUseCases', () => {
     expect(state.setError).toHaveBeenCalledWith(
       'El alcance principal y el token son obligatorios para cargar GitHub.',
     );
+  });
+
+  test('discoverProjects delega en fetchProjects cuando la config es valida', async () => {
+    const state = createStateMock();
+    const diagnostics = createDiagnosticsMock();
+    const fetchProjects = jest.fn().mockResolvedValue([{ id: 'repo-a' }]);
+    const useCase = createDiscoverProjectsUseCase({
+      state,
+      diagnostics,
+      activeProviderName: 'GitHub',
+    });
+
+    await useCase({
+      provider: 'github',
+      organization: 'acme',
+      project: '',
+      repositoryId: '',
+      personalAccessToken: 'pat',
+      targetReviewer: '',
+    }, fetchProjects);
+
+    expect(state.setError).toHaveBeenCalledWith(null);
+    expect(fetchProjects).toHaveBeenCalledWith(expect.objectContaining({
+      provider: 'github',
+      organization: 'acme',
+    }));
   });
 
   test('openExternalLink captura error del fetcher', async () => {
@@ -182,5 +244,34 @@ describe('repositorySourceUseCases', () => {
 
     await useCase('https://example.com/pr/1');
     expect(state.setError).toHaveBeenCalledWith('cannot open');
+  });
+
+  test('openExternalLink expone fallback cuando el error no es una instancia de Error', async () => {
+    const state = createStateMock();
+    const fetcher = {
+      openReviewItem: jest.fn().mockRejectedValue('boom'),
+    };
+    const useCase = createOpenExternalLinkUseCase({
+      fetcher,
+      state,
+      configRef: {
+        current: {
+          provider: 'github',
+          organization: 'acme',
+          project: '',
+          repositoryId: '',
+          personalAccessToken: 'pat',
+          targetReviewer: '',
+        },
+      },
+    });
+
+    await useCase('https://example.com/pr/1');
+    expect(state.setError).toHaveBeenCalledWith('Unable to open pull request.');
+  });
+
+  test('diagnostics service usa fallback cuando el error no es Error', () => {
+    expect(diagnosticsService.getRepositorySourceErrorMessage('GitHub', 'boom'))
+      .toBe('Unknown GitHub error.');
   });
 });

--- a/tests/unit/renderer/use-pull-request-ai-reviews.dom.test.js
+++ b/tests/unit/renderer/use-pull-request-ai-reviews.dom.test.js
@@ -147,6 +147,28 @@ describe('usePullRequestAiReviews', () => {
     expect(payload.timeoutMs).toBe(60000);
   });
 
+  test('si no esta configurado no abre preview ni intenta correr analisis', async () => {
+    const { result } = renderHook((props) => usePullRequestAiReviews(props), {
+      initialProps: {
+        ...createOptions(),
+        codexConfig: {
+          ...createOptions().codexConfig,
+          apiKey: '   ',
+        },
+      },
+    });
+
+    await act(async () => {
+      await result.current.openPriorityQueueReview();
+      await result.current.runSelectedPullRequests();
+    });
+
+    expect(result.current.isConfigured).toBe(false);
+    expect(result.current.isModalOpen).toBe(false);
+    expect(previewPullRequestAiReviews).not.toHaveBeenCalled();
+    expect(runPullRequestAiReviews).not.toHaveBeenCalled();
+  });
+
   test('usa cache local al reejecutar el mismo subset', async () => {
     const options = createOptions();
     const { result } = renderHook((props) => usePullRequestAiReviews(props), {
@@ -175,6 +197,28 @@ describe('usePullRequestAiReviews', () => {
 
     expect(runPullRequestAiReviews).toHaveBeenCalledTimes(1);
     expect(result.current.reviews[0].status).toBe('analyzed');
+  });
+
+  test('permite abrir la revision de un PR especifico y no hace nada si no existe', async () => {
+    const options = createOptions();
+    const { result } = renderHook((props) => usePullRequestAiReviews(props), {
+      initialProps: options,
+    });
+
+    await act(async () => {
+      await result.current.openPullRequestReview(999);
+    });
+
+    expect(previewPullRequestAiReviews).not.toHaveBeenCalled();
+    expect(result.current.isModalOpen).toBe(false);
+
+    await act(async () => {
+      await result.current.openPullRequestReview(1);
+    });
+
+    expect(previewPullRequestAiReviews).toHaveBeenCalledTimes(1);
+    expect(result.current.isModalOpen).toBe(true);
+    expect(result.current.selectedPullRequests).toEqual([expect.objectContaining({ id: 1 })]);
   });
 
   test('bloquea confirmacion cuando todos los previews quedan sin cobertura', async () => {
@@ -251,5 +295,233 @@ describe('usePullRequestAiReviews', () => {
     await act(async () => {
       await pendingRun;
     });
+  });
+
+  test('cancelar sin corrida activa no dispara IPC ni cambia estado', async () => {
+    const { result } = renderHook((props) => usePullRequestAiReviews(props), {
+      initialProps: createOptions(),
+    });
+
+    await act(async () => {
+      await result.current.cancelRunningAnalysis();
+    });
+
+    expect(cancelPullRequestAiReviews).not.toHaveBeenCalled();
+    expect(result.current.isSubmitting).toBe(false);
+  });
+
+  test('expone un error de preview sin romper el modal', async () => {
+    previewPullRequestAiReviews.mockRejectedValueOnce(new Error('preview unavailable'));
+    const { result } = renderHook((props) => usePullRequestAiReviews(props), {
+      initialProps: createOptions(),
+    });
+
+    await act(async () => {
+      await result.current.openPriorityQueueReview();
+    });
+
+    expect(result.current.isModalOpen).toBe(true);
+    expect(result.current.modalError).toBe('preview unavailable');
+    expect(result.current.modalPreviews).toEqual([]);
+    expect(result.current.isPreviewing).toBe(false);
+  });
+
+  test('usa mensajes fallback cuando preview o run fallan con valores no Error', async () => {
+    previewPullRequestAiReviews.mockRejectedValueOnce('preview exploded');
+    const { result } = renderHook((props) => usePullRequestAiReviews(props), {
+      initialProps: createOptions(),
+    });
+
+    await act(async () => {
+      await result.current.openPriorityQueueReview();
+    });
+
+    expect(result.current.modalError).toBe('No fue posible preparar el snapshot local del PR.');
+
+    previewPullRequestAiReviews.mockResolvedValueOnce([
+      {
+        pullRequestId: 1,
+        repository: 'repo-a',
+        title: 'PR 1',
+        filesPrepared: 1,
+        totalFilesChanged: 1,
+        includedFiles: ['src/auth.ts'],
+        truncated: false,
+        sensitivity: {
+          findings: [],
+          hasSensitiveConfigFiles: false,
+          hasSecretPatterns: false,
+          noSensitiveConfigFilesDetected: true,
+          summary: 'Sin señales sensibles.',
+        },
+        disclaimer: 'preview',
+        lacksPatchCoverage: false,
+        strictModeWouldBlock: false,
+      },
+    ]);
+    runPullRequestAiReviews.mockRejectedValueOnce('analysis exploded');
+
+    await act(async () => {
+      await result.current.openPriorityQueueReview();
+    });
+    act(() => {
+      result.current.setSnapshotAcknowledged(true);
+    });
+    await act(async () => {
+      await result.current.runSelectedPullRequests();
+    });
+
+    expect(result.current.modalError).toBe('No fue posible ejecutar el analisis IA del PR.');
+  });
+
+  test('marca reviews con error cuando la corrida falla', async () => {
+    runPullRequestAiReviews.mockRejectedValueOnce(new Error('analysis exploded'));
+    const { result } = renderHook((props) => usePullRequestAiReviews(props), {
+      initialProps: createOptions(),
+    });
+
+    await act(async () => {
+      await result.current.openPriorityQueueReview();
+    });
+    act(() => {
+      result.current.setSnapshotAcknowledged(true);
+    });
+
+    await act(async () => {
+      await result.current.runSelectedPullRequests();
+    });
+
+    expect(result.current.modalError).toBe('analysis exploded');
+    expect(result.current.reviews[0]).toEqual(expect.objectContaining({
+      pullRequestId: 1,
+      status: 'error',
+    }));
+    expect(result.current.isSubmitting).toBe(false);
+  });
+
+  test('reporta error si cancelar la corrida falla', async () => {
+    let releaseRun;
+    runPullRequestAiReviews.mockImplementationOnce(() => new Promise((resolve) => {
+      releaseRun = () => resolve([]);
+    }));
+    cancelPullRequestAiReviews.mockRejectedValueOnce(new Error('cancel unavailable'));
+
+    const { result } = renderHook((props) => usePullRequestAiReviews(props), {
+      initialProps: createOptions(),
+    });
+
+    await act(async () => {
+      await result.current.openPriorityQueueReview();
+    });
+    act(() => {
+      result.current.setSnapshotAcknowledged(true);
+    });
+
+    let pendingRun;
+    await act(async () => {
+      pendingRun = result.current.runSelectedPullRequests();
+      await Promise.resolve();
+    });
+
+    await act(async () => {
+      await result.current.cancelRunningAnalysis();
+    });
+
+    expect(result.current.modalError).toBe('cancel unavailable');
+    expect(result.current.isSubmitting).toBe(false);
+
+    act(() => {
+      releaseRun();
+    });
+    await act(async () => {
+      await pendingRun;
+    });
+  });
+
+  test('usa mensaje fallback si cancelar falla con un valor no Error', async () => {
+    let releaseRun;
+    runPullRequestAiReviews.mockImplementationOnce(() => new Promise((resolve) => {
+      releaseRun = () => resolve([]);
+    }));
+    cancelPullRequestAiReviews.mockRejectedValueOnce('cancel exploded');
+
+    const { result } = renderHook((props) => usePullRequestAiReviews(props), {
+      initialProps: createOptions(),
+    });
+
+    await act(async () => {
+      await result.current.openPriorityQueueReview();
+    });
+    act(() => {
+      result.current.setSnapshotAcknowledged(true);
+    });
+
+    let pendingRun;
+    await act(async () => {
+      pendingRun = result.current.runSelectedPullRequests();
+      await Promise.resolve();
+    });
+
+    await act(async () => {
+      await result.current.cancelRunningAnalysis();
+    });
+
+    expect(result.current.modalError).toBe('No fue posible cancelar la revision IA.');
+
+    act(() => {
+      releaseRun();
+    });
+    await act(async () => {
+      await pendingRun;
+    });
+  });
+
+  test('closeModal limpia estado transitorio del modal', async () => {
+    const { result } = renderHook((props) => usePullRequestAiReviews(props), {
+      initialProps: createOptions(),
+    });
+
+    await act(async () => {
+      await result.current.openPriorityQueueReview();
+    });
+    act(() => {
+      result.current.setSnapshotAcknowledged(true);
+    });
+
+    act(() => {
+      result.current.closeModal();
+    });
+
+    expect(result.current.isModalOpen).toBe(false);
+    expect(result.current.modalError).toBeNull();
+    expect(result.current.modalPreviews).toEqual([]);
+    expect(result.current.selectedPullRequests).toEqual([]);
+    expect(result.current.snapshotAcknowledged).toBe(false);
+  });
+
+  test('filtra reviews cuando cambia la lista de pull requests disponible', async () => {
+    const options = createOptions();
+    const { result, rerender } = renderHook((props) => usePullRequestAiReviews(props), {
+      initialProps: options,
+    });
+
+    await act(async () => {
+      await result.current.openPriorityQueueReview();
+    });
+    act(() => {
+      result.current.setSnapshotAcknowledged(true);
+    });
+    await act(async () => {
+      await result.current.runSelectedPullRequests();
+    });
+
+    expect(result.current.reviews).toHaveLength(1);
+
+    rerender({
+      ...options,
+      pullRequests: [],
+    });
+
+    await waitFor(() => expect(result.current.reviews).toEqual([]));
   });
 });

--- a/tests/unit/renderer/use-repository-branches.dom.test.js
+++ b/tests/unit/renderer/use-repository-branches.dom.test.js
@@ -1,0 +1,173 @@
+const { renderHook, waitFor, act } = require('@testing-library/react');
+
+jest.mock('../../../src/renderer/features/repository-source', () => ({
+  fetchBranches: jest.fn(),
+}));
+
+const { fetchBranches } = require('../../../src/renderer/features/repository-source');
+const { useRepositoryBranches } = require('../../../src/renderer/features/repository-analysis/presentation/hooks/useRepositoryBranches');
+
+function createConfig(overrides = {}) {
+  return {
+    provider: 'github',
+    organization: 'acme',
+    project: 'repo-a',
+    repositoryId: 'repo-a',
+    personalAccessToken: 'pat',
+    targetReviewer: '',
+    ...overrides,
+  };
+}
+
+describe('useRepositoryBranches', () => {
+  beforeEach(() => {
+    fetchBranches.mockReset();
+    fetchBranches.mockResolvedValue([]);
+  });
+
+  test('si falta config minima limpia las ramas y no consulta', async () => {
+    const { result, rerender } = renderHook((props) => useRepositoryBranches(props), {
+      initialProps: {
+        config: createConfig({ provider: '' }),
+        isConnectionReady: false,
+        repositoryId: '',
+      },
+    });
+
+    expect(result.current.branches).toEqual([]);
+    expect(result.current.branchName).toBe('');
+    expect(fetchBranches).not.toHaveBeenCalled();
+
+    fetchBranches.mockResolvedValue([]);
+    rerender({
+      config: createConfig(),
+      isConnectionReady: true,
+      repositoryId: 'repo-a',
+    });
+
+    await waitFor(() => expect(fetchBranches).toHaveBeenCalled());
+  });
+
+  test('carga ramas y selecciona la default cuando existe', async () => {
+    const config = createConfig();
+    fetchBranches.mockResolvedValue([
+      { name: 'develop', objectId: '1', isDefault: false },
+      { name: 'main', objectId: '2', isDefault: true },
+    ]);
+
+    const { result } = renderHook(() => useRepositoryBranches({
+      config,
+      isConnectionReady: true,
+      repositoryId: 'repo-a',
+    }));
+
+    expect(result.current.isLoadingBranches).toBe(true);
+    await waitFor(() => expect(result.current.branchName).toBe('main'));
+
+    expect(fetchBranches).toHaveBeenCalledWith(expect.objectContaining({
+      repositoryId: 'repo-a',
+      project: 'repo-a',
+    }));
+    expect(result.current.branches).toHaveLength(2);
+    expect(result.current.branchName).toBe('main');
+    expect(result.current.branchError).toBeNull();
+  });
+
+  test('si no hay default selecciona la primera rama disponible', async () => {
+    const config = createConfig();
+    fetchBranches.mockResolvedValue([
+      { name: 'release', objectId: '1', isDefault: false },
+      { name: 'develop', objectId: '2', isDefault: false },
+    ]);
+
+    const { result } = renderHook(() => useRepositoryBranches({
+      config,
+      isConnectionReady: true,
+      repositoryId: 'repo-a',
+    }));
+
+    await waitFor(() => expect(result.current.branchName).toBe('release'));
+
+    expect(result.current.branchName).toBe('release');
+  });
+
+  test('si no hay ramas disponibles deja el branchName vacio', async () => {
+    const config = createConfig();
+    fetchBranches.mockResolvedValue([]);
+
+    const { result } = renderHook(() => useRepositoryBranches({
+      config,
+      isConnectionReady: true,
+      repositoryId: 'repo-a',
+    }));
+
+    await waitFor(() => expect(result.current.isLoadingBranches).toBe(false));
+    expect(result.current.branches).toEqual([]);
+    expect(result.current.branchName).toBe('');
+  });
+
+  test('si fetchBranches falla, limpia el estado y expone el error', async () => {
+    const config = createConfig();
+    let rejectRequest;
+    fetchBranches.mockImplementation(() => new Promise((_, reject) => {
+      rejectRequest = reject;
+    }));
+
+    const { result } = renderHook(() => useRepositoryBranches({
+      config,
+      isConnectionReady: true,
+      repositoryId: 'repo-a',
+    }));
+
+    await waitFor(() => expect(fetchBranches).toHaveBeenCalled());
+
+    await act(async () => {
+      rejectRequest(new Error('provider unavailable'));
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    await waitFor(() => expect(result.current.branchError).toBe('provider unavailable'));
+    expect(result.current.branches).toEqual([]);
+    expect(result.current.branchName).toBe('');
+    expect(result.current.isLoadingBranches).toBe(false);
+  });
+
+  test('si fetchBranches falla con un valor no tipado usa el mensaje fallback', async () => {
+    const config = createConfig();
+    fetchBranches.mockRejectedValue('boom');
+
+    const { result } = renderHook(() => useRepositoryBranches({
+      config,
+      isConnectionReady: true,
+      repositoryId: 'repo-a',
+    }));
+
+    await waitFor(() => expect(result.current.branchError).toBe('No fue posible cargar las ramas.'));
+    expect(result.current.isLoadingBranches).toBe(false);
+  });
+
+  test('ignora respuestas tardias cuando el hook se desmonta', async () => {
+    const config = createConfig();
+    let resolveRequest;
+    fetchBranches.mockImplementation(() => new Promise((resolve) => {
+      resolveRequest = resolve;
+    }));
+
+    const { result, unmount } = renderHook(() => useRepositoryBranches({
+      config,
+      isConnectionReady: true,
+      repositoryId: 'repo-a',
+    }));
+
+    expect(result.current.isLoadingBranches).toBe(true);
+    unmount();
+
+    await act(async () => {
+      resolveRequest([{ name: 'main', objectId: '1', isDefault: true }]);
+      await Promise.resolve();
+    });
+
+    expect(fetchBranches).toHaveBeenCalled();
+  });
+});

--- a/tests/unit/services/azure-api.test.js
+++ b/tests/unit/services/azure-api.test.js
@@ -1,0 +1,76 @@
+const azureApi = require('../../../src/services/azure/azure.api');
+
+describe('azure api helpers', () => {
+  const originalFetch = global.fetch;
+
+  afterEach(() => {
+    global.fetch = originalFetch;
+    jest.clearAllMocks();
+  });
+
+  test('normalizeOrganization y normalizeProject soportan URLs y hosts legacy', () => {
+    expect(azureApi.normalizeOrganization('https://dev.azure.com/acme/platform/')).toBe('acme');
+    expect(azureApi.normalizeOrganization('acme.visualstudio.com')).toBe('acme');
+    expect(azureApi.normalizeProject('https://dev.azure.com/acme/platform/_git/repo-a')).toBe('platform');
+    expect(azureApi.normalizeProject('/platform/')).toBe('platform');
+    expect(azureApi.normalizeOrganization('https://%zz')).toBe('https://%zz');
+    expect(azureApi.normalizeProject('https://%zz')).toBe('https://%zz');
+    expect(azureApi.normalizeOrganization('https://dev.azure.com')).toBe('https://dev.azure.com');
+    expect(azureApi.normalizeProject('https://dev.azure.com/acme')).toBe('acme');
+    expect(azureApi.normalizeProject('https://dev.azure.com')).toBe('https://dev.azure.com');
+  });
+
+  test('getAzureConfig trimmea y normaliza el contexto', () => {
+    expect(azureApi.getAzureConfig({
+      organization: ' https://dev.azure.com/acme/ ',
+      project: ' /platform/ ',
+      personalAccessToken: ' pat ',
+    })).toEqual({
+      organization: 'acme',
+      project: 'platform',
+      personalAccessToken: 'pat',
+    });
+  });
+
+  test('getAzureContinuationToken lee el header cuando existe', () => {
+    expect(azureApi.getAzureContinuationToken(new Headers({
+      'x-ms-continuationtoken': 'next-page',
+    }))).toBe('next-page');
+
+    expect(azureApi.getAzureContinuationToken(new Headers())).toBeNull();
+  });
+
+  test('requestAzureJsonResponse devuelve data y headers', async () => {
+    global.fetch = jest.fn().mockResolvedValue(new Response(JSON.stringify({ value: [] }), {
+      status: 200,
+      headers: {
+        'content-type': 'application/json',
+        'x-ms-continuationtoken': 'page-2',
+      },
+    }));
+
+    const result = await azureApi.requestAzureJsonResponse('https://dev.azure.com/acme/_apis/projects', 'pat', 'projects request');
+
+    expect(result.data).toEqual({ value: [] });
+    expect(result.headers.get('x-ms-continuationtoken')).toBe('page-2');
+  });
+
+  test('requestAzureText reporta errores 401 y genericos', async () => {
+    global.fetch = jest.fn()
+      .mockResolvedValueOnce(new Response('Unauthorized', {
+        status: 401,
+        headers: { 'content-type': 'text/plain' },
+      }))
+      .mockResolvedValueOnce(new Response('', {
+        status: 500,
+        statusText: 'Server Error',
+        headers: { 'content-type': 'text/plain' },
+      }));
+
+    await expect(azureApi.requestAzureText('https://dev.azure.com/acme/file', 'pat', 'item content request'))
+      .rejects.toThrow('failed (401): unauthorized');
+
+    await expect(azureApi.requestAzureText('https://dev.azure.com/acme/file', 'pat', 'item content request'))
+      .rejects.toThrow('failed (500): Server Error');
+  });
+});

--- a/tests/unit/services/azure-context.test.js
+++ b/tests/unit/services/azure-context.test.js
@@ -1,0 +1,48 @@
+jest.mock('../../../src/services/azure/azure.api', () => ({
+  getAzureConfig: jest.fn((config) => config),
+}));
+
+const { getRequiredAzureProjectContext, getRequiredAzureRepositoryContext } = require('../../../src/services/azure/azure.context');
+
+describe('azure context helpers', () => {
+  test('getRequiredAzureProjectContext devuelve el contexto cuando la config es valida', () => {
+    expect(getRequiredAzureProjectContext({
+      organization: 'org',
+      project: 'proj',
+      personalAccessToken: 'pat',
+    })).toEqual({
+      organization: 'org',
+      project: 'proj',
+      personalAccessToken: 'pat',
+    });
+  });
+
+  test('getRequiredAzureProjectContext rechaza config incompleta', () => {
+    expect(() => getRequiredAzureProjectContext({
+      organization: 'org',
+      project: '',
+      personalAccessToken: 'pat',
+    })).toThrow('Organization, project, and personal access token are required.');
+  });
+
+  test('getRequiredAzureRepositoryContext exige repositoryId', () => {
+    expect(getRequiredAzureRepositoryContext({
+      organization: 'org',
+      project: 'proj',
+      repositoryId: 'repo-a',
+      personalAccessToken: 'pat',
+    })).toEqual({
+      organization: 'org',
+      project: 'proj',
+      repositoryId: 'repo-a',
+      personalAccessToken: 'pat',
+    });
+
+    expect(() => getRequiredAzureRepositoryContext({
+      organization: 'org',
+      project: 'proj',
+      repositoryId: '   ',
+      personalAccessToken: 'pat',
+    })).toThrow('Organization, project, repository, and personal access token are required.');
+  });
+});

--- a/tests/unit/services/azure-modules.test.js
+++ b/tests/unit/services/azure-modules.test.js
@@ -29,6 +29,29 @@ describe('azure modules', () => {
     expect(azureApi.requestAzureJsonResponse).toHaveBeenCalledTimes(2);
   });
 
+  test('getAzureProjects rechaza config incompleta y getAzureRepositories pagina con continuation token', async () => {
+    await expect(getAzureProjects({ organization: '', personalAccessToken: 'pat' }))
+      .rejects.toThrow('Organization and personal access token are required.');
+
+    azureApi.requestAzureJsonResponse
+      .mockResolvedValueOnce({
+        data: { value: [{ id: 'repo-a', name: 'Repo A', webUrl: 'https://dev.azure.com/org/proj/_git/repo-a', defaultBranch: 'refs/heads/main' }] },
+        headers: new Headers({ 'x-ms-continuationtoken': 'next' }),
+      })
+      .mockResolvedValueOnce({
+        data: { value: [{ id: 'repo-b', name: 'Repo B', webUrl: 'https://dev.azure.com/org/proj/_git/repo-b', defaultBranch: 'refs/heads/master' }] },
+        headers: new Headers(),
+      });
+    azureApi.getAzureContinuationToken
+      .mockReturnValueOnce('next')
+      .mockReturnValueOnce(null);
+
+    const repositories = await getAzureRepositories({ organization: 'org', project: 'proj', personalAccessToken: 'pat' });
+
+    expect(repositories).toHaveLength(2);
+    expect(azureApi.requestAzureJsonResponse.mock.calls[1][0]).toContain('continuationToken=next');
+  });
+
   test('getAzureRepositories y branches mapean payloads', async () => {
     azureApi.requestAzureJsonResponse.mockResolvedValue({
       data: {
@@ -46,6 +69,21 @@ describe('azure modules', () => {
 
     expect(repositories[0].name).toBe('Repo');
     expect(branches[0]).toEqual({ name: 'main', objectId: '1', isDefault: true });
+  });
+
+  test('getAzureBranches marca ramas no default correctamente', async () => {
+    azureApi.requestAzureJson.mockResolvedValue({
+      value: [{ name: 'refs/heads/feature/x', objectId: '2' }],
+    });
+
+    const branches = await getAzureBranches({
+      organization: 'org',
+      project: 'proj',
+      repositoryId: 'repo',
+      personalAccessToken: 'pat',
+    });
+
+    expect(branches[0]).toEqual({ name: 'feature/x', objectId: '2', isDefault: false });
   });
 
   test('getAzurePullRequests pagina con skip y normaliza ramas', async () => {
@@ -71,5 +109,49 @@ describe('azure modules', () => {
     expect(prs).toHaveLength(100);
     expect(prs[0].sourceBranch).toBe('feature/x');
     expect(azureApi.requestAzureJson).toHaveBeenCalledTimes(2);
+  });
+
+  test('getAzurePullRequests agrega repositoryId al query y aplica fallbacks de payload', async () => {
+    azureApi.requestAzureJson.mockResolvedValue({
+      value: [{
+        pullRequestId: 7,
+        title: 'PR 7',
+        description: '',
+        status: 'active',
+        creationDate: '2026-03-11T10:00:00.000Z',
+        sourceRefName: 'refs/heads/feature/y',
+        targetRefName: 'refs/heads/main',
+        repository: {},
+        createdBy: {},
+        reviewers: [],
+      }],
+    });
+
+    const prs = await getAzurePullRequests({
+      organization: 'org',
+      project: 'proj',
+      repositoryId: ' repo-a ',
+      personalAccessToken: 'pat',
+    });
+
+    expect(azureApi.requestAzureJson.mock.calls[0][0]).toContain('searchCriteria.repositoryId=repo-a');
+    expect(prs[0]).toEqual(expect.objectContaining({
+      repository: 'Unknown repository',
+      url: undefined,
+      mergeStatus: 'unknown',
+      description: 'No description provided.',
+      createdBy: expect.objectContaining({
+        displayName: 'Unknown author',
+      }),
+    }));
+  });
+
+  test('modulos de Azure rechazan configuracion incompleta', async () => {
+    await expect(getAzureRepositories({ organization: '', project: 'proj', personalAccessToken: 'pat' }))
+      .rejects.toThrow('Organization, project, and personal access token are required.');
+    await expect(getAzureBranches({ organization: 'org', project: 'proj', repositoryId: '', personalAccessToken: 'pat' }))
+      .rejects.toThrow('Organization, project, repository, and personal access token are required.');
+    await expect(getAzurePullRequests({ organization: 'org', project: '', personalAccessToken: 'pat' }))
+      .rejects.toThrow('Organization, project, and personal access token are required.');
   });
 });

--- a/tests/unit/services/github-api.test.js
+++ b/tests/unit/services/github-api.test.js
@@ -1,0 +1,75 @@
+const githubApi = require('../../../src/services/github/github.api');
+
+describe('github api helpers', () => {
+  const originalFetch = global.fetch;
+
+  afterEach(() => {
+    global.fetch = originalFetch;
+    jest.clearAllMocks();
+  });
+
+  test('getGitHubConfig normaliza owner, token y repositorio', () => {
+    expect(githubApi.getGitHubConfig({
+      organization: 'https://github.com/IanStuardo-Dev/',
+      project: '/electron-checkPR/',
+      repositoryId: '',
+      personalAccessToken: ' token ',
+    })).toEqual({
+      organization: 'IanStuardo-Dev',
+      personalAccessToken: 'token',
+      repository: 'electron-checkPR',
+    });
+  });
+
+  test('getGitHubNextPage devuelve la siguiente pagina cuando existe link header', () => {
+    expect(githubApi.getGitHubNextPage(new Headers({
+      link: '<https://api.github.com/page/2>; rel="next", <https://api.github.com/page/4>; rel="last"',
+    }))).toBe('https://api.github.com/page/2');
+
+    expect(githubApi.getGitHubNextPage(new Headers())).toBeNull();
+  });
+
+  test('readGitHubResponse propaga el hint de forbidden', async () => {
+    await expect(githubApi.readGitHubResponse(new Response('Forbidden', {
+      status: 403,
+      headers: { 'content-type': 'text/plain' },
+    }), 'projects request')).rejects.toThrow('Revisa scopes del token.');
+  });
+
+  test('requestGitHubPaginated recorre paginas y requestGitHubContent usa headers correctos', async () => {
+    global.fetch = jest.fn()
+      .mockResolvedValueOnce(new Response(JSON.stringify([{ id: 1 }]), {
+        status: 200,
+        headers: {
+          'content-type': 'application/json',
+          link: '<https://api.github.com/page/2>; rel="next"',
+        },
+      }))
+      .mockResolvedValueOnce(new Response(JSON.stringify([{ id: 2 }]), {
+        status: 200,
+        headers: { 'content-type': 'application/json' },
+      }))
+      .mockResolvedValueOnce(new Response(JSON.stringify({
+        type: 'file',
+        path: 'src/app.ts',
+        size: 20,
+        content: 'export const ok = true;',
+        encoding: 'utf8',
+      }), {
+        status: 200,
+        headers: { 'content-type': 'application/json' },
+      }));
+
+    const items = await githubApi.requestGitHubPaginated('https://api.github.com/page/1', 'pat', 'projects request');
+    const content = await githubApi.requestGitHubContent('https://api.github.com/repos/acme/repo/contents/src/app.ts', 'pat', 'content request');
+
+    expect(items).toEqual([{ id: 1 }, { id: 2 }]);
+    expect(content).toEqual(expect.objectContaining({ type: 'file', path: 'src/app.ts' }));
+    expect(global.fetch).toHaveBeenNthCalledWith(1, 'https://api.github.com/page/1', expect.objectContaining({
+      headers: expect.objectContaining({
+        Authorization: 'Bearer pat',
+        'X-GitHub-Api-Version': '2022-11-28',
+      }),
+    }));
+  });
+});

--- a/tests/unit/services/github-pull-requests.test.js
+++ b/tests/unit/services/github-pull-requests.test.js
@@ -1,0 +1,124 @@
+jest.mock('../../../src/services/github/github.api', () => ({
+  getGitHubConfig: jest.fn((config) => ({
+    organization: config.organization,
+    personalAccessToken: config.personalAccessToken,
+    repository: config.repositoryId || config.project || '',
+  })),
+  requestGitHubJson: jest.fn(),
+  requestGitHubPaginated: jest.fn(),
+}));
+
+jest.mock('../../../src/services/github/github.repositories', () => ({
+  getGitHubRepositories: jest.fn(),
+}));
+
+const githubApi = require('../../../src/services/github/github.api');
+const { getGitHubRepositories } = require('../../../src/services/github/github.repositories');
+const { getGitHubPullRequests } = require('../../../src/services/github/github.pull-requests');
+
+describe('github pull requests module', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  test('usa repositorio directo cuando viene configurado y consolida reviewers sin duplicados', async () => {
+    githubApi.requestGitHubPaginated.mockResolvedValue([
+      {
+        number: 10,
+        title: 'Improve auth',
+        body: '',
+        state: 'open',
+        created_at: '2026-03-11T10:00:00.000Z',
+        html_url: 'https://github.com/acme/repo-a/pull/10',
+        draft: false,
+        user: {},
+        requested_reviewers: [{ login: 'ana' }],
+        assignees: [{ login: 'ana' }, { login: 'luis' }],
+        head: { ref: 'feature/auth' },
+        base: { ref: 'main' },
+      },
+    ]);
+    githubApi.requestGitHubJson.mockResolvedValue([
+      { user: { login: 'ana' }, state: 'CHANGES_REQUESTED' },
+      { user: { login: 'reviewer-2' }, state: 'COMMENTED' },
+    ]);
+
+    const pullRequests = await getGitHubPullRequests({
+      organization: 'acme',
+      repositoryId: 'repo-a',
+      personalAccessToken: 'pat',
+    });
+
+    expect(getGitHubRepositories).not.toHaveBeenCalled();
+    expect(pullRequests).toEqual([
+      expect.objectContaining({
+        id: 10,
+        description: 'No description provided.',
+        createdBy: expect.objectContaining({
+          displayName: 'Unknown author',
+        }),
+        reviewers: [
+          { displayName: 'ana', uniqueName: 'ana', vote: -10, isRequired: true },
+          { displayName: 'reviewer-2', uniqueName: 'reviewer-2', vote: 0, isRequired: false },
+          { displayName: 'luis', uniqueName: 'luis', vote: 0, isRequired: false },
+        ],
+      }),
+    ]);
+  });
+
+  test('si no hay repository configurado obtiene repositorios y ordena por fecha', async () => {
+    getGitHubRepositories.mockResolvedValue([
+      { id: 'repo-a', name: 'repo-a' },
+      { id: 'repo-b', name: 'repo-b' },
+    ]);
+    githubApi.requestGitHubPaginated
+      .mockResolvedValueOnce([
+        {
+          number: 1,
+          title: 'Older PR',
+          body: 'body',
+          state: 'open',
+          created_at: '2026-03-10T10:00:00.000Z',
+          html_url: 'https://github.com/acme/repo-a/pull/1',
+          draft: false,
+          user: { login: 'ian' },
+          requested_reviewers: [],
+          assignees: [],
+          head: { ref: 'feature/a' },
+          base: { ref: 'main' },
+        },
+      ])
+      .mockResolvedValueOnce([
+        {
+          number: 2,
+          title: 'Newest PR',
+          body: 'body',
+          state: 'open',
+          created_at: '2026-03-12T10:00:00.000Z',
+          html_url: 'https://github.com/acme/repo-b/pull/2',
+          draft: false,
+          user: { login: 'ian' },
+          requested_reviewers: [],
+          assignees: [],
+          head: { ref: 'feature/b' },
+          base: { ref: 'main' },
+        },
+      ]);
+    githubApi.requestGitHubJson.mockResolvedValue([]);
+
+    const pullRequests = await getGitHubPullRequests({
+      organization: 'acme',
+      personalAccessToken: 'pat',
+    });
+
+    expect(getGitHubRepositories).toHaveBeenCalled();
+    expect(pullRequests.map((item) => item.id)).toEqual([2, 1]);
+  });
+
+  test('rechaza configuracion incompleta', async () => {
+    await expect(getGitHubPullRequests({
+      organization: '',
+      personalAccessToken: 'pat',
+    })).rejects.toThrow('Owner/organization y token son obligatorios para GitHub.');
+  });
+});

--- a/tests/unit/services/gitlab-modules.test.js
+++ b/tests/unit/services/gitlab-modules.test.js
@@ -75,4 +75,57 @@ describe('gitlab modules', () => {
       expect.objectContaining({ uniqueName: 'luis', vote: 0 }),
     ]));
   });
+
+  test('getGitLabPullRequests soporta fallback a getGitLabProjects y normaliza author/draft', async () => {
+    gitlabApi.requestGitLabPaginated
+      .mockResolvedValueOnce([
+        { path_with_namespace: 'acme/repo-a', name: 'Repo A', web_url: 'https://gitlab.com/acme/repo-a' },
+      ])
+      .mockResolvedValueOnce([
+        {
+          iid: 11,
+          title: 'MR fallback',
+          description: '',
+          state: 'opened',
+          created_at: '2026-03-11T10:00:00.000Z',
+          source_branch: 'feature/y',
+          target_branch: 'main',
+          web_url: 'https://gitlab.com/acme/repo-a/-/merge_requests/11',
+          draft: false,
+          work_in_progress: true,
+          detailed_merge_status: '',
+          author: {},
+          reviewers: [],
+          assignees: [],
+        },
+      ]);
+    gitlabApi.requestGitLabJson.mockResolvedValue({
+      approved_by: [{ user: null }],
+    });
+
+    const prs = await getGitLabPullRequests({
+      organization: 'acme',
+      personalAccessToken: 'pat',
+      project: '',
+    });
+
+    expect(prs).toHaveLength(1);
+    expect(prs[0]).toEqual(expect.objectContaining({
+      repository: 'Repo A',
+      isDraft: true,
+      mergeStatus: 'unknown',
+      createdBy: expect.objectContaining({
+        displayName: 'Unknown author',
+      }),
+    }));
+  });
+
+  test('gitlab modules rechazan configuracion incompleta', async () => {
+    await expect(getGitLabRepositories({ organization: '', personalAccessToken: 'pat' }))
+      .rejects.toThrow('Namespace/group y token son obligatorios para GitLab.');
+    await expect(getGitLabBranches({ project: '', personalAccessToken: 'pat' }))
+      .rejects.toThrow('Proyecto y token son obligatorios para GitLab.');
+    await expect(getGitLabPullRequests({ organization: '', personalAccessToken: 'pat' }))
+      .rejects.toThrow('Namespace/group y token son obligatorios para GitLab.');
+  });
 });

--- a/tests/unit/services/http-response.test.js
+++ b/tests/unit/services/http-response.test.js
@@ -1,0 +1,104 @@
+const { readJsonResponse } = require('../../../src/shared/http-response');
+
+describe('readJsonResponse', () => {
+  test('parsea JSON valido cuando la respuesta es correcta', async () => {
+    await expect(readJsonResponse(new Response(JSON.stringify({ ok: true }), {
+      status: 200,
+      headers: { 'content-type': 'application/json' },
+    }), {
+      providerLabel: 'GitHub',
+      context: 'projects request',
+    })).resolves.toEqual({ ok: true });
+  });
+
+  test('incluye unauthorizedHint en errores 401', async () => {
+    await expect(readJsonResponse(new Response('Unauthorized', {
+      status: 401,
+      headers: { 'content-type': 'text/plain' },
+    }), {
+      providerLabel: 'GitHub',
+      context: 'projects request',
+      unauthorizedHint: 'Revisa el token.',
+    })).rejects.toThrow('unauthorized. Revisa el token.');
+  });
+
+  test('maneja errores 401/403 sin hint y contenido desconocido sin body', async () => {
+    await expect(readJsonResponse(new Response('', {
+      status: 401,
+      statusText: 'Unauthorized',
+    }), {
+      providerLabel: 'GitHub',
+      context: 'projects request',
+    })).rejects.toThrow('unauthorized. Response: Unauthorized');
+
+    await expect(readJsonResponse(new Response('', {
+      status: 403,
+      statusText: 'Forbidden',
+    }), {
+      providerLabel: 'GitLab',
+      context: 'projects request',
+    })).rejects.toThrow('forbidden. Response: Forbidden');
+
+    const unknownContentResponse = {
+      ok: true,
+      status: 200,
+      statusText: 'OK',
+      headers: { get: () => null },
+      text: async () => '',
+    };
+
+    await expect(readJsonResponse(unknownContentResponse, {
+      providerLabel: 'Azure DevOps',
+      context: 'projects request',
+    })).rejects.toThrow('unexpected content (unknown). Response: empty body');
+  });
+
+  test('incluye forbiddenHint en errores 403', async () => {
+    await expect(readJsonResponse(new Response('Forbidden', {
+      status: 403,
+      headers: { 'content-type': 'text/plain' },
+    }), {
+      providerLabel: 'GitLab',
+      context: 'projects request',
+      forbiddenHint: 'Revisa scopes del token.',
+    })).rejects.toThrow('forbidden. Revisa scopes del token.');
+  });
+
+  test('rechaza contenido inesperado y JSON invalido', async () => {
+    await expect(readJsonResponse(new Response('<html></html>', {
+      status: 200,
+      headers: { 'content-type': 'text/html' },
+    }), {
+      providerLabel: 'Azure DevOps',
+      context: 'projects request',
+    })).rejects.toThrow('unexpected content');
+
+    await expect(readJsonResponse(new Response('{invalid', {
+      status: 200,
+      headers: { 'content-type': 'application/json' },
+    }), {
+      providerLabel: 'Azure DevOps',
+      context: 'projects request',
+      invalidJsonHint: 'Revisa organization/project.',
+    })).rejects.toThrow('returned invalid JSON. Revisa organization/project.');
+
+    await expect(readJsonResponse(new Response('{invalid', {
+      status: 200,
+      headers: { 'content-type': 'application/json' },
+    }), {
+      providerLabel: 'GitHub',
+      context: 'projects request',
+    })).rejects.toThrow('GitHub projects request returned invalid JSON.');
+  });
+
+  test('usa el statusText en errores genericos cuando el body viene vacio', async () => {
+    await expect(readJsonResponse(new Response('', {
+      status: 500,
+      statusText: 'Server Error',
+      headers: { 'content-type': 'application/json' },
+    }), {
+      providerLabel: 'GitHub',
+      context: 'projects request',
+    })).rejects.toThrow('failed (500): Server Error');
+  });
+});

--- a/tests/unit/services/provider-pr-snapshots.test.js
+++ b/tests/unit/services/provider-pr-snapshots.test.js
@@ -86,6 +86,37 @@ describe('provider PR snapshots', () => {
     expect(snapshot.partialReason).toMatch(/Azure DevOps no entrego patch textual/i);
   });
 
+  test('azure snapshot falla si no puede resolver la iteracion activa', async () => {
+    requestAzureJson.mockResolvedValueOnce({ value: [] });
+
+    await expect(getAzurePullRequestSnapshot(
+      { organization: 'acme', project: 'repo-a', personalAccessToken: 'pat' },
+      basePullRequest,
+      { excludedPathPatterns: '' },
+    )).rejects.toThrow('No fue posible resolver la iteracion activa');
+  });
+
+  test('azure snapshot usa repository del PR y status modified por defecto', async () => {
+    requestAzureJson
+      .mockResolvedValueOnce({ value: [{ id: 3 }] })
+      .mockResolvedValueOnce({
+        changeEntries: [
+          { item: { path: '/src/auth.ts' } },
+        ],
+      });
+
+    const snapshot = await getAzurePullRequestSnapshot(
+      { organization: 'acme', project: 'repo-a', personalAccessToken: 'pat', repositoryId: '   ' },
+      basePullRequest,
+      { excludedPathPatterns: '' },
+    );
+
+    expect(requestAzureJson.mock.calls[0][0]).toContain('/repositories/repo-a/pullRequests/7/iterations');
+    expect(snapshot.files).toEqual([
+      expect.objectContaining({ path: 'src/auth.ts', status: 'modified' }),
+    ]);
+  });
+
   test('gitlab snapshot marca diffs ausentes y respeta exclusiones', async () => {
     requestGitLabJson.mockResolvedValue({
       changes: [
@@ -104,5 +135,27 @@ describe('provider PR snapshots', () => {
     expect(snapshot.files[0].path).toBe('src/auth.ts');
     expect(snapshot.partialReason).toMatch(/Se excluyeron 1 archivos/i);
     expect(snapshot.partialReason).toMatch(/no incluyen diff textual/i);
+  });
+
+  test('gitlab snapshot normaliza estados added, removed y renamed', async () => {
+    requestGitLabJson.mockResolvedValue({
+      changes: [
+        { new_path: 'src/new.ts', old_path: 'src/new.ts', diff: '+const ok = true;', new_file: true, deleted_file: false, renamed_file: false },
+        { new_path: 'src/removed.ts', old_path: 'src/removed.ts', diff: '-const old = true;', new_file: false, deleted_file: true, renamed_file: false },
+        { new_path: 'src/renamed.ts', old_path: 'src/legacy.ts', diff: '@@', new_file: false, deleted_file: false, renamed_file: true },
+      ],
+    });
+
+    const snapshot = await getGitLabPullRequestSnapshot(
+      { project: 'group/repo-a', personalAccessToken: 'pat' },
+      basePullRequest,
+      { excludedPathPatterns: '' },
+    );
+
+    expect(snapshot.files).toEqual([
+      expect.objectContaining({ path: 'src/new.ts', status: 'added' }),
+      expect.objectContaining({ path: 'src/removed.ts', status: 'removed' }),
+      expect.objectContaining({ path: 'src/renamed.ts', status: 'renamed' }),
+    ]);
   });
 });

--- a/tests/unit/services/pull-request-analysis.parts.test.js
+++ b/tests/unit/services/pull-request-analysis.parts.test.js
@@ -54,10 +54,48 @@ describe('pull request analysis parts', () => {
     }))).toMatchObject({ riskScore: 55, shortSummary: 'Desde output_text' });
   });
 
+  test('response parser acepta payload estructurado dentro de output content', () => {
+    const parser = new PullRequestAnalysisResponseParser();
+
+    expect(parser.parse(JSON.stringify({
+      output: [
+        {
+          content: [
+            { text: 'not-json' },
+            {
+              text: JSON.stringify({
+                riskScore: 42,
+                shortSummary: 'Desde content',
+                topConcerns: ['auth'],
+                reviewChecklist: ['tests'],
+              }),
+            },
+          ],
+        },
+      ],
+    }))).toMatchObject({
+      riskScore: 42,
+      shortSummary: 'Desde content',
+      topConcerns: ['auth'],
+      reviewChecklist: ['tests'],
+    });
+  });
+
   test('response parser falla con payload invalido', () => {
     const parser = new PullRequestAnalysisResponseParser();
     expect(() => parser.parse('not-json')).toThrow(/respuesta invalida/i);
     expect(() => parser.parse(JSON.stringify({ foo: 'bar' }))).toThrow(/no devolvio salida estructurada/i);
+    expect(() => parser.parse(JSON.stringify({
+      output_text: '{"riskScore":"bad"}',
+      output: [
+        {
+          content: [
+            { text: '' },
+            { text: '{"riskScore":12}' },
+          ],
+        },
+      ],
+    }))).toThrow(/no devolvio salida estructurada/i);
   });
 
   test('openai client reintenta 429 y envia schema json', async () => {
@@ -94,6 +132,77 @@ describe('pull request analysis parts', () => {
     expect(lastCall[1].headers.Authorization).toBe('Bearer sk-test');
     expect(JSON.parse(lastCall[1].body).text.format.name).toBe('pull_request_analysis');
 
+    global.fetch = originalFetch;
+  });
+
+  test('openai client no reintenta si el signal ya fue abortado', async () => {
+    const originalFetch = global.fetch;
+    const controller = new AbortController();
+    controller.abort();
+    global.fetch = jest.fn().mockRejectedValue(new Error('Codex PR analysis failed (500): aborted upstream'));
+
+    const client = new OpenAIPullRequestAnalysisClient();
+
+    await expect(client.analyze({
+      request: {
+        apiKey: 'sk-test',
+        model: 'gpt-5.2-codex',
+      },
+      prompt: {
+        systemPrompt: 'system',
+        userPrompt: 'user',
+      },
+      signal: controller.signal,
+    })).rejects.toThrow('Codex PR analysis failed (500): aborted upstream');
+
+    expect(global.fetch).toHaveBeenCalledTimes(1);
+    global.fetch = originalFetch;
+  });
+
+  test('openai client no reintenta errores que no son instancias de Error', async () => {
+    const originalFetch = global.fetch;
+    global.fetch = jest.fn().mockRejectedValue('boom');
+    const client = new OpenAIPullRequestAnalysisClient();
+
+    await expect(client.analyze({
+      request: {
+        apiKey: 'sk-test',
+        model: 'gpt-5.2-codex',
+      },
+      prompt: {
+        systemPrompt: 'system',
+        userPrompt: 'user',
+      },
+      signal: new AbortController().signal,
+    })).rejects.toBe('boom');
+
+    expect(global.fetch).toHaveBeenCalledTimes(1);
+    global.fetch = originalFetch;
+  });
+
+  test('openai client usa statusText cuando la respuesta de error llega vacia', async () => {
+    const originalFetch = global.fetch;
+    global.fetch = jest.fn().mockResolvedValue({
+      ok: false,
+      status: 400,
+      text: async () => '',
+      statusText: 'Bad Request',
+    });
+    const client = new OpenAIPullRequestAnalysisClient();
+
+    await expect(client.analyze({
+      request: {
+        apiKey: 'sk-test',
+        model: 'gpt-5.2-codex',
+      },
+      prompt: {
+        systemPrompt: 'system',
+        userPrompt: 'user',
+      },
+      signal: new AbortController().signal,
+    })).rejects.toThrow('Codex PR analysis failed (400): Bad Request');
+
+    expect(global.fetch).toHaveBeenCalledTimes(1);
     global.fetch = originalFetch;
   });
 

--- a/tests/unit/services/pull-request-analysis.service.test.js
+++ b/tests/unit/services/pull-request-analysis.service.test.js
@@ -45,6 +45,73 @@ function createRequest(overrides = {}) {
 }
 
 describe('PullRequestAnalysisService', () => {
+  test('previewBatch construye previews respetando strictMode', async () => {
+    const snapshotProvider = {
+      getSnapshot: jest.fn().mockResolvedValue({
+        provider: 'github',
+        repository: 'repo-a',
+        pullRequestId: 88,
+        title: 'Actualizar auth',
+        description: 'Ajustes de seguridad',
+        author: 'Ian',
+        sourceBranch: 'feature/auth',
+        targetBranch: 'main',
+        reviewers: [],
+        files: [
+          { path: '.env', status: 'modified', patch: '+ SECRET=1' },
+          { path: 'src/auth.ts', status: 'modified', patch: '+ const enabled = true;' },
+        ],
+        totalFilesChanged: 2,
+        truncated: false,
+      }),
+    };
+    const service = new PullRequestAnalysisService({
+      snapshotProvider,
+      promptBuilder: { build: jest.fn() },
+      analysisClient: { analyze: jest.fn() },
+      responseParser: { parse: jest.fn() },
+    });
+
+    const previews = await service.previewBatch(createRequest({
+      snapshotPolicy: {
+        excludedPathPatterns: '',
+        strictMode: true,
+      },
+    }));
+
+    expect(previews).toHaveLength(1);
+    expect(previews[0]).toEqual(expect.objectContaining({
+      repository: 'repo-a',
+      pullRequestId: 88,
+      strictModeWouldBlock: true,
+    }));
+  });
+
+  test('cuando falta apiKey devuelve reviews not-configured sin consultar snapshots', async () => {
+    const snapshotProvider = {
+      getSnapshot: jest.fn(),
+    };
+    const service = new PullRequestAnalysisService({
+      snapshotProvider,
+      promptBuilder: { build: jest.fn() },
+      analysisClient: { analyze: jest.fn() },
+      responseParser: { parse: jest.fn() },
+    });
+
+    const result = await service.analyzeBatch(createRequest({
+      apiKey: '   ',
+    }));
+
+    expect(result).toEqual([
+      expect.objectContaining({
+        pullRequestId: 88,
+        status: 'not-configured',
+        coverageNote: 'Codex no configurado para PR AI review.',
+      }),
+    ]);
+    expect(snapshotProvider.getSnapshot).not.toHaveBeenCalled();
+  });
+
   test('omite PRs sin diff textual suficiente y no llama al cliente remoto', async () => {
     const snapshotProvider = {
       getSnapshot: jest.fn().mockResolvedValue({
@@ -125,6 +192,132 @@ describe('PullRequestAnalysisService', () => {
     expect(analysisClient.analyze).not.toHaveBeenCalled();
   });
 
+  test('en strict mode usa el mensaje de sensibilidad cuando hay secretos en el diff', async () => {
+    const service = new PullRequestAnalysisService({
+      snapshotProvider: {
+        getSnapshot: jest.fn().mockResolvedValue({
+          provider: 'github',
+          repository: 'repo-a',
+          pullRequestId: 88,
+          title: 'Actualizar auth',
+          description: 'Ajustes de seguridad',
+          author: 'Ian',
+          sourceBranch: 'feature/auth',
+          targetBranch: 'main',
+          reviewers: [],
+          files: [
+            { path: 'src/auth.ts', status: 'modified', patch: '+ const access_token = \"abcdefgh123456\";' },
+          ],
+          totalFilesChanged: 1,
+          truncated: false,
+        }),
+      },
+      promptBuilder: { build: jest.fn() },
+      analysisClient: { analyze: jest.fn() },
+      responseParser: { parse: jest.fn() },
+    });
+
+    const result = await service.analyzeBatch(createRequest({
+      snapshotPolicy: {
+        excludedPathPatterns: '',
+        strictMode: true,
+      },
+    }));
+
+    expect(result[0].status).toBe('omitted');
+    expect(result[0].coverageNote).toBe('PR omitido por modo estricto y señales sensibles en el diff.');
+  });
+
+  test('analiza PRs validos, acota el riskScore y conserva coverageNote parcial', async () => {
+    const snapshotProvider = {
+      getSnapshot: jest.fn().mockResolvedValue({
+        provider: 'github',
+        repository: 'repo-a',
+        pullRequestId: 88,
+        title: 'Actualizar auth',
+        description: 'Ajustes de seguridad',
+        author: 'Ian',
+        sourceBranch: 'feature/auth',
+        targetBranch: 'main',
+        reviewers: [],
+        files: [
+          { path: 'src/auth.ts', status: 'modified', patch: '+ const enabled = true;' },
+        ],
+        totalFilesChanged: 1,
+        truncated: false,
+        partialReason: 'Solo se cargo un subconjunto del diff.',
+      }),
+    };
+    const promptBuilder = { build: jest.fn().mockReturnValue('prompt') };
+    const analysisClient = { analyze: jest.fn().mockResolvedValue('raw-output') };
+    const responseParser = {
+      parse: jest.fn().mockReturnValue({
+        riskScore: 999,
+        shortSummary: 'Resumen corto',
+        topConcerns: ['auth'],
+        reviewChecklist: ['agregar tests'],
+      }),
+    };
+    const service = new PullRequestAnalysisService({
+      snapshotProvider,
+      promptBuilder,
+      analysisClient,
+      responseParser,
+    });
+
+    const result = await service.analyzeBatch(createRequest({
+      requestId: 'batch-success',
+    }));
+
+    expect(result).toEqual([
+      expect.objectContaining({
+        pullRequestId: 88,
+        status: 'analyzed',
+        riskScore: 100,
+        shortSummary: 'Resumen corto',
+        coverageNote: 'Solo se cargo un subconjunto del diff.',
+      }),
+    ]);
+    expect(service.activeRuns.size).toBe(0);
+  });
+
+  test('si el cliente remoto falla con un valor no-Error devuelve un mensaje generico', async () => {
+    const service = new PullRequestAnalysisService({
+      snapshotProvider: {
+        getSnapshot: jest.fn().mockResolvedValue({
+          provider: 'github',
+          repository: 'repo-a',
+          pullRequestId: 88,
+          title: 'Actualizar auth',
+          description: 'Ajustes de seguridad',
+          author: 'Ian',
+          sourceBranch: 'feature/auth',
+          targetBranch: 'main',
+          reviewers: [],
+          files: [
+            { path: 'src/auth.ts', status: 'modified', patch: '+ const enabled = true;' },
+          ],
+          totalFilesChanged: 1,
+          truncated: false,
+        }),
+      },
+      promptBuilder: { build: jest.fn().mockReturnValue('prompt') },
+      analysisClient: {
+        analyze: jest.fn().mockRejectedValue('network down'),
+      },
+      responseParser: { parse: jest.fn() },
+    });
+
+    const result = await service.analyzeBatch(createRequest({
+      requestId: 'batch-generic-error',
+    }));
+
+    expect(result[0]).toEqual(expect.objectContaining({
+      status: 'error',
+      error: 'No fue posible analizar el PR.',
+    }));
+  });
+
   test('permite cancelar una corrida en lote y limpia el request activo', async () => {
     const snapshotProvider = {
       getSnapshot: jest.fn().mockResolvedValue({
@@ -170,5 +363,16 @@ describe('PullRequestAnalysisService', () => {
     expect(result[0].status).toBe('error');
     expect(result[0].error).toMatch(/cancelled/i);
     expect(service.activeRuns.size).toBe(0);
+  });
+
+  test('cancelAnalysis ignora requestIds inexistentes', () => {
+    const service = new PullRequestAnalysisService({
+      snapshotProvider: { getSnapshot: jest.fn() },
+      promptBuilder: { build: jest.fn() },
+      analysisClient: { analyze: jest.fn() },
+      responseParser: { parse: jest.fn() },
+    });
+
+    expect(() => service.cancelAnalysis('missing-batch')).not.toThrow();
   });
 });

--- a/tests/unit/services/repository-analysis-parts.test.js
+++ b/tests/unit/services/repository-analysis-parts.test.js
@@ -2,6 +2,7 @@ const { RepositoryAnalysisPromptBuilder } = require('../../../src/services/analy
 const { RepositoryAnalysisResponseParser } = require('../../../src/services/analysis/repository-analysis.response-parser');
 const { OpenAIRepositoryAnalysisClient } = require('../../../src/services/analysis/repository-analysis.openai-client');
 const { RepositoryAnalysisSnapshotProvider } = require('../../../src/services/analysis/repository-analysis.snapshot-provider');
+const { buildRepositoryAnalysisPreview } = require('../../../src/services/analysis/repository-analysis.preview');
 const { RepositoryAnalysisService } = require('../../../src/services/analysis/repository-analysis.service');
 
 describe('repository analysis parts', () => {
@@ -83,6 +84,40 @@ describe('repository analysis parts', () => {
     })).rejects.toThrow('insufficient_quota');
   });
 
+  test('openai client compacta errores remotos genericos', async () => {
+    const client = new OpenAIRepositoryAnalysisClient();
+    global.fetch = jest.fn().mockResolvedValue(new Response('  upstream failed hard  ', {
+      status: 500,
+      statusText: 'Internal Server Error',
+    }));
+
+    await expect(client.analyze({
+      request: {
+        model: 'gpt-5.2-codex',
+        apiKey: 'sk-test',
+      },
+      prompt: { systemPrompt: 'system', userPrompt: 'user' },
+      signal: new AbortController().signal,
+    })).rejects.toThrow('Codex analysis failed (500): upstream failed hard');
+  });
+
+  test('openai client usa statusText cuando la respuesta llega vacia', async () => {
+    const client = new OpenAIRepositoryAnalysisClient();
+    global.fetch = jest.fn().mockResolvedValue(new Response('', {
+      status: 502,
+      statusText: 'Bad Gateway',
+    }));
+
+    await expect(client.analyze({
+      request: {
+        model: 'gpt-5.2-codex',
+        apiKey: 'sk-test',
+      },
+      prompt: { systemPrompt: 'system', userPrompt: 'user' },
+      signal: new AbortController().signal,
+    })).rejects.toThrow('Codex analysis failed (502): Bad Gateway');
+  });
+
   test('snapshot provider resuelve el provider y adapta el source config', async () => {
     const provider = {
       getRepositorySnapshot: jest.fn().mockResolvedValue({ files: [] }),
@@ -113,6 +148,70 @@ describe('repository analysis parts', () => {
       maxFiles: 50,
       includeTests: false,
     });
+  });
+
+  test('snapshot provider preserva el project en Azure DevOps', async () => {
+    const provider = {
+      getRepositorySnapshot: jest.fn().mockResolvedValue({ files: [] }),
+    };
+    const snapshotProvider = new RepositoryAnalysisSnapshotProvider({
+      get: jest.fn().mockReturnValue(provider),
+    });
+
+    await snapshotProvider.getSnapshot({
+      source: {
+        provider: 'azure-devops',
+        organization: 'acme',
+        project: 'platform-team',
+        repositoryId: 'repo-a',
+        personalAccessToken: 'pat',
+      },
+      repositoryId: 'repo-a',
+      branchName: 'main',
+      maxFilesPerRun: 25,
+      includeTests: true,
+      snapshotPolicy: {
+        excludedPathPatterns: '.env',
+      },
+    });
+
+    expect(provider.getRepositorySnapshot).toHaveBeenCalledWith(expect.objectContaining({
+      project: 'platform-team',
+      repositoryId: 'repo-a',
+    }), expect.objectContaining({
+      excludedPathPatterns: '.env',
+      includeTests: true,
+    }));
+  });
+
+  test('snapshot provider usa project como fallback cuando falta repositoryId fuera de Azure', async () => {
+    const provider = {
+      getRepositorySnapshot: jest.fn().mockResolvedValue({ files: [] }),
+    };
+    const snapshotProvider = new RepositoryAnalysisSnapshotProvider({
+      get: jest.fn().mockReturnValue(provider),
+    });
+
+    await snapshotProvider.getSnapshot({
+      source: {
+        provider: 'github',
+        organization: 'acme',
+        project: 'repo-a',
+        repositoryId: '',
+        personalAccessToken: 'pat',
+      },
+      repositoryId: '',
+      branchName: 'main',
+      maxFilesPerRun: 25,
+      includeTests: false,
+    });
+
+    expect(provider.getRepositorySnapshot).toHaveBeenCalledWith(expect.objectContaining({
+      project: 'repo-a',
+      repositoryId: '',
+    }), expect.objectContaining({
+      branchName: 'main',
+    }));
   });
 
   test('analysis service construye preview con sensibilidad local', async () => {
@@ -167,5 +266,24 @@ describe('repository analysis parts', () => {
     expect(preview.sensitivity.hasSensitiveConfigFiles).toBe(true);
     expect(preview.sensitivity.hasSecretPatterns).toBe(true);
     expect(preview.disclaimer).toContain('alertas de sensibilidad');
+  });
+
+  test('buildRepositoryAnalysisPreview crea exclusiones por defecto cuando el snapshot no las expone', () => {
+    const preview = buildRepositoryAnalysisPreview({
+      provider: 'github',
+      repository: 'repo-a',
+      branch: 'main',
+      files: [
+        { path: 'src/a.ts', extension: 'ts', size: 10, content: 'export const a = 1;' },
+      ],
+      totalFilesDiscovered: 1,
+      truncated: false,
+    });
+
+    expect(preview.exclusions).toEqual({
+      omittedByPrioritization: [],
+      omittedBySize: [],
+      omittedByBinaryDetection: [],
+    });
   });
 });

--- a/tests/unit/services/repository-analysis.service.test.js
+++ b/tests/unit/services/repository-analysis.service.test.js
@@ -22,7 +22,15 @@ describe('RepositoryAnalysisService', () => {
       branch: 'main',
       files: [{ path: 'src/index.ts', extension: 'ts', size: 32, content: 'export const ok = true;' }],
       totalFilesDiscovered: 1,
-      truncated: false,
+      truncated: true,
+      partialReason: 'Se omitieron archivos binarios.',
+      metrics: {
+        durationMs: 321,
+        retryCount: 2,
+        discardedByPrioritization: ['src/legacy.ts'],
+        discardedBySize: ['src/big.ts'],
+        discardedByBinaryDetection: ['assets/logo.png'],
+      },
     });
 
     global.fetch = jest.fn().mockResolvedValue(new Response(JSON.stringify({
@@ -67,6 +75,76 @@ describe('RepositoryAnalysisService', () => {
 
     expect(result.summary).toBe('Resumen en espanol');
     expect(result.snapshot.totalFilesDiscovered).toBe(1);
+    expect(result.snapshot).toEqual(expect.objectContaining({
+      truncated: true,
+      partialReason: 'Se omitieron archivos binarios.',
+      durationMs: 321,
+      retryCount: 2,
+      discardedByPrioritization: ['src/legacy.ts'],
+      discardedBySize: ['src/big.ts'],
+      discardedByBinaryDetection: ['assets/logo.png'],
+    }));
+  });
+
+  test('previewSnapshot rechaza snapshots sin archivos legibles', async () => {
+    const service = createServiceWithSnapshot({
+      provider: 'github',
+      repository: 'repo-a',
+      branch: 'main',
+      files: [],
+      totalFilesDiscovered: 0,
+      truncated: false,
+    });
+
+    await expect(service.previewSnapshot({
+      requestId: 'req-preview-empty',
+      source: {
+        provider: 'github',
+        organization: 'acme',
+        project: 'repo-a',
+        repositoryId: 'repo-a',
+        personalAccessToken: 'pat',
+      },
+      repositoryId: 'repo-a',
+      branchName: 'main',
+      model: 'gpt-5.2-codex',
+      apiKey: 'sk-test',
+      analysisDepth: 'standard',
+      maxFilesPerRun: 50,
+      includeTests: false,
+    })).rejects.toThrow('No se encontraron archivos de codigo legibles para analizar en el scope seleccionado.');
+  });
+
+  test('runAnalysis exige apiKey antes de consultar providers remotos', async () => {
+    const snapshotProvider = {
+      getSnapshot: jest.fn(),
+    };
+    const service = new RepositoryAnalysisService({
+      snapshotProvider,
+      promptBuilder: { build: jest.fn() },
+      analysisClient: { analyze: jest.fn() },
+      responseParser: { parse: jest.fn() },
+    });
+
+    await expect(service.runAnalysis({
+      requestId: 'req-no-key',
+      source: {
+        provider: 'github',
+        organization: 'acme',
+        project: 'repo-a',
+        repositoryId: 'repo-a',
+        personalAccessToken: 'pat',
+      },
+      repositoryId: 'repo-a',
+      branchName: 'main',
+      model: 'gpt-5.2-codex',
+      apiKey: '   ',
+      analysisDepth: 'standard',
+      maxFilesPerRun: 50,
+      includeTests: false,
+    })).rejects.toThrow('La API key de Codex es obligatoria para ejecutar el analisis.');
+
+    expect(snapshotProvider.getSnapshot).not.toHaveBeenCalled();
   });
 
   test('mapea error 500 del proveedor remoto', async () => {
@@ -142,6 +220,69 @@ describe('RepositoryAnalysisService', () => {
       maxFilesPerRun: 50,
       includeTests: false,
     })).rejects.toThrow('Codex no devolvio salida estructurada.');
+  });
+
+  test('runAnalysis rechaza snapshots vacios y limpia la corrida activa', async () => {
+    const service = createRepositoryAnalysisService({
+      snapshotProvider: {
+        getSnapshot: jest.fn().mockResolvedValue({
+          provider: 'github',
+          repository: 'repo-a',
+          branch: 'main',
+          files: [],
+          totalFilesDiscovered: 0,
+          truncated: false,
+        }),
+      },
+    });
+
+    await expect(service.runAnalysis({
+      requestId: 'req-empty',
+      source: {
+        provider: 'github',
+        organization: 'acme',
+        project: 'repo-a',
+        repositoryId: 'repo-a',
+        personalAccessToken: 'pat',
+      },
+      repositoryId: 'repo-a',
+      branchName: 'main',
+      model: 'gpt-5.2-codex',
+      apiKey: 'sk-test',
+      analysisDepth: 'standard',
+      maxFilesPerRun: 50,
+      includeTests: false,
+    })).rejects.toThrow('No se encontraron archivos de codigo legibles para analizar en el scope seleccionado.');
+
+    expect(service.activeRuns.size).toBe(0);
+  });
+
+  test('si el snapshot falla, limpia el estado interno de la corrida', async () => {
+    const service = createRepositoryAnalysisService({
+      snapshotProvider: {
+        getSnapshot: jest.fn().mockRejectedValue(new Error('provider down')),
+      },
+    });
+
+    await expect(service.runAnalysis({
+      requestId: 'req-snapshot-error',
+      source: {
+        provider: 'github',
+        organization: 'acme',
+        project: 'repo-a',
+        repositoryId: 'repo-a',
+        personalAccessToken: 'pat',
+      },
+      repositoryId: 'repo-a',
+      branchName: 'main',
+      model: 'gpt-5.2-codex',
+      apiKey: 'sk-test',
+      analysisDepth: 'standard',
+      maxFilesPerRun: 50,
+      includeTests: false,
+    })).rejects.toThrow('provider down');
+
+    expect(service.activeRuns.size).toBe(0);
   });
 
   test('cancela una corrida activa y limpia el estado interno', async () => {
@@ -256,5 +397,69 @@ describe('RepositoryAnalysisService', () => {
     expect(result.ok).toBe(false);
     expect(result.error.message).toContain('El analisis remoto excedio el timeout de 1 segundos.');
     expect(service.activeRuns.size).toBe(0);
+  });
+
+  test('si se cancela antes de la consulta remota, aborta sin llamar al cliente de analisis', async () => {
+    let resolveSnapshot;
+    const snapshotPromise = new Promise((resolve) => {
+      resolveSnapshot = resolve;
+    });
+    const analysisClient = {
+      analyze: jest.fn(),
+    };
+    const service = new RepositoryAnalysisService({
+      snapshotProvider: {
+        getSnapshot: jest.fn().mockReturnValue(snapshotPromise),
+      },
+      promptBuilder: {
+        build: jest.fn(),
+      },
+      analysisClient,
+      responseParser: {
+        parse: jest.fn(),
+      },
+    });
+
+    const runPromise = service.runAnalysis({
+      requestId: 'req-cancel-before-remote',
+      source: {
+        provider: 'github',
+        organization: 'acme',
+        project: 'repo-a',
+        repositoryId: 'repo-a',
+        personalAccessToken: 'pat',
+      },
+      repositoryId: 'repo-a',
+      branchName: 'main',
+      model: 'gpt-5.2-codex',
+      apiKey: 'sk-test',
+      analysisDepth: 'standard',
+      maxFilesPerRun: 50,
+      includeTests: false,
+    });
+
+    service.cancelAnalysis('req-cancel-before-remote');
+    resolveSnapshot({
+      provider: 'github',
+      repository: 'repo-a',
+      branch: 'main',
+      files: [{ path: 'src/index.ts', extension: 'ts', size: 32, content: 'export const ok = true;' }],
+      totalFilesDiscovered: 1,
+      truncated: false,
+    });
+
+    await expect(runPromise).rejects.toThrow('El analisis fue cancelado antes de iniciar la consulta remota.');
+    expect(analysisClient.analyze).not.toHaveBeenCalled();
+    expect(service.activeRuns.size).toBe(0);
+  });
+
+  test('cancelAnalysis ignora requestIds desconocidos sin lanzar error', () => {
+    const service = createRepositoryAnalysisService({
+      snapshotProvider: {
+        getSnapshot: jest.fn(),
+      },
+    });
+
+    expect(() => service.cancelAnalysis('missing-run')).not.toThrow();
   });
 });

--- a/tests/unit/services/repository-snapshot-modules.test.js
+++ b/tests/unit/services/repository-snapshot-modules.test.js
@@ -37,6 +37,10 @@ describe('repository snapshot modules', () => {
     jest.clearAllMocks();
   });
 
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
   test('enumerateGitHubContents corta temprano al alcanzar inventoryTarget', async () => {
     githubApi.requestGitHubContent
       .mockResolvedValueOnce([
@@ -55,6 +59,16 @@ describe('repository snapshot modules', () => {
 
     expect(result.reachedInventoryTarget).toBe(true);
     expect(result.files.length).toBeGreaterThanOrEqual(2);
+  });
+
+  test('enumerateGitHubContents no consulta si inventoryTarget ya esta agotado', async () => {
+    const result = await githubSnapshot.enumerateGitHubContents('acme', 'repo-a', 'main', 'pat', {
+      inventoryTarget: 0,
+      concurrency: 2,
+    });
+
+    expect(result).toEqual({ files: [], reachedInventoryTarget: true });
+    expect(githubApi.requestGitHubContent).not.toHaveBeenCalled();
   });
 
   test('getGitHubRepositorySnapshot omite archivos grandes y binarios', async () => {
@@ -87,6 +101,161 @@ describe('repository snapshot modules', () => {
     expect(snapshot.exclusions.omittedByBinaryDetection).toContain('src/b.ts');
   });
 
+  test('getGitHubRepositorySnapshot recompone inventario cuando el tree viene truncado', async () => {
+    githubApi.requestGitHubJson.mockResolvedValue({
+      tree: [],
+      truncated: true,
+    });
+    githubApi.requestGitHubContent
+      .mockResolvedValueOnce([
+        { type: 'file', path: 'src/a.ts', size: 20 },
+      ])
+      .mockResolvedValueOnce({
+        type: 'file',
+        size: 20,
+        encoding: 'utf8',
+        content: 'export const a = true;',
+      });
+
+    const snapshot = await githubSnapshot.getGitHubRepositorySnapshot({
+      organization: 'acme',
+      repositoryId: 'repo-a',
+      personalAccessToken: 'pat',
+    }, {
+      branchName: 'main',
+      maxFiles: 5,
+      includeTests: false,
+    });
+
+    expect(snapshot.files).toHaveLength(1);
+    expect(snapshot.partialReason).toMatch(/GitHub reporto el tree como truncado/i);
+  });
+
+  test('getGitHubRepositorySnapshot rechaza config incompleta y contabiliza retries de contenido', async () => {
+    await expect(githubSnapshot.getGitHubRepositorySnapshot({
+      organization: '',
+      repositoryId: 'repo-a',
+      personalAccessToken: 'pat',
+    }, {
+      branchName: 'main',
+      maxFiles: 5,
+      includeTests: false,
+    })).rejects.toThrow('Owner/organization, repository y token son obligatorios para GitHub.');
+
+    jest.spyOn(global, 'setTimeout').mockImplementation((callback) => {
+      if (typeof callback === 'function') {
+        callback();
+      }
+      return 0;
+    });
+    githubApi.requestGitHubJson.mockResolvedValue({
+      tree: [
+        { type: 'blob', path: 'src/a.ts', size: 20 },
+      ],
+      truncated: false,
+    });
+    githubApi.requestGitHubContent
+      .mockRejectedValueOnce(new Error('GitHub content request failed (500): boom'))
+      .mockResolvedValueOnce({
+        type: 'file',
+        size: 20,
+        encoding: 'utf8',
+        content: 'export const ok = true;',
+      });
+
+    const snapshot = await githubSnapshot.getGitHubRepositorySnapshot({
+      organization: 'acme',
+      repositoryId: 'repo-a',
+      personalAccessToken: 'pat',
+    }, {
+      branchName: 'main',
+      maxFiles: 5,
+      includeTests: false,
+    });
+
+    expect(snapshot.metrics.retryCount).toBe(1);
+  });
+
+  test('getGitHubRepositorySnapshot prioriza por tamano cuando el ranking del path empata', async () => {
+    githubApi.requestGitHubJson.mockResolvedValue({
+      tree: [
+        { type: 'blob', path: 'src/large.ts', size: 50 },
+        { type: 'blob', path: 'src/small.ts', size: 10 },
+      ],
+      truncated: false,
+    });
+    githubApi.requestGitHubContent.mockResolvedValue({
+      type: 'file',
+      size: 10,
+      encoding: 'utf8',
+      content: 'export const ok = true;',
+    });
+
+    const snapshot = await githubSnapshot.getGitHubRepositorySnapshot({
+      organization: 'acme',
+      repositoryId: 'repo-a',
+      personalAccessToken: 'pat',
+    }, {
+      branchName: 'main',
+      maxFiles: 1,
+      includeTests: false,
+    });
+
+    expect(snapshot.files).toEqual([
+      expect.objectContaining({ path: 'src/small.ts' }),
+    ]);
+  });
+
+  test('getGitHubRepositorySnapshot prioriza primero paths de mayor riesgo aunque pesen mas', async () => {
+    githubApi.requestGitHubJson.mockResolvedValue({
+      tree: [
+        { type: 'blob', path: 'src/core.ts', size: 10 },
+        { type: 'blob', path: 'src/auth.ts', size: 50 },
+      ],
+      truncated: false,
+    });
+    githubApi.requestGitHubContent.mockResolvedValue({
+      type: 'file',
+      size: 50,
+      encoding: 'utf8',
+      content: 'export const ok = true;',
+    });
+
+    const snapshot = await githubSnapshot.getGitHubRepositorySnapshot({
+      organization: 'acme',
+      repositoryId: 'repo-a',
+      personalAccessToken: 'pat',
+    }, {
+      branchName: 'main',
+      maxFiles: 1,
+      includeTests: false,
+    });
+
+    expect(snapshot.files).toEqual([
+      expect.objectContaining({ path: 'src/auth.ts' }),
+    ]);
+  });
+
+  test('getGitHubRepositorySnapshot falla si un archivo devuelve payload de directorio', async () => {
+    githubApi.requestGitHubJson.mockResolvedValue({
+      tree: [
+        { type: 'blob', path: 'src/a.ts', size: 20 },
+      ],
+      truncated: false,
+    });
+    githubApi.requestGitHubContent.mockResolvedValue([]);
+
+    await expect(githubSnapshot.getGitHubRepositorySnapshot({
+      organization: 'acme',
+      repositoryId: 'repo-a',
+      personalAccessToken: 'pat',
+    }, {
+      branchName: 'main',
+      maxFiles: 5,
+      includeTests: false,
+    })).rejects.toThrow('returned a directory payload unexpectedly');
+  });
+
   test('getAzureRepositorySnapshot omite tamano excesivo y binario', async () => {
     azureApi.requestAzureJson.mockResolvedValue({
       value: [
@@ -112,6 +281,31 @@ describe('repository snapshot modules', () => {
     expect(snapshot.truncated).toBe(true);
     expect(snapshot.exclusions.omittedBySize).toContain('src/large.ts');
     expect(snapshot.exclusions.omittedByBinaryDetection).toContain('src/bin.ts');
+  });
+
+  test('getAzureRepositorySnapshot recorta archivos priorizados y normaliza paths', async () => {
+    azureApi.requestAzureJson.mockResolvedValue({
+      value: [
+        { path: '/src/a.ts', isFolder: false },
+        { path: '/src/b.ts', isFolder: false },
+      ],
+    });
+    azureApi.requestAzureText.mockResolvedValue('export const ok = true;');
+
+    const snapshot = await getAzureRepositorySnapshot({
+      organization: 'org',
+      project: 'proj',
+      repositoryId: 'repo-a',
+      personalAccessToken: 'pat',
+    }, {
+      branchName: 'main',
+      maxFiles: 1,
+      includeTests: false,
+    });
+
+    expect(snapshot.files).toHaveLength(1);
+    expect(snapshot.files[0].path).toBe('src/a.ts');
+    expect(snapshot.partialReason).toMatch(/se recorto a 1 archivos priorizados/i);
   });
 
   test('getGitLabRepositorySnapshot omite tamano excesivo y binario', async () => {
@@ -146,5 +340,74 @@ describe('repository snapshot modules', () => {
     expect(snapshot.truncated).toBe(true);
     expect(snapshot.exclusions.omittedBySize).toContain('src/large.ts');
     expect(snapshot.exclusions.omittedByBinaryDetection).toContain('src/bin.ts');
+  });
+
+  test('getGitLabRepositorySnapshot soporta contenido no base64 y partialReason por recorte', async () => {
+    gitlabApi.requestPaginatedGitLabTree.mockResolvedValue([
+      { path: 'src/a.ts', type: 'blob' },
+      { path: 'src/b.ts', type: 'blob' },
+    ]);
+    gitlabApi.requestGitLabJson.mockResolvedValue({
+      file_path: 'src/a.ts',
+      size: 22,
+      content: 'export const ok = true;',
+      encoding: 'text',
+    });
+
+    const snapshot = await getGitLabRepositorySnapshot({
+      project: 'group/repo-a',
+      repositoryId: 'group/repo-a',
+      personalAccessToken: 'pat',
+    }, {
+      branchName: 'main',
+      maxFiles: 1,
+      includeTests: false,
+    });
+
+    expect(snapshot.files).toHaveLength(1);
+    expect(snapshot.files[0].path).toBe('src/a.ts');
+    expect(snapshot.partialReason).toMatch(/se recorto a 1 archivos priorizados/i);
+  });
+
+  test('getGitLabRepositorySnapshot rechaza config incompleta y contabiliza retries', async () => {
+    await expect(getGitLabRepositorySnapshot({
+      project: '',
+      repositoryId: '',
+      personalAccessToken: 'pat',
+    }, {
+      branchName: 'main',
+      maxFiles: 1,
+      includeTests: false,
+    })).rejects.toThrow('Proyecto y token son obligatorios para GitLab.');
+
+    jest.spyOn(global, 'setTimeout').mockImplementation((callback) => {
+      if (typeof callback === 'function') {
+        callback();
+      }
+      return 0;
+    });
+    gitlabApi.requestPaginatedGitLabTree.mockResolvedValue([
+      { path: 'src/a.ts', type: 'blob' },
+    ]);
+    gitlabApi.requestGitLabJson
+      .mockRejectedValueOnce(new Error('GitLab file request failed (500): boom'))
+      .mockResolvedValueOnce({
+        file_path: 'src/a.ts',
+        size: 22,
+        content: 'export const ok = true;',
+        encoding: 'text',
+      });
+
+    const snapshot = await getGitLabRepositorySnapshot({
+      project: 'group/repo-a',
+      repositoryId: 'group/repo-a',
+      personalAccessToken: 'pat',
+    }, {
+      branchName: 'main',
+      maxFiles: 1,
+      includeTests: false,
+    });
+
+    expect(snapshot.metrics.retryCount).toBe(1);
   });
 });

--- a/tests/unit/services/shared-selection-and-helpers.test.js
+++ b/tests/unit/services/shared-selection-and-helpers.test.js
@@ -1,0 +1,50 @@
+const { selectPullRequestsForAiReview } = require('../../../src/shared/pull-request-selection');
+const {
+  isTestFile,
+  isSupportedCodeFile,
+  rankPath,
+  mergeExcludedPathPatterns,
+  parseExcludedPathPatterns,
+  shouldExcludeSnapshotPath,
+} = require('../../../src/services/shared/repository-snapshot-helpers');
+
+function createPullRequest(id, riskScore, ageHours) {
+  return {
+    id,
+    riskScore,
+    ageHours,
+  };
+}
+
+describe('shared selection and snapshot helpers', () => {
+  test('shared pull-request selection cubre top-risk, oldest y mixed', () => {
+    const sample = [
+      createPullRequest(1, 10, 10),
+      createPullRequest(2, 8, 30),
+      createPullRequest(3, 4, 50),
+      createPullRequest(4, 2, 70),
+    ];
+
+    expect(selectPullRequestsForAiReview(sample, 'top-risk', 2).map((item) => item.id)).toEqual([1, 2]);
+    expect(selectPullRequestsForAiReview(sample, 'oldest', 2).map((item) => item.id)).toEqual([4, 3]);
+    expect(selectPullRequestsForAiReview(sample, 'mixed', 3).map((item) => item.id)).toEqual([1, 4, 2]);
+    expect(selectPullRequestsForAiReview(sample, 'top-risk', 0)).toHaveLength(1);
+  });
+
+  test('snapshot helpers clasifican archivos, prioridad y exclusiones', () => {
+    expect(isTestFile('src/__tests__/auth.spec.ts')).toBe(true);
+    expect(isTestFile('src/auth.ts')).toBe(false);
+    expect(isSupportedCodeFile('src/app.ts')).toBe(true);
+    expect(isSupportedCodeFile('assets/logo.png')).toBe(false);
+
+    expect(rankPath('src/auth/token.ts')).toBe(4);
+    expect(rankPath('src/server/app.ts')).toBe(3);
+    expect(rankPath('infra/deploy.yaml')).toBe(2);
+    expect(rankPath('docs/readme.md')).toBe(1);
+
+    expect(parseExcludedPathPatterns('.env\n dist/** \n')).toEqual(['.env', 'dist/**']);
+    expect(mergeExcludedPathPatterns('.env', 'dist/**', '.env')).toBe('.env\ndist/**');
+    expect(shouldExcludeSnapshotPath('.env', '.env\n*.pem')).toBe(true);
+    expect(shouldExcludeSnapshotPath('src/app.ts', '.env\n*.pem')).toBe(false);
+  });
+});


### PR DESCRIPTION
## Resumen

Este PR fortalece la red de regresion del proyecto para reducir el riesgo de romper comportamiento existente cuando agreguemos nuevas funcionalidades o hagamos refactors pequenos/medianos.

Ademas del aumento de cobertura, durante este trabajo aparecieron algunos edge cases reales que fueron corregidos en codigo productivo para que la suite no solo detecte regresiones, sino que tambien deje el comportamiento mas robusto.

## Objetivo

- Endurecer la suite de tests en renderer, main e integraciones de providers.
- Cubrir ramas de error, fallback, retries, truncation y configuraciones incompletas que antes quedaban fuera.
- Reducir el espacio donde un refactor pequeno pueda romper features sin aviso.
- Mantener la arquitectura, el gate de calidad y el build totalmente verdes.

## Cambios incluidos

### Renderer y hooks
- Se reforzaron flows de repository-source, incluyendo configuracion, bootstrap, efectos, estado, seleccion de proyectos y persistencia de snapshots.
- Se agrego cobertura especifica para useRepositoryBranches, incluyendo errores tipados/no tipados, listas vacias y respuestas tardias.
- Se sumaron tests para indicators y summary del dashboard.
- Se agregaron tests para electronBridge y APIs expuestas a la capa de renderer.
- Se cubrieron mas ramas en pull-request-ai y repository-analysis.

### Main e IPC
- Se agregaron tests nuevos para analysis.shared, window-controls y handlers IPC.
- Se ampliaron los tests de sanitizacion y contracts del main process.

### Services y providers
- Se reforzaron adapters HTTP y helpers compartidos (http-response, selection helpers, snapshot helpers).
- Se agregaron suites nuevas para github.api, azure.api, azure.context y flujos de pull requests/snapshots de providers.
- Se cubrieron ramas de retries, paginacion, truncation, payloads inesperados, status fallbacks y configuraciones incompletas.

### Fixes descubiertos por la suite
- Se corrigio el manejo de cancelacion tardia en useRepositoryBranches para ignorar respuestas stale despues del cleanup.
- Se corrigio un edge case en repository-analysis.service relacionado con cancelaciones tempranas.
- Se corrigio un fallback en gitlab.repositories/gitlab.api para preservar correctamente el nombre del proyecto al construir proyectos desde path_with_namespace.

## Impacto

- La cobertura global sube y, mas importante, mejora en zonas con alto riesgo de regresion real.
- Los hooks y adapters mas sensibles quedan mucho mejor defendidos ante cambios futuros.
- El gate local y remoto ahora valida una suite bastante mas representativa del comportamiento del producto.

## Validacion realizada

- npm run quality:check
- pre-commit OK
- pre-push OK

Resultado final:
- 78/78 suites OK
- 341/341 tests OK
- cobertura global:
  - statements 98.48%
  - branches 90.22%
  - functions 97.04%
  - lines 98.51%
- analyze:architecture OK
- analyze:cycles OK
- jscpd con 0 clones
- build OK

## Riesgos / notas

- Quedan algunos branches de bajo retorno sin cubrir al 100%, principalmente en adapters de providers y archivos triviales/de composicion. No representan una deuda critica frente al nivel actual de cobertura.
- El cambio es mayoritariamente de tests, pero incluye pequenos fixes de robustez encontrados al endurecer la suite.

## QA sugerido

- Ejecutar npm run quality:check localmente.
- Probar manualmente al menos una pasada de:
  - carga de proyectos/repositorios
  - analisis de repositorio
  - snapshot de PR/repository con algun provider soportado
  - title bar / window controls en runtime Electron