### PR TITLE
refactor: eliminar la capa espejo entre shared y services/shared

### DIFF
--- a/src/services/analysis/pull-request-analysis.openai-client.ts
+++ b/src/services/analysis/pull-request-analysis.openai-client.ts
@@ -1,5 +1,5 @@
 import type { PullRequestAnalysisBatchRequest } from '../../types/analysis';
-import { retryWithBackoff } from '../shared/request-control';
+import { retryWithBackoff } from '../../shared/request-control';
 import type { PullRequestAnalysisClientPort, PullRequestAnalysisPromptPayload } from './pull-request-analysis.ports';
 
 const PULL_REQUEST_ANALYSIS_SCHEMA = {

--- a/src/services/analysis/pull-request-analysis.service.ts
+++ b/src/services/analysis/pull-request-analysis.service.ts
@@ -1,5 +1,5 @@
 import type { PullRequestAiReview, PullRequestAnalysisBatchRequest, PullRequestAnalysisPreview } from '../../types/analysis';
-import { mapWithConcurrency } from '../shared/request-control';
+import { mapWithConcurrency } from '../../shared/request-control';
 import type {
   PullRequestAnalysisClientPort,
   PullRequestAnalysisPromptBuilderPort,

--- a/src/services/azure/azure.api.ts
+++ b/src/services/azure/azure.api.ts
@@ -1,5 +1,5 @@
 import type { AzureConnectionConfig } from '../../types/azure';
-import { readJsonResponse } from '../shared/http-response';
+import { readJsonResponse } from '../../shared/http-response';
 
 const AZURE_API_VERSION = '7.1';
 

--- a/src/services/azure/azure.snapshot.ts
+++ b/src/services/azure/azure.snapshot.ts
@@ -1,7 +1,7 @@
 import type { AzureConnectionConfig } from '../../types/azure';
 import type { RepositorySnapshot } from '../../types/analysis';
 import type { RepositorySnapshotOptions } from '../../types/repository';
-import { mapWithConcurrency, retryWithBackoff } from '../shared/request-control';
+import { mapWithConcurrency, retryWithBackoff } from '../../shared/request-control';
 import {
   buildRepositoryFileSnapshot,
   buildRepositorySnapshot,

--- a/src/services/github/github.api.ts
+++ b/src/services/github/github.api.ts
@@ -1,5 +1,5 @@
 import type { RepositoryConnectionConfig } from '../../types/repository';
-import { readJsonResponse } from '../shared/http-response';
+import { readJsonResponse } from '../../shared/http-response';
 
 const GITHUB_API_VERSION = '2022-11-28';
 

--- a/src/services/github/github.pull-requests.ts
+++ b/src/services/github/github.pull-requests.ts
@@ -1,5 +1,5 @@
 import type { RepositoryConnectionConfig, ReviewItem, ReviewItemReviewer } from '../../types/repository';
-import { mapWithConcurrency } from '../shared/request-control';
+import { mapWithConcurrency } from '../../shared/request-control';
 import { getGitHubConfig, requestGitHubJson, requestGitHubPaginated } from './github.api';
 import { getGitHubRepositories } from './github.repositories';
 import type { GitHubPullRequestListResponseItem, GitHubReviewResponseItem } from './github.types';

--- a/src/services/github/github.snapshot.ts
+++ b/src/services/github/github.snapshot.ts
@@ -1,6 +1,6 @@
 import type { RepositoryConnectionConfig, RepositorySnapshotOptions } from '../../types/repository';
 import type { RepositorySnapshot } from '../../types/analysis';
-import { mapWithConcurrency, retryWithBackoff } from '../shared/request-control';
+import { mapWithConcurrency, retryWithBackoff } from '../../shared/request-control';
 import { rankPath } from '../shared/repository-snapshot-helpers';
 import { getGitHubConfig, requestGitHubContent, requestGitHubJson } from './github.api';
 import type { GitHubTreeResponse } from './github.types';

--- a/src/services/gitlab/gitlab.api.ts
+++ b/src/services/gitlab/gitlab.api.ts
@@ -1,5 +1,5 @@
 import type { RepositoryConnectionConfig, RepositoryProject, RepositorySummary } from '../../types/repository';
-import { readJsonResponse } from '../shared/http-response';
+import { readJsonResponse } from '../../shared/http-response';
 
 export const GITLAB_API_BASE_URL = 'https://gitlab.com/api/v4';
 

--- a/src/services/gitlab/gitlab.snapshot.ts
+++ b/src/services/gitlab/gitlab.snapshot.ts
@@ -1,6 +1,6 @@
 import type { RepositoryConnectionConfig, RepositorySnapshotOptions } from '../../types/repository';
 import type { RepositorySnapshot } from '../../types/analysis';
-import { mapWithConcurrency, retryWithBackoff } from '../shared/request-control';
+import { mapWithConcurrency, retryWithBackoff } from '../../shared/request-control';
 import {
   buildRepositoryFileSnapshot,
   buildRepositorySnapshot,

--- a/src/services/shared/http-response.ts
+++ b/src/services/shared/http-response.ts
@@ -1,1 +1,0 @@
-export { readJsonResponse } from '../../shared/http-response';

--- a/src/services/shared/request-control.ts
+++ b/src/services/shared/request-control.ts
@@ -1,5 +1,0 @@
-export {
-  isRetryableHttpError,
-  mapWithConcurrency,
-  retryWithBackoff,
-} from '../../shared/request-control';

--- a/tests/unit/services/request-control.test.js
+++ b/tests/unit/services/request-control.test.js
@@ -2,7 +2,7 @@ const {
   isRetryableHttpError,
   mapWithConcurrency,
   retryWithBackoff,
-} = require('../../../src/services/shared/request-control');
+} = require('../../../src/shared/request-control');
 
 describe('request-control', () => {
   afterEach(() => {


### PR DESCRIPTION
## Resumen
- eliminar los wrappers espejo de `src/services/shared`
- hacer que los servicios importen directamente desde `src/shared`
- alinear los tests de utilidades para apuntar a la fuente de verdad real

## Problema
`src/services/shared` no agregaba comportamiento ni ownership real: solo reexportaba utilidades que ya vivían en `src/shared`. Eso duplicaba la arquitectura semántica del proyecto y hacía confuso dónde debía vivir cada helper transversal.

## Solución
Se elimina la capa espejo y se dejan como fuente única:
- `src/shared/request-control.ts`
- `src/shared/http-response.ts`

Los servicios y tests ahora consumen directamente esos módulos.

## Verificación
- `npm test -- --runInBand tests/unit/services/request-control.test.js tests/unit/services/http-response.test.js tests/unit/services/github-api.test.js tests/unit/services/gitlab-api.test.js tests/unit/services/azure-api.test.js tests/unit/services/github-pull-requests.test.js tests/unit/services/repository-snapshot-modules.test.js tests/unit/services/pull-request-analysis.service.test.js`

Closes #40
