### PR TITLE
refactor: mover la composición API de repository-source a application

### DIFF
--- a/src/renderer/features/repository-source/application/repositorySourceApiFactory.ts
+++ b/src/renderer/features/repository-source/application/repositorySourceApiFactory.ts
@@ -1,21 +1,20 @@
-import type React from 'react';
-import type { RepositorySourceFetcherPort } from './repositorySourceFetcher';
+import type { RepositorySourceFetcherPort } from '../data/repositorySourceFetcher';
 import type {
   RepositorySourceDiagnosticsPort,
   RepositorySourceSnapshotPort,
   RepositorySourceStatePort,
-} from '../application/repositorySourceApiPorts';
+} from './repositorySourceApiPorts';
 import {
   createDiscoverProjectsUseCase,
   createFetchProjectsUseCase,
   createFetchRepositoriesUseCase,
   createOpenExternalLinkUseCase,
   createSyncPullRequestsUseCase,
-} from '../application/repositorySourceUseCases';
+} from './repositorySourceUseCases';
 import type { SavedConnectionConfig } from '../types';
 
 interface CreateRepositorySourceApiOptions {
-  configRef: React.MutableRefObject<SavedConnectionConfig>;
+  configRef: { current: SavedConnectionConfig };
   activeProviderName: string;
   scopeLabel: string;
   state: RepositorySourceStatePort;

--- a/src/renderer/features/repository-source/presentation/hooks/useRepositorySourceApi.ts
+++ b/src/renderer/features/repository-source/presentation/hooks/useRepositorySourceApi.ts
@@ -1,8 +1,8 @@
 import React from 'react';
 import type { ReviewItem } from '../../../../../types/repository';
+import { createRepositorySourceApi } from '../../application/repositorySourceApiFactory';
 import { repositorySourceFetcher } from '../../data/repositorySourceFetcher';
 import type { RepositorySourceFetcherPort } from '../../data/repositorySourceFetcher';
-import { createRepositorySourceApi } from '../../data/repositorySourceApiService';
 import type { SavedConnectionConfig } from '../../types';
 import type { useRepositoryDiagnostics } from './useRepositoryDiagnostics';
 import { useRepositorySourceEffects } from './useRepositorySourceEffects';

--- a/tests/unit/renderer/repository-source-api-service.test.js
+++ b/tests/unit/renderer/repository-source-api-service.test.js
@@ -1,4 +1,4 @@
-const { createRepositorySourceApi } = require('../../../src/renderer/features/repository-source/data/repositorySourceApiService');
+const { createRepositorySourceApi } = require('../../../src/renderer/features/repository-source/application/repositorySourceApiFactory');
 
 function createStateMock() {
   return {
@@ -22,7 +22,7 @@ function createDiagnosticsMock() {
   };
 }
 
-describe('repositorySourceApiService', () => {
+describe('repositorySourceApiFactory', () => {
   beforeEach(() => {
     jest.clearAllMocks();
   });


### PR DESCRIPTION
## Resumen
- mover `createRepositorySourceApi` desde `data` a `application`
- dejar `data` enfocado en fetchers/adapters concretos
- alinear el hook de presentation y los tests con el nuevo ownership

## Problema
La composición de use cases y coordinación de puertos vivía en `data/repositorySourceApiService.ts`, aunque dependía de conceptos más cercanos a orchestration que a infraestructura. Eso hacía que la capa `data` del feature cargara responsabilidades de ensamblaje del flujo principal.

## Solución
Se renombra y mueve el módulo a `application/repositorySourceApiFactory.ts`. Con eso:
- `data` conserva fetchers e IPC adapters
- `application` asume la composición de casos de uso
- `presentation` consume una factory cuyo ownership es más coherente con su responsabilidad real

## Verificación
- `npm test -- --runInBand tests/unit/renderer/repository-source-api-service.test.js tests/unit/renderer/repository-source-use-cases.test.js tests/unit/renderer/repository-source-operations.dom.test.js tests/integration/renderer/use-repository-source-hooks.dom.test.js tests/integration/renderer/repository-source-context.dom.test.js`

Closes #45
