### PR TITLE
refactor: deduplicar el layout y contrato de modales en Settings

### DIFF
--- a/src/renderer/features/settings/presentation/components/SettingsIntegrationsPanel.tsx
+++ b/src/renderer/features/settings/presentation/components/SettingsIntegrationsPanel.tsx
@@ -6,8 +6,9 @@ import CodexIntegrationCard from './CodexIntegrationCard';
 import GlobalSnapshotPolicyCard from './GlobalSnapshotPolicyCard';
 import SettingsIntegrationActionCards from './SettingsIntegrationActionCards';
 import SettingsProviderModal from './SettingsProviderModal';
+import SettingsSectionModal from './SettingsSectionModal';
 import type { SettingsProviderConnectionProps } from './SettingsProvider.types';
-import { SettingsModal, SettingsSectionCard, SettingsStatusBadge } from '../../../../ui/configuration/ConfigurationPrimitives';
+import { SettingsSectionCard, SettingsStatusBadge } from '../../../../ui/configuration/ConfigurationPrimitives';
 
 export function SettingsIntegrationsSection({
   activeProvider,
@@ -45,6 +46,22 @@ export function SettingsIntegrationsSection({
   const [isSnapshotModalOpen, setIsSnapshotModalOpen] = React.useState(false);
 
   const activeProviderLabel = config.provider ? activeProviderName : 'No seleccionado';
+  const providerConnectionProps: SettingsProviderConnectionProps = {
+    activeProviderName,
+    config,
+    error,
+    isConnectionReady,
+    isLoading,
+    projects,
+    projectsLoading,
+    projectDiscoveryWarning,
+    repositories,
+    repositoriesLoading,
+    discoverProjects,
+    selectProject,
+    updateConfig,
+    refreshPullRequests,
+  };
 
   return (
     <section className="space-y-6">
@@ -72,23 +89,10 @@ export function SettingsIntegrationsSection({
         isOpen={isProviderModalOpen}
         onClose={() => setIsProviderModalOpen(false)}
         activeProvider={activeProvider}
-        activeProviderName={activeProviderName}
-        config={config}
-        error={error}
-        isConnectionReady={isConnectionReady}
-        isLoading={isLoading}
-        projects={projects}
-        projectsLoading={projectsLoading}
-        projectDiscoveryWarning={projectDiscoveryWarning}
-        repositories={repositories}
-        repositoriesLoading={repositoriesLoading}
-        discoverProjects={discoverProjects}
-        selectProject={selectProject}
-        updateConfig={updateConfig}
-        refreshPullRequests={refreshPullRequests}
+        connection={providerConnectionProps}
       />
 
-      <SettingsModal
+      <SettingsSectionModal
         isOpen={isCodexModalOpen}
         onClose={() => setIsCodexModalOpen(false)}
         title="Configuracion de Codex"
@@ -99,9 +103,9 @@ export function SettingsIntegrationsSection({
           isReady={isCodexReady}
           onChange={updateCodexConfig}
         />
-      </SettingsModal>
+      </SettingsSectionModal>
 
-      <SettingsModal
+      <SettingsSectionModal
         isOpen={isSnapshotModalOpen}
         onClose={() => setIsSnapshotModalOpen(false)}
         title="Reglas globales de snapshot"
@@ -111,7 +115,7 @@ export function SettingsIntegrationsSection({
           snapshotPolicy={codexConfig.snapshotPolicy}
           onChange={(value) => updateCodexConfig('snapshotPolicy', value)}
         />
-      </SettingsModal>
+      </SettingsSectionModal>
     </section>
   );
 }

--- a/src/renderer/features/settings/presentation/components/SettingsProviderModal.tsx
+++ b/src/renderer/features/settings/presentation/components/SettingsProviderModal.tsx
@@ -2,67 +2,40 @@ import React from 'react';
 import type { RepositoryProviderDefinition } from '../../../../../types/repository';
 import { RepositorySourceProviderCatalog } from '../../../repository-source';
 import RepositoryProviderCard from './RepositoryProviderCard';
-import { SettingsModal } from '../../../../ui/configuration/ConfigurationPrimitives';
+import SettingsSectionModal from './SettingsSectionModal';
 import type { SettingsProviderConnectionProps } from './SettingsProvider.types';
 
-interface SettingsProviderModalProps extends SettingsProviderConnectionProps {
+interface SettingsProviderModalProps {
   isOpen: boolean;
   onClose: () => void;
   activeProvider: RepositoryProviderDefinition | null;
+  connection: SettingsProviderConnectionProps;
 }
 
 const SettingsProviderModal = ({
   isOpen,
   onClose,
   activeProvider,
-  activeProviderName,
-  config,
-  error,
-  isConnectionReady,
-  isLoading,
-  projects,
-  projectsLoading,
-  projectDiscoveryWarning,
-  repositories,
-  repositoriesLoading,
-  discoverProjects,
-  selectProject,
-  updateConfig,
-  refreshPullRequests,
+  connection,
 }: SettingsProviderModalProps) => {
   return (
-    <SettingsModal
+    <SettingsSectionModal
       isOpen={isOpen}
       onClose={onClose}
       title="Configuracion de provider"
       description="Selecciona la fuente principal del workspace y completa su conexion sin cargar la vista principal."
     >
-      <div className="grid gap-4">
-        <RepositorySourceProviderCatalog
-          activeProvider={activeProvider}
-          activeProviderName={activeProviderName}
-          config={config}
-          error={error}
-          isConnectionReady={isConnectionReady}
-          isLoading={isLoading}
-          projects={projects}
-          projectsLoading={projectsLoading}
-          projectDiscoveryWarning={projectDiscoveryWarning}
-          repositories={repositories}
-          repositoriesLoading={repositoriesLoading}
-          discoverProjects={discoverProjects}
-          selectProject={selectProject}
-          updateConfig={updateConfig}
-          refreshPullRequests={refreshPullRequests}
-          renderProviderCard={(providerCardProps) => (
-            <RepositoryProviderCard
-              key={providerCardProps.provider.kind}
-              {...providerCardProps}
-            />
-          )}
-        />
-      </div>
-    </SettingsModal>
+      <RepositorySourceProviderCatalog
+        activeProvider={activeProvider}
+        {...connection}
+        renderProviderCard={(providerCardProps) => (
+          <RepositoryProviderCard
+            key={providerCardProps.provider.kind}
+            {...providerCardProps}
+          />
+        )}
+      />
+    </SettingsSectionModal>
   );
 };
 

--- a/src/renderer/features/settings/presentation/components/SettingsSectionModal.tsx
+++ b/src/renderer/features/settings/presentation/components/SettingsSectionModal.tsx
@@ -1,0 +1,33 @@
+import React from 'react';
+import { SettingsModal } from '../../../../ui/configuration/ConfigurationPrimitives';
+
+interface SettingsSectionModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+  title: string;
+  description: string;
+  children: React.ReactNode;
+  contentClassName?: string;
+}
+
+const SettingsSectionModal = ({
+  isOpen,
+  onClose,
+  title,
+  description,
+  children,
+  contentClassName = 'grid gap-4',
+}: SettingsSectionModalProps) => (
+  <SettingsModal
+    isOpen={isOpen}
+    onClose={onClose}
+    title={title}
+    description={description}
+  >
+    <div className={contentClassName}>
+      {children}
+    </div>
+  </SettingsModal>
+);
+
+export default SettingsSectionModal;


### PR DESCRIPTION
## Resumen
- extraer un componente `SettingsSectionModal` para encapsular el layout base de modales simples de Settings
- agrupar el contrato de conexión del provider en un único objeto `providerConnectionProps`
- reutilizar ese objeto tanto al abrir `SettingsProviderModal` como al renderizar `RepositorySourceProviderCatalog`

## Problema
`jscpd` estaba detectando duplicación entre `SettingsIntegrationsPanel.tsx` y `SettingsProviderModal.tsx`. El clon no estaba solo en el shell del modal, sino también en el listado repetido de props del contrato de conexión del provider.

Eso hacía más costoso cambiar el contrato o el wiring de Settings, y agregaba ruido en una zona del renderer donde ya estamos intentando simplificar composición y naming.

## Solución
Se aplica un refactor mínimo y localizado en la feature `settings`:
- se crea `SettingsSectionModal` para compartir la estructura de modales simples sin moverlo a `shared`
- se construye `providerConnectionProps` una sola vez en `SettingsIntegrationsPanel`
- `SettingsProviderModal` recibe ese objeto y lo propaga al catálogo mediante spread controlado

Con esto desaparece la duplicación reportada por `jscpd` sin cambiar comportamiento ni introducir una abstracción genérica innecesaria.

## Verificación
- `npx jscpd src/ --threshold 3`
- `npm test -- --runInBand tests/integration/renderer/settings.page.dom.test.js`

Closes #35
