### PR TITLE
refactor: simplificar el bootstrap de repository-source

### DIFF
--- a/src/renderer/features/repository-source/application/repositorySourceRules.ts
+++ b/src/renderer/features/repository-source/application/repositorySourceRules.ts
@@ -16,3 +16,6 @@ export function hasMinimumRepositoryConfig(config: SavedConnectionConfig): boole
   return Boolean(config.organization && config.project && config.personalAccessToken);
 }
 
+export function hasMinimumPullRequestSyncConfig(config: SavedConnectionConfig): boolean {
+  return hasMinimumRepositoryConfig(config);
+}

--- a/src/renderer/features/repository-source/presentation/hooks/useRepositorySource.ts
+++ b/src/renderer/features/repository-source/presentation/hooks/useRepositorySource.ts
@@ -13,7 +13,7 @@ export function useRepositorySource() {
     onConfigChangeStart: (name, value) => facadeRef.current?.current?.onConfigChangeStart(name, value),
     onProjectSelected: (project) => facadeRef.current?.current?.onProjectSelected(project),
   });
-  const { config, configRef, updateConfig, selectProjectConfig, hydrateSecret } = configHook;
+  const { config, configRef, updateConfig, selectProjectConfig, applyHydratedSecret, hydrateSecret } = configHook;
   const { activeProviderName, baseScopeLabel } = useRepositorySourceMetadata(config);
   const persistSnapshot = useRepositorySourceSnapshotPersistence(configRef);
 
@@ -58,9 +58,8 @@ export function useRepositorySource() {
   });
 
   useRepositorySourceBootstrap({
-    configRef,
+    applyHydratedSecret,
     hydrateSecret,
-    updateConfig,
     refreshPullRequests,
   });
 
@@ -91,4 +90,3 @@ export function useRepositorySource() {
     openConnectionPanel,
   };
 }
-

--- a/src/renderer/features/repository-source/presentation/hooks/useRepositorySourceBootstrap.ts
+++ b/src/renderer/features/repository-source/presentation/hooks/useRepositorySourceBootstrap.ts
@@ -1,41 +1,36 @@
 import React from 'react';
+import { hasMinimumPullRequestSyncConfig } from '../../application/repositorySourceRules';
 import type { SavedConnectionConfig } from '../../types';
 
 interface UseRepositorySourceBootstrapOptions {
-  configRef: React.MutableRefObject<SavedConnectionConfig>;
   hydrateSecret: () => Promise<string>;
-  updateConfig: (name: keyof SavedConnectionConfig, value: string) => void;
+  applyHydratedSecret: (value: string) => SavedConnectionConfig;
   refreshPullRequests: () => Promise<void>;
 }
 
 export function useRepositorySourceBootstrap({
-  configRef,
   hydrateSecret,
-  updateConfig,
+  applyHydratedSecret,
   refreshPullRequests,
 }: UseRepositorySourceBootstrapOptions) {
   React.useEffect(() => {
-    void hydrateSecret().then((personalAccessToken) => {
-      if (!personalAccessToken) {
-        return;
-      }
+    let isMounted = true;
 
-      updateConfig('personalAccessToken', personalAccessToken);
+    void hydrateSecret()
+      .then((personalAccessToken) => {
+        if (!personalAccessToken || !isMounted) {
+          return;
+        }
 
-      const nextConfig = {
-        ...configRef.current,
-        personalAccessToken,
-      };
-      configRef.current = nextConfig;
+        const nextConfig = applyHydratedSecret(personalAccessToken);
+        if (hasMinimumPullRequestSyncConfig(nextConfig)) {
+          void refreshPullRequests();
+        }
+      })
+      .catch(() => undefined);
 
-      const hasMinimumConfig = nextConfig.provider === 'github' || nextConfig.provider === 'gitlab'
-        ? Boolean(nextConfig.organization && nextConfig.personalAccessToken)
-        : Boolean(nextConfig.provider && nextConfig.organization && nextConfig.project && nextConfig.personalAccessToken);
-
-      if (hasMinimumConfig) {
-        void refreshPullRequests();
-      }
-    }).catch(() => undefined);
-  // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
+    return () => {
+      isMounted = false;
+    };
+  }, [applyHydratedSecret, hydrateSecret, refreshPullRequests]);
 }

