### PR TITLE
fix: alinear los controles custom de macOS con full screen nativo

### DIFF
--- a/src/main/ipc/window-controls.ts
+++ b/src/main/ipc/window-controls.ts
@@ -57,10 +57,14 @@ export function registerWindowControlsIpc(): void {
   ipcMain.handle(TOGGLE_MAXIMIZE_CHANNEL, (event) => {
     const targetWindow = resolveSenderWindow(event.sender);
 
-    if (targetWindow.isMaximized()) {
-      targetWindow.unmaximize();
+    if (process.platform === 'darwin') {
+      targetWindow.setFullScreen(!targetWindow.isFullScreen());
     } else {
-      targetWindow.maximize();
+      if (targetWindow.isMaximized()) {
+        targetWindow.unmaximize();
+      } else {
+        targetWindow.maximize();
+      }
     }
 
     return buildWindowState(targetWindow);

--- a/src/renderer/shared/layout/TitleBar.tsx
+++ b/src/renderer/shared/layout/TitleBar.tsx
@@ -96,6 +96,7 @@ interface TitleBarProps {
 
 interface WindowControlButtonsProps {
   isMaximized: boolean;
+  isFullScreen: boolean;
   onMinimize: () => Promise<void>;
   onToggleMaximize: () => Promise<void>;
   onClose: () => Promise<void>;
@@ -142,7 +143,7 @@ const DesktopTitleBarButton = ({
 );
 
 const MacWindowControls = ({
-  isMaximized,
+  isFullScreen,
   onMinimize,
   onToggleMaximize,
   onClose,
@@ -159,7 +160,7 @@ const MacWindowControls = ({
       toneClassName: 'bg-amber-400 ring-1 ring-amber-500/20 hover:bg-amber-500 focus-visible:outline-amber-500',
     },
     {
-      label: isMaximized ? 'Restore window' : 'Maximize window',
+      label: isFullScreen ? 'Exit full screen' : 'Enter full screen',
       onClick: onToggleMaximize,
       toneClassName: 'bg-emerald-400 ring-1 ring-emerald-500/20 hover:bg-emerald-500 focus-visible:outline-emerald-500',
     },
@@ -277,6 +278,7 @@ const TitleBar = ({ pathname }: TitleBarProps) => {
           {isMacOS ? (
             <MacWindowControls
               isMaximized={windowState.isMaximized}
+              isFullScreen={windowState.isFullScreen}
               onMinimize={handleMinimize}
               onToggleMaximize={handleToggleMaximize}
               onClose={handleClose}
@@ -289,6 +291,7 @@ const TitleBar = ({ pathname }: TitleBarProps) => {
         {supportsWindowControls && !isMacOS ? (
           <DesktopWindowControls
             isMaximized={windowState.isMaximized}
+            isFullScreen={windowState.isFullScreen}
             onMinimize={handleMinimize}
             onToggleMaximize={handleToggleMaximize}
             onClose={handleClose}

--- a/tests/unit/main/ipc.window-controls.test.js
+++ b/tests/unit/main/ipc.window-controls.test.js
@@ -1,0 +1,59 @@
+const handle = jest.fn();
+
+jest.mock('electron', () => ({
+  ipcMain: {
+    handle,
+  },
+  BrowserWindow: {
+    fromWebContents: jest.fn(),
+  },
+}));
+
+const { ipcMain, BrowserWindow } = require('electron');
+const { registerWindowControlsIpc } = require('../../../src/main/ipc/window-controls');
+
+function withPlatform(platform, callback) {
+  const originalDescriptor = Object.getOwnPropertyDescriptor(process, 'platform');
+
+  Object.defineProperty(process, 'platform', {
+    configurable: true,
+    value: platform,
+  });
+
+  try {
+    callback();
+  } finally {
+    Object.defineProperty(process, 'platform', originalDescriptor);
+  }
+}
+
+describe('window controls ipc', () => {
+  beforeEach(() => {
+    ipcMain.handle.mockReset();
+    BrowserWindow.fromWebContents.mockReset();
+  });
+
+  test('en macOS usa full screen para el toggle principal', () => {
+    const targetWindow = {
+      isFullScreen: jest.fn().mockReturnValue(false),
+      setFullScreen: jest.fn(),
+      isMaximized: jest.fn().mockReturnValue(false),
+      maximize: jest.fn(),
+      unmaximize: jest.fn(),
+      close: jest.fn(),
+      minimize: jest.fn(),
+    };
+
+    BrowserWindow.fromWebContents.mockReturnValue(targetWindow);
+
+    withPlatform('darwin', () => {
+      registerWindowControlsIpc();
+      const toggleHandler = ipcMain.handle.mock.calls.find(([channel]) => channel === 'window-controls:toggle-maximize')[1];
+      toggleHandler({ sender: {} });
+    });
+
+    expect(targetWindow.setFullScreen).toHaveBeenCalledWith(true);
+    expect(targetWindow.maximize).not.toHaveBeenCalled();
+    expect(targetWindow.unmaximize).not.toHaveBeenCalled();
+  });
+});

--- a/tests/unit/renderer/title-bar.dom.test.js
+++ b/tests/unit/renderer/title-bar.dom.test.js
@@ -43,7 +43,7 @@ describe('TitleBar', () => {
     await waitFor(() => {
       expect(
         screen.getAllByRole('button').map((button) => button.getAttribute('aria-label')),
-      ).toEqual(['Close window', 'Minimize window', 'Maximize window']);
+      ).toEqual(['Close window', 'Minimize window', 'Enter full screen']);
     });
   });
 });


### PR DESCRIPTION
## Resumen

Este PR alinea los controles custom de ventana en macOS con la semántica esperada del sistema: el botón verde ahora entra y sale de `full screen` en lugar de usar la lógica de maximizado/restauración pensada para otras plataformas.

Closes #14

## Qué cambia

- en el main process, `window-controls:toggle-maximize` usa `setFullScreen(!isFullScreen())` cuando la plataforma es `darwin`;
- en el renderer, los traffic lights de macOS pasan a etiquetar el botón verde como:
  - `Enter full screen`
  - `Exit full screen`
- se agrega cobertura unitaria para validar el branch específico de macOS en IPC;
- se actualizan los tests del `TitleBar` para reflejar el comportamiento esperado.

## Impacto

- mejora la consistencia con la UX nativa de macOS;
- evita que el botón verde custom quede semánticamente desalineado con el estado real de la ventana;
- deja mejor cubierto el comportamiento cross-platform de los controles de ventana.

## Archivos principales

- `src/main/ipc/window-controls.ts`
- `src/renderer/shared/layout/TitleBar.tsx`
- `tests/unit/main/ipc.window-controls.test.js`
- `tests/unit/renderer/title-bar.dom.test.js`

## Validación

Ejecutado:

```bash
npm test -- --runInBand tests/unit/main/ipc.window-controls.test.js tests/unit/renderer/title-bar.dom.test.js tests/unit/main/main.test.js
```
