### PR TITLE
docs: preparar el contenido completo de la wiki del proyecto

### DIFF
--- a/docs/wiki/Arquitectura-General.md
+++ b/docs/wiki/Arquitectura-General.md
@@ -1,0 +1,127 @@
+# Arquitectura General
+
+## Principios base
+
+El proyecto sigue una separacion pragmatica por runtime y responsabilidad:
+
+- `main` gestiona Electron, ventana e IPC;
+- `preload` expone solo capacidades permitidas;
+- `renderer` contiene la UI y la composicion por features;
+- `services` encapsula integraciones externas y fabricas de analisis;
+- `shared` y `types` deben mantenerse desacoplados de capas de aplicacion.
+
+No es una clean architecture academica pura, pero si tiene boundaries obligatorios y automatizados.
+
+## Capas principales
+
+### `src/main`
+
+Responsabilidades:
+
+- bootstrap de Electron;
+- configuracion de storage de app;
+- creacion de `BrowserWindow`;
+- registro de handlers IPC;
+- coordinacion de servicios de analisis y providers.
+
+Piezas importantes:
+
+- `src/main.ts`
+- `src/main/application-bootstrap.ts`
+- `src/main/main-window.ts`
+- `src/main/ipc/*`
+
+### `src/preload.ts`
+
+Responsabilidades:
+
+- validar canales IPC permitidos;
+- exponer `window.electronApi`;
+- evitar acceso directo del renderer a APIs nativas no aprobadas.
+
+Es una frontera de seguridad, no un lugar para meter logica de negocio.
+
+### `src/renderer`
+
+Responsabilidades:
+
+- paginas, componentes y contextos de UI;
+- hooks de composicion por feature;
+- estado de pantalla y flujos interactivos.
+
+Organizacion dominante:
+
+- `app/`: paginas y rutas;
+- `features/`: vertical slices del renderer;
+- `shared/`: layout y helpers compartidos del renderer;
+- `ui/`: primitives visuales reutilizables.
+
+### `src/services`
+
+Responsabilidades:
+
+- adaptadores hacia Azure, GitHub y GitLab;
+- factories de servicios de analisis;
+- composicion del registry de providers;
+- infraestructura compartida entre analisis y providers.
+
+### `src/shared` y `src/types`
+
+Regla clave:
+
+- no deben depender de `renderer`, `main` ni `services`.
+
+Se usan para contratos y utilitarios verdaderamente transversales.
+
+## Boundaries obligatorios
+
+El repo tiene enforcement explicito para:
+
+- `renderer` no importa `main` ni `services`;
+- `main` no importa `renderer`;
+- `services` no importa `main` ni `renderer`;
+- `shared` y `types` no dependen de capas de aplicacion;
+- `app` consume APIs publicas de features, no internals;
+- una feature del renderer no debe importar internals de otra feature;
+- `renderer/shared` no debe depender de internals de features.
+
+Estos checks viven principalmente en:
+
+- `scripts/check-renderer-architecture.js`
+- `.dependency-cruiser.cjs`
+
+## Runtime y direccion de dependencias
+
+```text
+Renderer UI
+  -> preload bridge
+  -> IPC
+  -> main
+  -> servicios / providers
+```
+
+Dentro del renderer:
+
+```text
+app
+  -> feature public APIs
+feature presentation
+  -> feature application/data
+shared/ui
+  -> sin depender de internals de features
+```
+
+## Decisiones importantes del proyecto
+
+- El provider activo y el estado operativo viven en el renderer bajo `repository-source`.
+- Los providers reales y el analisis corren del lado seguro, no en el renderer puro.
+- La app privilegia modales y workflows guiados para no saturar la vista principal.
+- El proyecto usa quality gates como linea base, no como “check opcional”.
+
+## Riesgos arquitectonicos recurrentes
+
+- reexportar demasiado desde una feature y volver opaca su API publica;
+- meter en `shared` cosas que siguen sesgadas a una feature;
+- acoplar features por imports a `data/` o `presentation/` de otras features;
+- duplicar condicionales por provider en varios puntos del renderer;
+- mezclar UI state, persistencia y reglas de negocio en un mismo hook.

