### PR TITLE
refactor: unificar snapshotPolicy como contrato compartido

### DIFF
--- a/src/main/ipc/analysis.shared.ts
+++ b/src/main/ipc/analysis.shared.ts
@@ -1,4 +1,5 @@
 import type { RepositoryProviderKind } from '../../types/repository';
+import type { RepositoryAnalysisSnapshotPolicy } from '../../types/analysis/snapshot';
 
 export function readRequiredString(value: unknown, fieldName: string): string {
   if (typeof value !== 'string' || !value.trim()) {
@@ -26,9 +27,9 @@ export function clampNumber(value: unknown, minimum: number, maximum: number, fa
   return Math.min(maximum, Math.max(minimum, Math.floor(Number(value) || fallback)));
 }
 
-export function readSnapshotPolicy(payload: unknown): { excludedPathPatterns: string; strictMode: boolean } {
+export function readSnapshotPolicy(payload: unknown): RepositoryAnalysisSnapshotPolicy {
   const policy = payload && typeof payload === 'object'
-    ? payload as { excludedPathPatterns?: unknown; strictMode?: unknown }
+    ? payload as Partial<Record<keyof RepositoryAnalysisSnapshotPolicy, unknown>>
     : {};
 
   return {

--- a/src/renderer/features/pull-request-ai/presentation/hooks/usePullRequestAiReviews.ts
+++ b/src/renderer/features/pull-request-ai/presentation/hooks/usePullRequestAiReviews.ts
@@ -1,5 +1,6 @@
 import React from 'react';
 import type { PullRequestAiReview, PullRequestAnalysisPreview } from '../../../../../types/analysis';
+import type { RepositoryAnalysisSnapshotPolicy } from '../../../../../types/analysis/snapshot';
 import type { PrioritizedPullRequest } from '../../../../../types/repository';
 import {
   cancelPullRequestAiReviews,
@@ -25,10 +26,7 @@ interface UsePullRequestAiReviewsOptions {
   codexConfig: {
     apiKey: string;
     model: string;
-    snapshotPolicy: {
-      excludedPathPatterns: string;
-      strictMode: boolean;
-    };
+    snapshotPolicy: RepositoryAnalysisSnapshotPolicy;
     prReview: {
       enabled: boolean;
       maxPullRequests: number;

--- a/src/renderer/features/settings/types.ts
+++ b/src/renderer/features/settings/types.ts
@@ -1,4 +1,5 @@
 import type { PullRequestAnalysisPromptDirectives } from '../../../types/analysis';
+import type { RepositoryAnalysisSnapshotPolicy } from '../../../types/analysis/snapshot';
 
 export interface CodexIntegrationConfig {
   enabled: boolean;
@@ -8,10 +9,7 @@ export interface CodexIntegrationConfig {
   includeTests: boolean;
   repositoryScope: 'selected' | 'all';
   apiKey: string;
-  snapshotPolicy: {
-    excludedPathPatterns: string;
-    strictMode: boolean;
-  };
+  snapshotPolicy: RepositoryAnalysisSnapshotPolicy;
   prReview: {
     enabled: boolean;
     maxPullRequests: number;


### PR DESCRIPTION
## Resumen
- reutilizar el tipo de snapshot policy del dominio de análisis en Settings
- usar el mismo contrato también en `analysis.shared` y en el hook de PR AI reviews
- eliminar shapes inline duplicados para `excludedPathPatterns` y `strictMode`

## Problema
`snapshotPolicy` estaba duplicado en distintos puntos del proyecto, especialmente en Settings, IPC y presentation hooks. Eso dejaba a la UI como dueña accidental de un contrato que en realidad pertenece al dominio de análisis.

## Solución
Se toma `RepositoryAnalysisSnapshotPolicy` como fuente única de verdad y se reutiliza en:
- `CodexIntegrationConfig`
- `readSnapshotPolicy()`
- `usePullRequestAiReviews`

## Verificación
- `npm test -- --runInBand tests/unit/main/analysis.shared.test.js tests/unit/renderer/codex-integration-card.dom.test.js tests/unit/renderer/global-snapshot-policy-card.dom.test.js tests/unit/renderer/use-pull-request-ai-reviews.dom.test.js tests/unit/renderer/repository-analysis-payload.test.js tests/integration/renderer/use-codex-settings.dom.test.js tests/integration/renderer/repository-analysis.page.dom.test.js`

Closes #42