--- a/src/renderer/features/repository-source/presentation/hooks/useRepositorySourceConfig.ts
+++ b/src/renderer/features/repository-source/presentation/hooks/useRepositorySourceConfig.ts
@@ -11,6 +11,7 @@ interface UseRepositorySourceConfigResult {
   configRef: React.MutableRefObject<SavedConnectionConfig>;
   updateConfig: (name: keyof SavedConnectionConfig, value: string) => void;
   selectProjectConfig: (project: string) => void;
+  applyHydratedSecret: (value: string) => SavedConnectionConfig;
   hydrateSecret: () => Promise<string>;
 }
 
@@ -79,6 +80,17 @@ export function useRepositorySourceConfig(
     });
   }, [handlers]);
 
+  const applyHydratedSecret = React.useCallback((value: string) => {
+    const nextConfig = {
+      ...configRef.current,
+      personalAccessToken: value,
+    };
+
+    configRef.current = nextConfig;
+    setConfig(nextConfig);
+    return nextConfig;
+  }, []);
+
   const hydrateSecret = React.useCallback(() => hydrateConnectionSecret(), []);
 
   return {
@@ -86,6 +98,7 @@ export function useRepositorySourceConfig(
     configRef,
     updateConfig,
     selectProjectConfig,
+    applyHydratedSecret,
     hydrateSecret,
   };
 }

--- a/tests/unit/renderer/repository-source-config-hooks.dom.test.js
+++ b/tests/unit/renderer/repository-source-config-hooks.dom.test.js
@@ -180,51 +180,52 @@ describe('repository source config hooks', () => {
     await expect(result.current.hydrateSecret()).resolves.toBe('pat-session');
   });
 