--- a/docs/wiki/Calidad-Testing-y-Buenas-Practicas.md
+++ b/docs/wiki/Calidad-Testing-y-Buenas-Practicas.md
@@ -1,0 +1,88 @@
+# Calidad, Testing y Buenas Practicas
+
+## Filosofia del repo
+
+La calidad no depende solo de review manual. El proyecto intenta automatizar los proxies mas utiles de arquitectura sana y disciplina de cambio.
+
+## Quality gates
+
+Capas activas hoy:
+
+- lint;
+- typecheck;
+- chequeo de arquitectura custom;
+- reglas de capas con dependency-cruiser;
+- deteccion de ciclos;
+- deteccion de duplicacion con jscpd;
+- tests con coverage;
+- build productivo.
+
+Scripts principales:
+
+- `npm run guard:commit`
+- `npm run guard:push`
+- `npm run quality:check`
+
+CI:
+
+- `.github/workflows/quality-gate.yml`
+
+## Hooks locales
+
+El repo versiona hooks en `.githooks/`.
+
+- `pre-commit` corre el gate de commit;
+- `pre-push` corre el gate completo.
+
+Esto busca evitar que los checks vivan solo en CI.
+
+## Testing
+
+Capas de testing hoy:
+
+- unit tests de `main`;
+- unit tests de `renderer`;
+- unit tests de `services`;
+- integration tests del renderer;
+- e2e con Playwright.
+
+Estructura:
+
+- `tests/unit`
+- `tests/integration`
+- `tests/e2e`
+- `tests/support`
+
+## Buenas practicas de testing
+
+- cubrir regresiones reales, no solo snapshots triviales;
+- preferir tests focalizados cuando el cambio es arquitectonico;
+- si un hook orquesta mucho comportamiento, validar el caso feliz y la regresion concreta;
+- cuando un refactor cambia boundaries, agregar tests que hagan visible la nueva API publica;
+- no usar mocks que escondan precisamente el contrato que intentas proteger.
+
+## Buenas practicas de arquitectura
+
+- una feature consume solo la API publica de otra;
+- `shared` debe seguir siendo realmente compartido;
+- evita nombres legacy que distorsionen el dominio actual;
+- no mezcles persistencia, UI state y negocio en el mismo hook;
+- encapsula comportamiento variable por provider, no lo repitas;
+- si una abstraccion necesita `eslint-disable` para hooks o dependencias, probablemente haya que rediseñarla.
+
+## Buenas practicas de diseño de codigo
+
+- preferir cambios minimos y explicitos;
+- mantener ownership claro por modulo;
+- extraer helpers o componentes solo cuando reducen complejidad real;
+- evitar “Facade”, “Manager” u “Operations” cuando no agregan semantica;
+- no ampliar barrels sin pensar en la API publica real.
+
+## Checklist de revision tecnica
+
+- el cambio respeta boundaries entre layers y features;
+- no introduce nuevos imports a internals ajenos;
+- no deja duplicacion evitable;
+- no rompe tests focalizados del area;
+- mantiene naming alineado al dominio actual;
+- no expone secretos ni abre canales IPC innecesarios.

--- a/docs/wiki/Desarrollo-Local-y-Build.md
+++ b/docs/wiki/Desarrollo-Local-y-Build.md
@@ -1,0 +1,91 @@
+# Desarrollo Local y Build
+
+## Requisitos
+
+- Node.js 20 o superior recomendado;
+- npm;
+- sistema operativo compatible con Electron.
+
+## Instalacion
+
+```bash
+npm install
+```
+
+El `prepare` del repo configura `core.hooksPath` para usar hooks versionados en `.githooks/`.
+
+## Desarrollo diario
+
+Comando recomendado:
+
+```bash
+npm run start
+```
+
+Alias:
+
+```bash
+npm run dev
+```
+
+Este flujo:
+
+- compila `main` en watch;
+- levanta `webpack-dev-server`;
+- espera renderer y `dist/main.js`;
+- abre Electron apuntando al renderer de desarrollo.
+
+## Build
+
+Build productivo:
+
+```bash
+npm run build
+```
+
+Empaquetado:
+
+```bash
+npm run build:prod
+```
+
+## Scripts utiles
+
+### Desarrollo
+
+- `npm run start`
+- `npm run dev`
+- `npm run watch`
+
+### Testing
+
+- `npm run test`
+- `npm run test:coverage`
+- `npm run test:e2e`
+- `npm run test:all`
+
+### Calidad
+
+- `npm run lint`
+- `npm run typecheck`
+- `npm run analyze:architecture`
+- `npm run analyze:cycles`
+- `npm run analyze:solid`
+- `npm run analyze:duplicates`
+- `npm run quality:check`
+
+## Flujo recomendado antes de abrir un PR
+
+1. `npm run lint`
+2. `npm run typecheck`
+3. `npm run analyze:architecture`
+4. `npm run analyze:solid`
+5. `npm run test`
+6. si el cambio toca runtime o empaquetado, `npm run build`
+
+## Notas practicas
+
+- si tocas boundaries entre features, corre `npm run analyze:architecture`;
+- si moviste naming o componentes parecidos, corre `npm run analyze:duplicates`;
+- si tocaste imports en cascada, corre `npm run analyze:cycles`;
+- si tocaste main/preload, no asumas que el renderer aislado valida esos cambios.

