### PR TITLE
refactor: unificar la construcción inicial de diagnostics

### DIFF
--- a/src/renderer/features/repository-source/presentation/hooks/useRepositoryDiagnostics.ts
+++ b/src/renderer/features/repository-source/presentation/hooks/useRepositoryDiagnostics.ts
@@ -3,15 +3,9 @@ import { buildDiagnostics } from '../../application/repositorySourceDiagnostics'
 import type { RepositorySourceDiagnostics, SavedConnectionConfig } from '../../types';
 
 export function useRepositoryDiagnostics(initialConfig: SavedConnectionConfig) {
-  const [diagnostics, setDiagnostics] = React.useState<RepositorySourceDiagnostics>({
-    operation: null,
-    provider: initialConfig.provider,
-    organization: '',
-    project: '',
-    repositoryId: '',
-    requestPath: '',
-    lastError: null,
-  });
+  const [diagnostics, setDiagnostics] = React.useState<RepositorySourceDiagnostics>(
+    () => buildDiagnostics(null, initialConfig),
+  );
 
   const updateDiagnostics = React.useCallback((
     operation: RepositorySourceDiagnostics['operation'],

--- a/tests/integration/renderer/use-repository-source-hooks.dom.test.js
+++ b/tests/integration/renderer/use-repository-source-hooks.dom.test.js
@@ -158,6 +158,27 @@ describe('repository source hooks', () => {
     expect(result.current.diagnostics.requestPath).toBe('');
   });
 
+  test('useRepositoryDiagnostics usa el builder tambien para el estado inicial', () => {
+    const { result } = renderHook(() => actualDiagnosticsModule.useRepositoryDiagnostics({
+      provider: 'azure-devops',
+      organization: ' org ',
+      project: ' platform ',
+      repositoryId: ' repo-a ',
+      personalAccessToken: '',
+      targetReviewer: '',
+    }));
+
+    expect(result.current.diagnostics).toEqual(expect.objectContaining({
+      operation: null,
+      provider: 'azure-devops',
+      organization: 'org',
+      project: 'platform',
+      repositoryId: 'repo-a',
+      requestPath: '',
+      lastError: null,
+    }));
+  });
+
   test('useRepositorySourceActions delega en state y diagnostics', () => {
     const state = createStateMock();
     const diagnostics = createDiagnosticsMock();


### PR DESCRIPTION
## Resumen
- reutiliza `buildDiagnostics` para construir también el estado inicial del hook
- elimina la duplicación manual del shape inicial en `useRepositoryDiagnostics`
- agrega una prueba para asegurar que el estado inicial queda alineado con el builder

## Motivación
El hook de presentation reconstruía manualmente un objeto que ya sabe construir la capa de aplicación. Eso abría una divergencia innecesaria: si `buildDiagnostics` cambiaba, el estado inicial del hook podía quedarse desalineado. Con este cambio el contrato vive en un solo lugar.

## Validación
- `npm test -- --runInBand tests/integration/renderer/use-repository-source-hooks.dom.test.js tests/unit/renderer/repository-source-helpers.test.js tests/unit/renderer/repository-source-operations.dom.test.js`

Closes #49
