### PR TITLE
refactor: evitar semántica falsa de Bitbucket heredada desde Azure

### DIFF
--- a/src/renderer/features/repository-source/application/repositorySourceProviderBehavior.ts
+++ b/src/renderer/features/repository-source/application/repositorySourceProviderBehavior.ts
@@ -150,11 +150,10 @@ const namespaceBehavior: RepositorySourceProviderBehavior = {
   },
 };
 
-const providerBehaviorMap: Record<Exclude<RepositoryProviderSelection, ''>, RepositorySourceProviderBehavior> = {
+const providerBehaviorMap: Partial<Record<Exclude<RepositoryProviderSelection, ''>, RepositorySourceProviderBehavior>> = {
   'azure-devops': azureBehavior,
   github: namespaceBehavior,
   gitlab: namespaceBehavior,
-  bitbucket: azureBehavior,
 };
 
 export function getRepositorySourceProviderBehavior(

--- a/tests/unit/renderer/repository-source-helpers.test.js
+++ b/tests/unit/renderer/repository-source-helpers.test.js
@@ -135,6 +135,7 @@ describe('repository source helpers', () => {
       personalAccessToken: 'pat',
       targetReviewer: '',
     })).toBe(false);
+    expect(providerBehavior.getRepositorySourceProviderBehavior('bitbucket')).toBeNull();
   });
 
   test('hasMinimumProjectDiscoveryConfig y hasMinimumRepositoryConfig validan por provider', () => {


### PR DESCRIPTION
## Resumen
- elimina el comportamiento operativo heredado de Azure para `bitbucket`
- ajusta el mapa de comportamientos para aceptar providers sin soporte operativo
- agrega una prueba explícita para evitar que Bitbucket vuelva a resolverse como alias de Azure

## Motivación
La UI marca Bitbucket como backlog (`todo`), pero la capa de aplicación todavía lo resolvía con el comportamiento de Azure DevOps. Eso dejaba una semántica engañosa: el sistema decía que el provider no estaba implementado, mientras que internamente sí le asignaba reglas, request paths y validaciones que no le pertenecen.

## Validación
- `npm test -- --runInBand tests/unit/renderer/repository-source-helpers.test.js tests/unit/renderer/repository-source-config-hooks.dom.test.js tests/unit/renderer/repository-source-state-service.test.js tests/integration/renderer/use-repository-source-hooks.dom.test.js`

Closes #44