--- a/docs/wiki/Home.md
+++ b/docs/wiki/Home.md
@@ -1,0 +1,81 @@
+# CheckPR Desktop Wiki
+
+## Vision general
+
+CheckPR Desktop es una aplicacion de escritorio construida con Electron, React y TypeScript para centralizar trabajo operativo sobre repositorios y Pull Requests.
+
+El producto hoy cubre cuatro capacidades principales:
+
+- conexion a providers de repositorios;
+- exploracion de proyectos, repositorios, ramas y PRs;
+- analisis de repositorio por rama con snapshots;
+- flujos asistidos por IA para revision de PRs.
+
+El runtime soportado es Electron. El renderer por si solo no es un target web soportado porque depende de IPC y bridge nativo.
+
+## Estado funcional actual
+
+Providers soportados:
+
+- Azure DevOps
+- GitHub
+- GitLab
+
+Backlog declarado:
+
+- Bitbucket
+
+Features relevantes ya implementadas:
+
+- dashboard operativo con resumen y priorizacion;
+- configuracion simplificada por modales;
+- title bar custom integrada a la UI;
+- sincronizacion de proyectos, repositorios, ramas y pull requests;
+- repository analysis por rama;
+- revision AI de Pull Requests;
+- historial de snapshots del dashboard;
+- quality gates locales y en CI.
+
+## Stack principal
+
+- Electron
+- React 18
+- TypeScript
+- Webpack
+- Tailwind CSS
+- Jest + Testing Library
+- Playwright
+- ESLint
+- dependency-cruiser
+- jscpd
+
+## Mapa rapido del repo
+
+- `src/main`: proceso principal, ventana e IPC.
+- `src/preload.ts`: bridge seguro entre renderer y Electron.
+- `src/renderer`: aplicacion UI organizada por features.
+- `src/services`: integraciones con providers y servicios de analisis.
+- `src/shared`: contratos y utilitarios transversales.
+- `src/types`: tipos compartidos del dominio.
+- `tests`: unitarios, integracion y e2e.
+- `scripts`: quality gates y chequeos arquitectonicos.
+
+## Flujo de uso esperado
+
+1. Abrir `Settings`.
+2. Configurar provider, scope y token.
+3. Sincronizar proyectos o repositorios.
+4. Revisar el `Dashboard`.
+5. Ejecutar `Repository Analysis` sobre una rama.
+6. Lanzar analisis AI de Pull Requests si Codex/OpenAI esta configurado.
+7. Revisar `History` para comparar snapshots.
+
+## Documentacion recomendada
+
+- [Arquitectura General](Arquitectura-General)
+- [Renderer y Features](Renderer-y-Features)
+- [Main, Preload e IPC](Main-Preload-e-IPC)
+- [Servicios y Providers](Servicios-y-Providers)
+- [Desarrollo Local y Build](Desarrollo-Local-y-Build)
+- [Calidad, Testing y Buenas Practicas](Calidad-Testing-y-Buenas-Practicas)
+- [Publicacion del Wiki](Publicacion-del-Wiki)

