### PR TITLE
refactor: limpiar contratos legacy de Azure en repository-source storage

### DIFF
--- a/src/renderer/features/repository-source/application/repositorySourcePersistence.ts
+++ b/src/renderer/features/repository-source/application/repositorySourcePersistence.ts
@@ -2,7 +2,6 @@ import type { ReviewItem } from '../../../../types/repository';
 import { persistDashboardSnapshot } from '../../history';
 import { buildDashboardSummary } from '../../../shared/dashboard/summary';
 import { buildScopeLabel } from './repositorySourceDiagnostics';
-import { persistSavedAzureContext } from '../data/repositorySourceStorage';
 import type { SavedConnectionConfig } from '../types';
 
 export function persistRepositorySourceSnapshot(
@@ -12,7 +11,6 @@ export function persistRepositorySourceSnapshot(
   targetReviewer?: string,
 ): void {
   const effectiveScopeLabel = buildScopeLabel(config, null, null);
-  persistSavedAzureContext(config);
   const snapshotSummary = buildDashboardSummary(result, snapshotTimestamp, effectiveScopeLabel, targetReviewer);
 
   persistDashboardSnapshot({

--- a/src/renderer/features/repository-source/data/repositorySourceStorage.ts
+++ b/src/renderer/features/repository-source/data/repositorySourceStorage.ts
@@ -2,10 +2,12 @@ import type { SavedConnectionConfig } from '../types';
 import { loadStoredObject, removeStoredKeys, saveStoredObject } from '../../../shared/storage/jsonStorage';
 import { getSessionSecret, setSessionSecret } from '../../../shared/storage/sessionSecrets';
 
-export const REPOSITORY_SOURCE_STORAGE_KEY = 'checkpr.azure.config';
 export const REPOSITORY_SOURCE_SESSION_CONFIG_KEY = 'checkpr.repository.session.config';
-export const REPOSITORY_SOURCE_SESSION_PAT_KEY = 'checkpr.azure.session.pat';
-export const REPOSITORY_SOURCE_SAVED_CONTEXTS_KEY = 'checkpr.azure.saved-contexts';
+export const REPOSITORY_SOURCE_SESSION_SECRET_KEY = 'checkpr.repository.session.pat';
+
+const LEGACY_REPOSITORY_SOURCE_LOCAL_CONFIG_KEY = 'checkpr.azure.config';
+const LEGACY_REPOSITORY_SOURCE_SESSION_SECRET_KEY = 'checkpr.azure.session.pat';
+const LEGACY_REPOSITORY_SOURCE_SAVED_CONTEXTS_KEY = 'checkpr.azure.saved-contexts';
 
 export const defaultConnectionConfig: SavedConnectionConfig = {
   provider: '',
@@ -16,8 +18,15 @@ export const defaultConnectionConfig: SavedConnectionConfig = {
   targetReviewer: '',
 };
 
+function clearLegacyRepositorySourceStorage(): void {
+  removeStoredKeys(window.localStorage, [
+    LEGACY_REPOSITORY_SOURCE_LOCAL_CONFIG_KEY,
+    LEGACY_REPOSITORY_SOURCE_SAVED_CONTEXTS_KEY,
+  ]);
+}
+
 export function loadConnectionConfig(): SavedConnectionConfig {
-  removeStoredKeys(window.localStorage, [REPOSITORY_SOURCE_STORAGE_KEY, REPOSITORY_SOURCE_SAVED_CONTEXTS_KEY]);
+  clearLegacyRepositorySourceStorage();
 
   return {
     ...loadStoredObject<SavedConnectionConfig>(window.sessionStorage, REPOSITORY_SOURCE_SESSION_CONFIG_KEY, defaultConnectionConfig),
@@ -26,7 +35,20 @@ export function loadConnectionConfig(): SavedConnectionConfig {
 }
 
 export async function hydrateConnectionSecret(): Promise<string> {
-  return getSessionSecret(REPOSITORY_SOURCE_SESSION_PAT_KEY);
+  const storedSecret = await getSessionSecret(REPOSITORY_SOURCE_SESSION_SECRET_KEY);
+
+  if (storedSecret) {
+    return storedSecret;
+  }
+
+  const legacySecret = await getSessionSecret(LEGACY_REPOSITORY_SOURCE_SESSION_SECRET_KEY);
+  if (!legacySecret) {
+    return '';
+  }
+
+  await setSessionSecret(REPOSITORY_SOURCE_SESSION_SECRET_KEY, legacySecret);
+  await setSessionSecret(LEGACY_REPOSITORY_SOURCE_SESSION_SECRET_KEY, '');
+  return legacySecret;
 }
 
 export async function persistConnectionConfig(config: SavedConnectionConfig): Promise<void> {
@@ -35,16 +57,7 @@ export async function persistConnectionConfig(config: SavedConnectionConfig): Pr
     personalAccessToken: '',
   };
   saveStoredObject(window.sessionStorage, REPOSITORY_SOURCE_SESSION_CONFIG_KEY, safeConfig);
-  await setSessionSecret(REPOSITORY_SOURCE_SESSION_PAT_KEY, config.personalAccessToken);
-  removeStoredKeys(window.localStorage, [REPOSITORY_SOURCE_STORAGE_KEY]);
-}
-
-export function loadSavedAzureContexts(): never[] {
-  removeStoredKeys(window.localStorage, [REPOSITORY_SOURCE_SAVED_CONTEXTS_KEY]);
-  return [];
-}
-
-export function persistSavedAzureContext(config: SavedConnectionConfig): void {
-  void config;
-  removeStoredKeys(window.localStorage, [REPOSITORY_SOURCE_SAVED_CONTEXTS_KEY]);
+  await setSessionSecret(REPOSITORY_SOURCE_SESSION_SECRET_KEY, config.personalAccessToken);
+  await setSessionSecret(LEGACY_REPOSITORY_SOURCE_SESSION_SECRET_KEY, '');
+  clearLegacyRepositorySourceStorage();
 }

--- a/tests/unit/renderer/repository-source-persistence.test.js
+++ b/tests/unit/renderer/repository-source-persistence.test.js
@@ -2,10 +2,6 @@ jest.mock('../../../src/renderer/features/history/data/historyStorage', () => ({
   persistDashboardSnapshot: jest.fn(),
 }));
 
-jest.mock('../../../src/renderer/features/repository-source/data/repositorySourceStorage', () => ({
-  persistSavedAzureContext: jest.fn(),
-}));
-
 jest.mock('../../../src/renderer/shared/dashboard/summary', () => ({
   buildDashboardSummary: jest.fn(() => ({
     activePRs: 4,
@@ -20,7 +16,6 @@ jest.mock('../../../src/renderer/shared/dashboard/summary', () => ({
 }));
 
 const { persistDashboardSnapshot } = require('../../../src/renderer/features/history/data/historyStorage');
-const { persistSavedAzureContext } = require('../../../src/renderer/features/repository-source/data/repositorySourceStorage');
 const { persistRepositorySourceSnapshot } = require('../../../src/renderer/features/repository-source/application/repositorySourcePersistence');
 
 describe('repository source persistence', () => {
@@ -36,7 +31,6 @@ describe('repository source persistence', () => {
       targetReviewer: '',
     }, [], timestamp);
 
-    expect(persistSavedAzureContext).toHaveBeenCalled();
     expect(persistDashboardSnapshot).toHaveBeenCalledWith(expect.objectContaining({
       id: `${timestamp.toISOString()}-acme / Todos los repositorios`,
       activePRs: 4,

--- a/tests/unit/renderer/repository-source-snapshot-persistence.dom.test.js
+++ b/tests/unit/renderer/repository-source-snapshot-persistence.dom.test.js
@@ -4,10 +4,6 @@ jest.mock('../../../src/renderer/features/history/data/historyStorage', () => ({
   persistDashboardSnapshot: jest.fn(),
 }));
 
-jest.mock('../../../src/renderer/features/repository-source/data/repositorySourceStorage', () => ({
-  persistSavedAzureContext: jest.fn(),
-}));
-
 jest.mock('../../../src/renderer/shared/dashboard/summary', () => ({
   buildDashboardSummary: jest.fn(() => ({
     activePRs: 3,
@@ -22,7 +18,6 @@ jest.mock('../../../src/renderer/shared/dashboard/summary', () => ({
 }));
 
 const { persistDashboardSnapshot } = require('../../../src/renderer/features/history/data/historyStorage');
-const { persistSavedAzureContext } = require('../../../src/renderer/features/repository-source/data/repositorySourceStorage');
 const { useRepositorySourceSnapshotPersistence } = require('../../../src/renderer/features/repository-source/presentation/hooks/useRepositorySourceSnapshotPersistence');
 
 describe('useRepositorySourceSnapshotPersistence', () => {
@@ -47,11 +42,6 @@ describe('useRepositorySourceSnapshotPersistence', () => {
 
     result.current([{ id: 1, title: 'PR', url: 'https://example.com/pr/1' }], timestamp, 'ignored', 'ian');
 
-    expect(persistSavedAzureContext).toHaveBeenCalledWith(expect.objectContaining({
-      organization: 'org-a',
-      project: 'platform',
-      repositoryId: 'repo-a',
-    }));
     expect(persistDashboardSnapshot).toHaveBeenCalledWith(expect.objectContaining({
       scopeLabel: 'org-a / platform / Todos los repositorios',
       activePRs: 3,

--- a/tests/unit/renderer/repository-source-storage.dom.test.js
+++ b/tests/unit/renderer/repository-source-storage.dom.test.js
@@ -18,8 +18,8 @@ describe('repository source storage', () => {
       project: 'repo-a',
       repositoryId: 'repo-a',
     }));
-    window.localStorage.setItem(storage.REPOSITORY_SOURCE_STORAGE_KEY, 'legacy');
-    window.localStorage.setItem(storage.REPOSITORY_SOURCE_SAVED_CONTEXTS_KEY, 'legacy-contexts');
+    window.localStorage.setItem('checkpr.azure.config', 'legacy');
+    window.localStorage.setItem('checkpr.azure.saved-contexts', 'legacy-contexts');
 
     const config = storage.loadConnectionConfig();
 
@@ -30,8 +30,8 @@ describe('repository source storage', () => {
       repositoryId: 'repo-a',
       personalAccessToken: '',
     });
-    expect(window.localStorage.getItem(storage.REPOSITORY_SOURCE_STORAGE_KEY)).toBeNull();
-    expect(window.localStorage.getItem(storage.REPOSITORY_SOURCE_SAVED_CONTEXTS_KEY)).toBeNull();
+    expect(window.localStorage.getItem('checkpr.azure.config')).toBeNull();
+    expect(window.localStorage.getItem('checkpr.azure.saved-contexts')).toBeNull();
   });
 
   test('persistConnectionConfig guarda config segura y secreto en sesion', async () => {
@@ -55,15 +55,45 @@ describe('repository source storage', () => {
       targetReviewer: 'ian',
     });
     expect(window.electronApi.invoke).toHaveBeenCalledWith('session-secrets:set', {
-      key: storage.REPOSITORY_SOURCE_SESSION_PAT_KEY,
+      key: storage.REPOSITORY_SOURCE_SESSION_SECRET_KEY,
       value: 'secret',
     });
   });
 
   test('hydrateConnectionSecret lee el secreto desde ipc', async () => {
-    window.electronApi.invoke.mockResolvedValue({ ok: true, data: 'stored-secret' });
+    window.electronApi.invoke.mockImplementation(async (channel, key) => {
+      if (channel === 'session-secrets:get' && key === storage.REPOSITORY_SOURCE_SESSION_SECRET_KEY) {
+        return { ok: true, data: 'stored-secret' };
+      }
+
+      return { ok: true, data: '' };
+    });
 
     await expect(storage.hydrateConnectionSecret()).resolves.toBe('stored-secret');
+  });
+
+  test('hydrateConnectionSecret migra el secreto legacy si existe', async () => {
+    window.electronApi.invoke.mockImplementation(async (channel, payload) => {
+      if (channel === 'session-secrets:get' && payload === storage.REPOSITORY_SOURCE_SESSION_SECRET_KEY) {
+        return { ok: true, data: '' };
+      }
+
+      if (channel === 'session-secrets:get' && payload === 'checkpr.azure.session.pat') {
+        return { ok: true, data: 'legacy-secret' };
+      }
+
+      return { ok: true, data: null };
+    });
+
+    await expect(storage.hydrateConnectionSecret()).resolves.toBe('legacy-secret');
+    expect(window.electronApi.invoke).toHaveBeenCalledWith('session-secrets:set', {
+      key: storage.REPOSITORY_SOURCE_SESSION_SECRET_KEY,
+      value: 'legacy-secret',
+    });
+    expect(window.electronApi.invoke).toHaveBeenCalledWith('session-secrets:set', {
+      key: 'checkpr.azure.session.pat',
+      value: '',
+    });
   });
 
   test('loadConnectionConfig tolera JSON invalido en sesion', () => {
@@ -109,12 +139,23 @@ describe('repository source storage', () => {
     }
   });
 
-  test('saved azure contexts sigue deshabilitado y limpia legacy', () => {
-    window.localStorage.setItem(storage.REPOSITORY_SOURCE_SAVED_CONTEXTS_KEY, 'legacy-contexts');
+  test('persistConnectionConfig limpia storage legacy y el secreto azure anterior', async () => {
+    window.localStorage.setItem('checkpr.azure.config', 'legacy');
+    window.localStorage.setItem('checkpr.azure.saved-contexts', 'legacy-contexts');
+    window.electronApi.invoke.mockResolvedValue({ ok: true, data: null });
 
-    expect(storage.loadSavedAzureContexts()).toEqual([]);
-    storage.persistSavedAzureContext(storage.defaultConnectionConfig);
+    await storage.persistConnectionConfig({
+      ...storage.defaultConnectionConfig,
+      provider: 'github',
+      organization: 'acme',
+      personalAccessToken: 'secret',
+    });
 
-    expect(window.localStorage.getItem(storage.REPOSITORY_SOURCE_SAVED_CONTEXTS_KEY)).toBeNull();
+    expect(window.localStorage.getItem('checkpr.azure.config')).toBeNull();
+    expect(window.localStorage.getItem('checkpr.azure.saved-contexts')).toBeNull();
+    expect(window.electronApi.invoke).toHaveBeenCalledWith('session-secrets:set', {
+      key: 'checkpr.azure.session.pat',
+      value: '',
+    });
   });
 });


### PR DESCRIPTION
## Resumen

Este PR limpia contratos legacy de Azure dentro del storage de `repository-source` y deja la persistencia alineada con el dominio multi-provider actual.

Closes #15

## Qué cambia

- reemplaza la key activa del secreto de sesión por una key neutral: `checkpr.repository.session.pat`;
- migra automáticamente secretos guardados en la key legacy `checkpr.azure.session.pat`;
- limpia claves legacy de `localStorage` en una rutina explícita;
- elimina APIs públicas engañosas que no hacían persistencia real:
  - `loadSavedAzureContexts()`
  - `persistSavedAzureContext()`
- actualiza los tests del storage y de la persistencia derivada.

## Impacto

- el storage deja de exponer semántica Azure en el contrato vigente;
- los secretos ya guardados no se pierden: se migran al nuevo nombre al hidratar;
- se reduce ruido conceptual en `repository-source` y desaparecen helpers no-op con naming engañoso.

## Archivos principales

- `src/renderer/features/repository-source/data/repositorySourceStorage.ts`
- `src/renderer/features/repository-source/application/repositorySourcePersistence.ts`
- `tests/unit/renderer/repository-source-storage.dom.test.js`
- `tests/unit/renderer/repository-source-persistence.test.js`
- `tests/unit/renderer/repository-source-snapshot-persistence.dom.test.js`

## Validación

Ejecutado:

```bash
npm test -- --runInBand tests/unit/renderer/repository-source-storage.dom.test.js tests/unit/renderer/repository-source-persistence.test.js tests/unit/renderer/repository-source-snapshot-persistence.dom.test.js
```
