### PR TITLE
refactor: aclarar el ownership del helper de prompt directives de Codex

### DIFF
--- a/src/renderer/codex/architecturePromptDirectives.ts
+++ b/src/renderer/codex/architecturePromptDirectives.ts
@@ -7,7 +7,7 @@ export interface ArchitecturePromptDirectivesLike {
   customInstructions: string;
 }
 
-export function countActiveArchitectureDirectives(promptDirectives: ArchitecturePromptDirectivesLike): number {
+export function countConfiguredArchitectureDirectives(promptDirectives: ArchitecturePromptDirectivesLike): number {
   return [
     promptDirectives.architectureReviewEnabled,
     Boolean(promptDirectives.architecturePattern.trim()),

--- a/src/renderer/features/repository-analysis/presentation/components/RepositoryAnalysisShared.tsx
+++ b/src/renderer/features/repository-analysis/presentation/components/RepositoryAnalysisShared.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { ArrowPathIcon, ShieldExclamationIcon, SparklesIcon } from '@heroicons/react/24/outline';
-import { countActiveArchitectureDirectives } from '../../../../shared/codex/prompt-directives';
+import { countConfiguredArchitectureDirectives } from '../../../../codex/architecturePromptDirectives';
 
 export function countActiveDirectives(config: {
   promptDirectives: {
@@ -12,7 +12,7 @@ export function countActiveDirectives(config: {
     customInstructions: string;
   };
 }): number {
-  return countActiveArchitectureDirectives(config.promptDirectives);
+  return countConfiguredArchitectureDirectives(config.promptDirectives);
 }
 
 export const StatusRow = ({ label, value, ok }: { label: string; value: string; ok: boolean }) => (

--- a/src/renderer/features/settings/presentation/components/CodexIntegration.shared.ts
+++ b/src/renderer/features/settings/presentation/components/CodexIntegration.shared.ts
@@ -1,5 +1,5 @@
 import type { CodexIntegrationConfig } from '../../types';
-import { countActiveArchitectureDirectives } from '../../../../shared/codex/prompt-directives';
+import { countConfiguredArchitectureDirectives } from '../../../../codex/architecturePromptDirectives';
 
 export type CodexIntegrationChangeHandler = <K extends keyof CodexIntegrationConfig>(
   key: K,
@@ -9,7 +9,7 @@ export type CodexIntegrationChangeHandler = <K extends keyof CodexIntegrationCon
 export function countConfiguredPolicies(config: CodexIntegrationConfig): number {
   const prDirectives = config.prReview.promptDirectives;
 
-  return countActiveArchitectureDirectives(config.promptDirectives)
+  return countConfiguredArchitectureDirectives(config.promptDirectives)
     + (prDirectives.focusAreas.trim() ? 1 : 0)
     + (prDirectives.customInstructions.trim() ? 1 : 0);
 }


### PR DESCRIPTION
## Resumen

Este PR aclara el ownership del helper que contaba directivas de arquitectura de Codex: deja de vivir en `shared/codex` y pasa a un módulo `renderer/codex` con naming más explícito.

Closes #23

## Qué cambia

- `src/renderer/shared/codex/prompt-directives.ts` se mueve a `src/renderer/codex/architecturePromptDirectives.ts`;
- la función se renombra a `countConfiguredArchitectureDirectives()`;
- se actualizan los consumidores reales en Settings y Repository Analysis.

## Por qué

El helper no era un shared transversal del renderer, sino una pieza pequeña del dominio de configuración/prompting de Codex. El cambio mantiene comportamiento pero hace más claro el boundary y el ownership del código.

## Archivos principales

- `src/renderer/codex/architecturePromptDirectives.ts`
- `src/renderer/features/settings/presentation/components/CodexIntegration.shared.ts`
- `src/renderer/features/repository-analysis/presentation/components/RepositoryAnalysisShared.tsx`

## Validación

Ejecutado:

```bash
npm test -- --runInBand tests/integration/renderer/settings.page.dom.test.js tests/integration/renderer/repository-analysis.page.dom.test.js
```