--- a/docs/wiki/Main-Preload-e-IPC.md
+++ b/docs/wiki/Main-Preload-e-IPC.md
@@ -1,0 +1,92 @@
+# Main, Preload e IPC
+
+## Proceso principal
+
+El entrypoint real es `src/main.ts`.
+
+Secuencia principal:
+
+1. configura paths de storage;
+2. define `AppUserModelId`;
+3. al hacer `app.whenReady()` bootstrappea servicios y handlers;
+4. crea la ventana principal;
+5. maneja comportamiento de cierre y reactivacion en macOS.
+
+## Creacion de ventana
+
+`src/main/main-window.ts` define:
+
+- `frame: false`
+- `titleBarStyle: hidden`
+- `backgroundColor`
+- `preload: dist/preload.js`
+- `nodeIntegration: false`
+- `contextIsolation: true`
+- `sandbox: true`
+
+Esto confirma que la UI depende del bridge seguro y no del acceso libre a Node.
+
+## Bootstrap de aplicacion
+
+`src/main/application-bootstrap.ts` compone:
+
+- registry de providers;
+- `repositoryAnalysisService`;
+- `pullRequestAnalysisService`;
+- registro de handlers IPC;
+- creacion de la ventana principal.
+
+## Preload
+
+`src/preload.ts` es una whitelist de canales.
+
+Canales permitidos hoy:
+
+- window controls;
+- repository source;
+- repository analysis;
+- pull request AI analysis;
+- session secrets.
+
+No deberian agregarse canales “por comodidad”. Cada nuevo canal es una decision de seguridad y arquitectura.
+
+## IPC
+
+Los handlers IPC viven en `src/main/ipc/`.
+
+Responsabilidades tipicas:
+
+- saneamiento de payloads;
+- adaptacion entre renderer y servicios;
+- apertura de enlaces externos;
+- control de ventana;
+- acceso a secretos de sesion.
+
+## Regla de seguridad
+
+El renderer no debe tener acceso directo a APIs nativas.
+
+Todo acceso a Electron debe pasar por:
+
+1. `window.electronApi` en preload;
+2. canal permitido;
+3. handler registrado en `main`.
+
+## Buenas practicas para nuevos handlers
+
+- definir el canal en preload y mantener la whitelist acotada;
+- validar datos de entrada en `main`;
+- tipar payload y respuesta;
+- evitar meter logica de negocio pesada en el handler;
+- delegar a servicios y use cases ya existentes;
+- si el canal opera sobre archivos o red, dejar claro su ownership.
+
+## Controles de ventana
+
+El proyecto usa title bar custom.
+
+Eso implica:
+
+- sincronizacion de estado de ventana hacia el renderer;
+- manejo especial en macOS para full screen;
+- cuidado extra al cambiar maximize/minimize/full screen para no romper la semantica nativa.

--- a/docs/wiki/Publicacion-del-Wiki.md
+++ b/docs/wiki/Publicacion-del-Wiki.md
@@ -1,0 +1,43 @@
+# Publicacion del Wiki
+
+## Estado actual
+
+El contenido del Wiki vive en `docs/wiki/` como fuente versionada dentro del repo principal.
+
+Esto se hizo porque el wiki de GitHub del repositorio aun no tiene una primera pagina materializada, y GitHub no expone una API oficial para crearla programaticamente.
+
+Mientras el wiki no tenga esa primera pagina inicial, la URL:
+
+`https://github.com/IanStuardo-Dev/electron-checkPR/wiki`
+
+redirige al repo principal y el remoto `.wiki.git` responde `Repository not found`.
+
+## Como publicarlo cuando el wiki quede inicializado
+
+1. Crear manualmente una primera pagina vacia o minima desde la UI de GitHub Wiki.
+2. Clonar el repo del wiki:
+
+```bash
+git clone https://github.com/IanStuardo-Dev/electron-checkPR.wiki.git
+```
+
+3. Copiar el contenido de `docs/wiki/` al repo del wiki.
+4. Confirmar que al menos existan:
+   - `Home.md`
+   - `_Sidebar.md`
+5. Commit y push:
+
+```bash
+git add .
+git commit -m "Seed project wiki"
+git push origin master
+```
+
+## Recomendacion
+
+Mantener `docs/wiki/` como source of truth aun despues de publicar el wiki ayuda a:
+
+- versionar la documentacion junto con el codigo;
+- revisar cambios de documentacion en PRs;
+- evitar perder contexto si alguien edita el wiki manualmente;
+- resincronizar rapidamente el wiki si GitHub cambia algo o se recrea.

