### PR TITLE
refactor: limpiar la semántica Azure heredada del shared dashboard

### DIFF
--- a/src/renderer/shared/dashboard/summary-core.ts
+++ b/src/renderer/shared/dashboard/summary-core.ts
@@ -1,4 +1,4 @@
-import type { PullRequest } from '../../../types/azure';
+import type { ReviewItem } from '../../../types/repository';
 import type { PrioritizedPullRequest } from './summary.types';
 
 export function getAgeHours(createdAt: string): number {
@@ -6,23 +6,23 @@ export function getAgeHours(createdAt: string): number {
   return Math.max(0, Math.round((Date.now() - created) / (1000 * 60 * 60)));
 }
 
-export function getApprovals(pr: PullRequest): number {
+export function getApprovals(pr: ReviewItem): number {
   return pr.reviewers.filter((reviewer) => reviewer.vote >= 5).length;
 }
 
-export function getPendingReviewers(pr: PullRequest): number {
+export function getPendingReviewers(pr: ReviewItem): number {
   return pr.reviewers.filter((reviewer) => reviewer.vote === 0).length;
 }
 
-export function hasMergeConflict(pr: PullRequest): boolean {
+export function hasMergeConflict(pr: ReviewItem): boolean {
   return pr.mergeStatus.toLowerCase().includes('conflict');
 }
 
-export function hasEmptyDescription(pr: PullRequest): boolean {
+export function hasEmptyDescription(pr: ReviewItem): boolean {
   return !pr.description || pr.description === 'No description provided.';
 }
 
-export function getRiskScore(pr: PullRequest): number {
+export function getRiskScore(pr: ReviewItem): number {
   const ageHours = getAgeHours(pr.createdAt);
   const pendingReviewers = getPendingReviewers(pr);
   let score = 0;
@@ -48,7 +48,7 @@ export function getRiskScore(pr: PullRequest): number {
   return score;
 }
 
-export function prioritizePullRequests(pullRequests: PullRequest[]): PrioritizedPullRequest[] {
+export function prioritizePullRequests(pullRequests: ReviewItem[]): PrioritizedPullRequest[] {
   return pullRequests
     .map((pr) => ({
       ...pr,

--- a/src/renderer/shared/dashboard/summary.ts
+++ b/src/renderer/shared/dashboard/summary.ts
@@ -1,11 +1,11 @@
-import type { PullRequest } from '../../../types/azure';
+import type { ReviewItem } from '../../../types/repository';
 import type { DashboardSummary } from './summary.types';
 import { buildMetrics, buildDeliveryIndicators, buildGovernanceAlerts, buildReviewIndicators } from './summary-indicators';
 import { formatLastUpdate, getAverageAgeHours, hasEmptyDescription, hasMergeConflict, prioritizePullRequests, countPullRequestsOlderThan } from './summary-core';
 import { buildBranchInsights, buildRepositoryInsights, buildReviewerInsights } from './summary-insights';
 
 export function buildDashboardSummary(
-  pullRequests: PullRequest[],
+  pullRequests: ReviewItem[],
   lastUpdatedAt: Date | null,
   scopeLabel: string,
   targetReviewer?: string,


### PR DESCRIPTION
## Resumen

Este PR limpia la semántica heredada de Azure dentro del módulo `shared/dashboard`: el dashboard pasa a tipar sus entradas desde el modelo canónico de repositorio (`ReviewItem`) en lugar de importar `PullRequest` desde `types/azure`.

Closes #19

## Qué cambia

- `buildDashboardSummary()` ahora recibe `ReviewItem[]` desde `src/types/repository`;
- los helpers de `summary-core` también dejan de depender de `types/azure`;
- el comportamiento del dashboard no cambia, pero el módulo queda alineado con el dominio multi-provider actual.

## Por qué

`shared/dashboard` ya no es Azure-specific en la práctica, pero seguía arrastrando ese lenguaje en sus imports. Esto agregaba fricción semántica y hacía menos claro cuál era el modelo canónico de PR del renderer.

## Archivos principales

- `src/renderer/shared/dashboard/summary.ts`
- `src/renderer/shared/dashboard/summary-core.ts`

## Validación

Ejecutado:

```bash
npm test -- --runInBand tests/unit/renderer/dashboard-summary.test.js tests/unit/renderer/dashboard-indicators.test.js
```
