### PR TITLE
refactor: mover la persistencia de snapshots a shared storage

### DIFF
--- a/src/renderer/features/history/data/historyStorage.ts
+++ b/src/renderer/features/history/data/historyStorage.ts
@@ -1,35 +1,5 @@
-export interface DashboardHistorySnapshot {
-  id: string;
-  capturedAt: string;
-  scopeLabel: string;
-  activePRs: number;
-  highRiskPRs: number;
-  blockedPRs: number;
-  reviewBacklog: number;
-  averageAgeHours: number;
-  stalePRs: number;
-  repositoryCount: number;
-  hotfixPRs: number;
-}
-
-const HISTORY_STORAGE_KEY = 'checkpr.dashboard.history';
-const MAX_SNAPSHOTS = 120;
-
-export function loadDashboardHistory(): DashboardHistorySnapshot[] {
-  try {
-    const saved = window.localStorage.getItem(HISTORY_STORAGE_KEY);
-    if (!saved) {
-      return [];
-    }
-
-    return JSON.parse(saved) as DashboardHistorySnapshot[];
-  } catch {
-    return [];
-  }
-}
-
-export function persistDashboardSnapshot(snapshot: DashboardHistorySnapshot): void {
-  const history = loadDashboardHistory();
-  const nextHistory = [snapshot, ...history].slice(0, MAX_SNAPSHOTS);
-  window.localStorage.setItem(HISTORY_STORAGE_KEY, JSON.stringify(nextHistory));
-}
+export {
+  loadDashboardHistory,
+  persistDashboardSnapshot,
+} from '../../../shared/storage/dashboardHistoryStorage';
+export type { DashboardHistorySnapshot } from '../../../shared/storage/dashboardHistoryStorage';

--- a/src/renderer/features/history/presentation/components/HistoryCharts.tsx
+++ b/src/renderer/features/history/presentation/components/HistoryCharts.tsx
@@ -8,7 +8,7 @@ import { XAxis } from 'recharts/es6/cartesian/XAxis';
 import { YAxis } from 'recharts/es6/cartesian/YAxis';
 import { ResponsiveContainer } from 'recharts/es6/component/ResponsiveContainer';
 import { Tooltip } from 'recharts/es6/component/Tooltip';
-import type { DashboardHistorySnapshot } from '../../data/historyStorage';
+import type { DashboardHistorySnapshot } from '../../../../shared/storage/dashboardHistoryStorage';
 
 interface HistoryChartsProps {
   history: DashboardHistorySnapshot[];

--- a/src/renderer/features/repository-source/data/repositorySourceSnapshotStorage.ts
+++ b/src/renderer/features/repository-source/data/repositorySourceSnapshotStorage.ts
@@ -1,5 +1,5 @@
 import type { ReviewItem } from '../../../../types/repository';
-import { persistDashboardSnapshot } from '../../history';
+import { persistDashboardSnapshot } from '../../../shared/storage/dashboardHistoryStorage';
 import { buildRepositorySourceSnapshotRecord } from '../application/repositorySourcePersistence';
 import type { SavedConnectionConfig } from '../types';
 

--- a/src/renderer/shared/storage/dashboardHistoryStorage.ts
+++ b/src/renderer/shared/storage/dashboardHistoryStorage.ts
@@ -1,0 +1,35 @@
+export interface DashboardHistorySnapshot {
+  id: string;
+  capturedAt: string;
+  scopeLabel: string;
+  activePRs: number;
+  highRiskPRs: number;
+  blockedPRs: number;
+  reviewBacklog: number;
+  averageAgeHours: number;
+  stalePRs: number;
+  repositoryCount: number;
+  hotfixPRs: number;
+}
+
+const HISTORY_STORAGE_KEY = 'checkpr.dashboard.history';
+const MAX_SNAPSHOTS = 120;
+
+export function loadDashboardHistory(): DashboardHistorySnapshot[] {
+  try {
+    const saved = window.localStorage.getItem(HISTORY_STORAGE_KEY);
+    if (!saved) {
+      return [];
+    }
+
+    return JSON.parse(saved) as DashboardHistorySnapshot[];
+  } catch {
+    return [];
+  }
+}
+
+export function persistDashboardSnapshot(snapshot: DashboardHistorySnapshot): void {
+  const history = loadDashboardHistory();
+  const nextHistory = [snapshot, ...history].slice(0, MAX_SNAPSHOTS);
+  window.localStorage.setItem(HISTORY_STORAGE_KEY, JSON.stringify(nextHistory));
+}

--- a/tests/unit/renderer/history.dom.test.js
+++ b/tests/unit/renderer/history.dom.test.js
@@ -1,4 +1,4 @@
-const history = require('../../../src/renderer/features/history/data/historyStorage');
+const history = require('../../../src/renderer/shared/storage/dashboardHistoryStorage');
 
 describe('dashboard history storage', () => {
   beforeEach(() => {

--- a/tests/unit/renderer/repository-source-snapshot-persistence.dom.test.js
+++ b/tests/unit/renderer/repository-source-snapshot-persistence.dom.test.js
@@ -1,6 +1,6 @@
 const { renderHook } = require('@testing-library/react');
 
-jest.mock('../../../src/renderer/features/history/data/historyStorage', () => ({
+jest.mock('../../../src/renderer/shared/storage/dashboardHistoryStorage', () => ({
   persistDashboardSnapshot: jest.fn(),
 }));
 
@@ -17,7 +17,7 @@ jest.mock('../../../src/renderer/shared/dashboard/summary', () => ({
   })),
 }));
 
-const { persistDashboardSnapshot } = require('../../../src/renderer/features/history/data/historyStorage');
+const { persistDashboardSnapshot } = require('../../../src/renderer/shared/storage/dashboardHistoryStorage');
 const { useRepositorySourceSnapshotPersistence } = require('../../../src/renderer/features/repository-source/presentation/hooks/useRepositorySourceSnapshotPersistence');
 
 describe('useRepositorySourceSnapshotPersistence', () => {


### PR DESCRIPTION
## Resumen
- extraer la persistencia de snapshots del dashboard a `renderer/shared/storage`
- hacer que `repository-source` persista snapshots sin pasar por la API pública de `history`
- dejar `history` como consumidor del storage compartido en vez de dueño implícito de esa infraestructura

## Problema
`repository-source` seguía dependiendo de `history` para persistir snapshots del dashboard. Aunque el acoplamiento ya no estaba en application, seguía existiendo a nivel feature-to-feature a través de la API pública.

## Solución
Se crea `dashboardHistoryStorage` en `renderer/shared/storage` como ownership neutral del almacenamiento local. Desde ahí:
- `history` reusa el storage compartido
- `repository-source` persiste snapshots directamente sobre esa infraestructura compartida

## Verificación
- `npm test -- --runInBand tests/unit/renderer/history.dom.test.js tests/unit/renderer/repository-source-persistence.test.js tests/unit/renderer/repository-source-snapshot-persistence.dom.test.js tests/integration/renderer/history.page.dom.test.js tests/integration/renderer/use-repository-source-hooks.dom.test.js`

Closes #41