--- a/docs/wiki/Renderer-y-Features.md
+++ b/docs/wiki/Renderer-y-Features.md
@@ -1,0 +1,112 @@
+# Renderer y Features
+
+## Estructura del renderer
+
+El renderer esta organizado alrededor de `src/renderer/app` y `src/renderer/features`.
+
+### `app`
+
+Contiene paginas y ruteo:
+
+- `Dashboard`
+- `RepositoryAnalysis`
+- `Settings`
+
+`WorkspaceRoutes.tsx` monta `RepositorySourceProvider` y envuelve las rutas con `Suspense`.
+
+### `features`
+
+Features principales hoy:
+
+- `repository-source`
+- `repository-analysis`
+- `pull-request-ai`
+- `dashboard`
+- `history`
+- `settings`
+
+Cada feature deberia exponer una API publica clara desde su `index.ts`.
+
+## Feature: `repository-source`
+
+Es la pieza central del workspace operativo.
+
+Responsabilidades:
+
+- configurar provider, organization, project y repository;
+- sincronizar proyectos, repositorios y PRs;
+- exponer el contexto operativo del provider activo;
+- construir diagnostico y snapshots del dashboard.
+
+Partes clave:
+
+- `presentation/context/RepositorySourceContext.tsx`
+- `presentation/hooks/useRepositorySource.ts`
+- `application/*`
+- `data/*`
+
+Es la feature mas sensible desde el punto de vista arquitectonico porque muchas otras dependen de su API publica.
+
+## Feature: `repository-analysis`
+
+Responsabilidades:
+
+- preparar el request de analisis de repositorio;
+- seleccionar rama;
+- ejecutar y cancelar analisis;
+- mostrar resultados y snapshots.
+
+Debe depender de la API publica de `repository-source`, nunca de internals.
+
+## Feature: `pull-request-ai`
+
+Responsabilidades:
+
+- disparar analisis AI de PRs;
+- resumir hallazgos;
+- mostrar resultados de revision asistida.
+
+Se apoya en la configuracion de Codex y en snapshots/servicios de analisis.
+
+## Feature: `settings`
+
+Responsabilidades:
+
+- concentrar configuracion de provider;
+- configurar integracion Codex/OpenAI;
+- exponer diagnostico y politicas globales.
+
+La tendencia actual del proyecto es mantener `Settings` simplificado y mover detalle tecnico a modales dedicados.
+
+## Feature: `dashboard`
+
+Responsabilidades:
+
+- mostrar resumen operativo del workspace;
+- priorizar PRs;
+- resumir carga de trabajo, riesgo y backlog.
+
+## Feature: `history`
+
+Responsabilidades:
+
+- persistir y mostrar snapshots historicos del dashboard;
+- servir de capa de almacenamiento para comparativas de estado.
+
+## Que deberia quedar fuera del renderer
+
+No deberia vivir en el renderer:
+
+- acceso nativo directo a Electron;
+- logica de provider que dependa de APIs remotas;
+- secretos persistidos en disco fuera de canales controlados;
+- validaciones de seguridad del request que correspondan a `main`.
+
+## Buenas practicas al trabajar en features
+
+- exponer contratos publicos pequenos desde `index.ts`;
+- preferir nombres que expresen intencion y ownership;
+- evitar hooks “fachada” que solo reenvian llamadas sin agregar valor real;
+- no importar `data/`, `presentation/` o `application/` de otra feature;
+- si una regla cambia por provider, encapsularla en un contrato comun en vez de repetir ternarios;
+- cuando un modulo deja de ser realmente shared, devolverlo a su bounded context.

