### PR TITLE
test: estabilizar la suite de main entre plataformas

### DIFF
--- a/tests/unit/main/main.test.js
+++ b/tests/unit/main/main.test.js
@@ -162,7 +162,10 @@ describe('main process bootstrap', () => {
 
   test('window-all-closed cierra la app fuera de macOS', () => {
     const windowAllClosedHandler = registeredAppEvents.get('window-all-closed');
-    windowAllClosedHandler();
+
+    withPlatform('win32', () => {
+      windowAllClosedHandler();
+    });
 
     expect(appQuit).toHaveBeenCalled();
   });

--- a/tests/unit/main/window-controls.test.js
+++ b/tests/unit/main/window-controls.test.js
@@ -20,6 +20,21 @@ const {
   registerWindowControlsIpc,
 } = require('../../../src/main/ipc/window-controls');
 
+function withPlatform(platform, callback) {
+  const originalDescriptor = Object.getOwnPropertyDescriptor(process, 'platform');
+
+  Object.defineProperty(process, 'platform', {
+    configurable: true,
+    value: platform,
+  });
+
+  try {
+    callback();
+  } finally {
+    Object.defineProperty(process, 'platform', originalDescriptor);
+  }
+}
+
 function createTargetWindow(overrides = {}) {
   const listeners = {};
   const targetWindow = {
@@ -32,6 +47,7 @@ function createTargetWindow(overrides = {}) {
     minimize: jest.fn(),
     maximize: jest.fn(),
     unmaximize: jest.fn(),
+    setFullScreen: jest.fn(),
     close: jest.fn(),
     webContents: {
       send: jest.fn(),
@@ -133,15 +149,19 @@ describe('window controls ipc', () => {
     });
     fromWebContents.mockReturnValue(targetWindow);
 
-    registerWindowControlsIpc();
-    const state = registeredHandlers['window-controls:toggle-maximize']({ sender: {} });
+    let state;
+    withPlatform('win32', () => {
+      registerWindowControlsIpc();
+      state = registeredHandlers['window-controls:toggle-maximize']({ sender: {} });
+    });
 
     expect(targetWindow.maximize).toHaveBeenCalled();
     expect(targetWindow.unmaximize).not.toHaveBeenCalled();
+    expect(targetWindow.setFullScreen).not.toHaveBeenCalled();
     expect(state).toEqual({
       isMaximized: false,
       isFullScreen: false,
-      platform: process.platform,
+      platform: 'win32',
     });
   });
 
@@ -151,15 +171,41 @@ describe('window controls ipc', () => {
     });
     fromWebContents.mockReturnValue(targetWindow);
 
-    registerWindowControlsIpc();
-    const state = registeredHandlers['window-controls:toggle-maximize']({ sender: {} });
+    let state;
+    withPlatform('win32', () => {
+      registerWindowControlsIpc();
+      state = registeredHandlers['window-controls:toggle-maximize']({ sender: {} });
+    });
 
     expect(targetWindow.unmaximize).toHaveBeenCalled();
     expect(targetWindow.maximize).not.toHaveBeenCalled();
+    expect(targetWindow.setFullScreen).not.toHaveBeenCalled();
     expect(state).toEqual({
       isMaximized: true,
       isFullScreen: false,
-      platform: process.platform,
+      platform: 'win32',
+    });
+  });
+
+  test('toggle-maximize usa full screen en macOS', () => {
+    const { targetWindow } = createTargetWindow({
+      isFullScreen: jest.fn(() => false),
+    });
+    fromWebContents.mockReturnValue(targetWindow);
+
+    let state;
+    withPlatform('darwin', () => {
+      registerWindowControlsIpc();
+      state = registeredHandlers['window-controls:toggle-maximize']({ sender: {} });
+    });
+
+    expect(targetWindow.setFullScreen).toHaveBeenCalledWith(true);
+    expect(targetWindow.maximize).not.toHaveBeenCalled();
+    expect(targetWindow.unmaximize).not.toHaveBeenCalled();
+    expect(state).toEqual({
+      isMaximized: false,
+      isFullScreen: false,
+      platform: 'darwin',
     });
   });
 


### PR DESCRIPTION
## Resumen
- actualizar `window-controls.test.js` para reflejar el comportamiento real del toggle de ventana segun plataforma
- agregar soporte explicito a `setFullScreen()` en el mock de `BrowserWindow`
- hacer que `main.test.js` fuerce una plataforma no-macOS en el caso `window-all-closed`

## Problema
Despues de varios PRs cruzados, la suite del proceso principal quedo inestable entre plataformas:

- en macOS, `window-controls.test.js` seguia esperando `maximize/unmaximize` cuando el codigo ya usa `setFullScreen(...)`
- `main.test.js` dependia del `process.platform` real del runner para validar `window-all-closed`

Eso hacia que la suite pudiera fallar por el host donde corria y no por un bug real del producto.

## Solucion
Se estabiliza la suite con un enfoque orientado al contrato real:
- `toggle-maximize` ahora valida `full screen` en macOS y `maximize/unmaximize` fuera de macOS
- el mock del `BrowserWindow` incluye `setFullScreen`
- el test de cierre de app deja de depender de la plataforma real del entorno

## Verificacion
- `npm test -- --runInBand tests/unit/main/window-controls.test.js tests/unit/main/main.test.js`
- `npm test -- --runInBand`

Closes #38