+  test('useRepositorySourceConfig aplica el secreto hidratado sin disparar resets de config', async () => {
+    const handlers = {
+      onConfigChangeStart: jest.fn(),
+      onProjectSelected: jest.fn(),
+    };
+    const { result } = renderHook(() => useRepositorySourceConfig(handlers));
+
+    await act(async () => {
+      result.current.applyHydratedSecret('pat-session');
+    });
+
+    expect(handlers.onConfigChangeStart).not.toHaveBeenCalled();
+    expect(result.current.config.personalAccessToken).toBe('pat-session');
+    expect(result.current.configRef.current.personalAccessToken).toBe('pat-session');
+  });
+
   test('useRepositorySourceBootstrap restaura PAT y refresca cuando el config minimo existe', async () => {
     const refreshPullRequests = jest.fn().mockResolvedValue(undefined);
-    const updateConfig = jest.fn();
-    const configRef = {
-      current: {
-        provider: 'github',
-        organization: 'acme',
-        project: '',
-        repositoryId: '',
-        personalAccessToken: '',
-        targetReviewer: '',
-      },
-    };
+    const applyHydratedSecret = jest.fn((value) => ({
+      provider: 'github',
+      organization: 'acme',
+      project: '',
+      repositoryId: '',
+      personalAccessToken: value,
+      targetReviewer: '',
+    }));
 
     renderHook(() => useRepositorySourceBootstrap({
-      configRef,
       hydrateSecret: jest.fn().mockResolvedValue('pat-restored'),
-      updateConfig,
+      applyHydratedSecret,
       refreshPullRequests,
     }));
 
     await waitFor(() => {
-      expect(updateConfig).toHaveBeenCalledWith('personalAccessToken', 'pat-restored');
+      expect(applyHydratedSecret).toHaveBeenCalledWith('pat-restored');
       expect(refreshPullRequests).toHaveBeenCalled();
-      expect(configRef.current.personalAccessToken).toBe('pat-restored');
     });
   });
 
   test('useRepositorySourceBootstrap ignora errores de hidratacion y no refresca', async () => {
     const refreshPullRequests = jest.fn();
-    const updateConfig = jest.fn();
+    const applyHydratedSecret = jest.fn();
 
     renderHook(() => useRepositorySourceBootstrap({
-      configRef: {
-        current: {
-          provider: 'azure-devops',
-          organization: 'org-a',
-          project: 'project-a',
-          repositoryId: '',
-          personalAccessToken: '',
-          targetReviewer: '',
-        },
-      },
       hydrateSecret: jest.fn().mockRejectedValue(new Error('boom')),
-      updateConfig,
+      applyHydratedSecret,
       refreshPullRequests,
     }));
 
@@ -232,27 +233,17 @@ describe('repository source config hooks', () => {
       await Promise.resolve();
     });
 
-    expect(updateConfig).not.toHaveBeenCalled();
+    expect(applyHydratedSecret).not.toHaveBeenCalled();
     expect(refreshPullRequests).not.toHaveBeenCalled();
   });
 
   test('useRepositorySourceBootstrap no actualiza ni refresca si el secreto no existe', async () => {
     const refreshPullRequests = jest.fn();
-    const updateConfig = jest.fn();
+    const applyHydratedSecret = jest.fn();
 
     renderHook(() => useRepositorySourceBootstrap({
-      configRef: {
-        current: {
-          provider: 'github',
-          organization: 'acme',
-          project: '',
-          repositoryId: '',
-          personalAccessToken: '',
-          targetReviewer: '',
-        },
-      },
       hydrateSecret: jest.fn().mockResolvedValue(''),
-      updateConfig,
+      applyHydratedSecret,
       refreshPullRequests,
     }));
 
@@ -260,32 +251,29 @@ describe('repository source config hooks', () => {
       await Promise.resolve();
     });
 
-    expect(updateConfig).not.toHaveBeenCalled();
+    expect(applyHydratedSecret).not.toHaveBeenCalled();
     expect(refreshPullRequests).not.toHaveBeenCalled();
   });
 
   test('useRepositorySourceBootstrap restaura secreto pero no refresca si falta config minima', async () => {
     const refreshPullRequests = jest.fn();
-    const updateConfig = jest.fn();
+    const applyHydratedSecret = jest.fn((value) => ({
+      provider: 'azure-devops',
+      organization: 'acme',
+      project: '',
+      repositoryId: '',
+      personalAccessToken: value,
+      targetReviewer: '',
+    }));
 
     renderHook(() => useRepositorySourceBootstrap({
-      configRef: {
-        current: {
-          provider: 'azure-devops',
-          organization: 'acme',
-          project: '',
-          repositoryId: '',
-          personalAccessToken: '',
-          targetReviewer: '',
-        },
-      },
       hydrateSecret: jest.fn().mockResolvedValue('pat-restored'),
-      updateConfig,
+      applyHydratedSecret,
       refreshPullRequests,
     }));
 
     await waitFor(() => {
-      expect(updateConfig).toHaveBeenCalledWith('personalAccessToken', 'pat-restored');
+      expect(applyHydratedSecret).toHaveBeenCalledWith('pat-restored');
     });
 
     expect(refreshPullRequests).not.toHaveBeenCalled();


### PR DESCRIPTION
## Resumen

Este PR simplifica `useRepositorySourceBootstrap` para que deje de duplicar reglas de negocio, deje de mutar `configRef` manualmente y ya no dependa de un `eslint-disable` para funcionar.

Closes #17

## Qué cambia

- extrae la política de “config mínima suficiente para auto-sync” a `hasMinimumPullRequestSyncConfig()` en `application/repositorySourceRules.ts`;
- mueve la responsabilidad de aplicar el secreto hidratado al hook de configuración mediante `applyHydratedSecret()`;
- elimina la mutación manual de `configRef.current` dentro del bootstrap;
- elimina el `eslint-disable-next-line react-hooks/exhaustive-deps` y deja el effect con dependencias reales;
- amplía la cobertura de tests del wiring de configuración y bootstrap.

## Impacto

- el bootstrap queda con una responsabilidad mucho más acotada;
- desaparece la duplicación inline de reglas de negocio;
- el flujo de hidratación de secretos pasa a tener una sola fuente de verdad para actualizar `config` y `configRef`;
- el código queda más legible y más fácil de mantener.

## Archivos principales

- `src/renderer/features/repository-source/application/repositorySourceRules.ts`
- `src/renderer/features/repository-source/presentation/hooks/useRepositorySourceConfig.ts`
- `src/renderer/features/repository-source/presentation/hooks/useRepositorySourceBootstrap.ts`
- `src/renderer/features/repository-source/presentation/hooks/useRepositorySource.ts`
- `tests/unit/renderer/repository-source-config-hooks.dom.test.js`

## Validación

Ejecutado:

```bash
npm test -- --runInBand tests/unit/renderer/repository-source-config-hooks.dom.test.js tests/integration/renderer/use-repository-source-hooks.dom.test.js
```