--- a/docs/wiki/Servicios-y-Providers.md
+++ b/docs/wiki/Servicios-y-Providers.md
@@ -1,0 +1,95 @@
+# Servicios y Providers
+
+## Objetivo de `src/services`
+
+La carpeta `src/services` concentra integraciones remotas y fabricas de servicios que no pertenecen al renderer.
+
+Subdominios principales:
+
+- `analysis`
+- `azure`
+- `github`
+- `gitlab`
+- `providers`
+- `shared`
+- `notifications`
+
+## Registry de providers
+
+`src/services/providers/repository-provider.bootstrap.ts` construye los puertos por defecto:
+
+- Azure DevOps
+- GitHub
+- GitLab
+
+La composicion usa un registry para que el resto del sistema no dependa de implementaciones concretas dispersas.
+
+## Providers soportados
+
+### Azure DevOps
+
+Cobertura relevante:
+
+- repositorios;
+- pull requests;
+- snapshots asociados a analisis.
+
+### GitHub
+
+Cobertura relevante:
+
+- listado de repositorios;
+- ramas;
+- pull requests;
+- snapshots de repositorio y PR.
+
+### GitLab
+
+Cobertura relevante:
+
+- proyectos;
+- merge requests;
+- snapshots y ramas.
+
+### Bitbucket
+
+Hoy aparece en tipos y UI de backlog, pero no como provider operativo en el bootstrap por defecto.
+
+## Servicios de analisis
+
+El proyecto tiene dos grandes fabricas:
+
+- repository analysis
+- pull request analysis
+
+Ambas usan snapshot providers que dependen del registry de providers, no de un provider hardcodeado.
+
+## Responsabilidades correctas en servicios
+
+Deberian vivir aqui:
+
+- requests a APIs remotas;
+- normalizacion de respuestas;
+- armado de snapshots;
+- adaptacion de modelos remotos al dominio interno;
+- factories de servicios que ensamblan dependencias.
+
+No deberian vivir aqui:
+
+- componentes React;
+- hooks del renderer;
+- dependencias a `main` o `renderer`;
+- accesos directos a UI state.
+
+## Criterios para agregar un nuevo provider
+
+1. definir o extender el contrato del provider;
+2. implementar adaptadores del provider en `src/services/<provider>`;
+3. registrar el provider en el bootstrap;
+4. revisar tipos y metadata del renderer;
+5. encapsular diferencias de comportamiento en un lugar unico;
+6. agregar tests por servicio, boundaries y feature integration.
+
+## Olor comun a evitar
+
+Cuando una diferencia entre providers obliga a tocar varios hooks y utilitarios del renderer al mismo tiempo, probablemente falte una abstraccion de comportamiento por provider o un contrato mejor definido.

--- a/docs/wiki/_Sidebar.md
+++ b/docs/wiki/_Sidebar.md
@@ -1,0 +1,10 @@
+### CheckPR Desktop
+
+- [Home](Home)
+- [Arquitectura General](Arquitectura-General)
+- [Renderer y Features](Renderer-y-Features)
+- [Main, Preload e IPC](Main-Preload-e-IPC)
+- [Servicios y Providers](Servicios-y-Providers)
+- [Desarrollo Local y Build](Desarrollo-Local-y-Build)
+- [Calidad, Testing y Buenas Practicas](Calidad-Testing-y-Buenas-Practicas)
+- [Publicacion del Wiki](Publicacion-del-Wiki)


### PR DESCRIPTION
## Resumen
- agregar un seed completo de la Wiki del proyecto en `docs/wiki/`
- documentar arquitectura, runtime Electron, features, servicios, desarrollo local, calidad y buenas practicas
- dejar una guia explicita para sincronizar este contenido al Wiki de GitHub apenas exista la primera pagina inicial

## Contexto
Se pidio crear la Wiki del proyecto en GitHub con el mayor detalle posible. Durante la ejecucion se verifico que:
- el repo tiene `has_wiki = true`
- la URL `/wiki` todavia redirige al repo principal
- el remoto `electron-checkPR.wiki.git` responde `Repository not found`

Eso indica que el Wiki todavia no tiene una primera pagina materializada y GitHub no expone una API oficial para crear esa primera pagina de forma programatica.

## Que deja este PR
- contenido listo para Wiki en formato de paginas Markdown
- sidebar para navegacion
- documentacion tecnica bastante mas profunda que el README actual
- pagina de publicacion con el flujo para sincronizarlo al Wiki real cuando GitHub lo permita

## Paginas incluidas
- `Home`
- `Arquitectura General`
- `Renderer y Features`
- `Main, Preload e IPC`
- `Servicios y Providers`
- `Desarrollo Local y Build`
- `Calidad, Testing y Buenas Practicas`
- `Publicacion del Wiki`
