### PR TITLE
refactor: mover la migración Azure fuera del hot path de storage

### DIFF
--- a/src/renderer/features/repository-source/data/repositorySourceStorage.ts
+++ b/src/renderer/features/repository-source/data/repositorySourceStorage.ts
@@ -26,29 +26,33 @@ function clearLegacyRepositorySourceStorage(): void {
 }
 
 export function loadConnectionConfig(): SavedConnectionConfig {
-  clearLegacyRepositorySourceStorage();
-
   return {
     ...loadStoredObject<SavedConnectionConfig>(window.sessionStorage, REPOSITORY_SOURCE_SESSION_CONFIG_KEY, defaultConnectionConfig),
     personalAccessToken: '',
   };
 }
 
-export async function hydrateConnectionSecret(): Promise<string> {
-  const storedSecret = await getSessionSecret(REPOSITORY_SOURCE_SESSION_SECRET_KEY);
+export async function migrateLegacyRepositorySourceStorage(): Promise<void> {
+  clearLegacyRepositorySourceStorage();
 
+  const storedSecret = await getSessionSecret(REPOSITORY_SOURCE_SESSION_SECRET_KEY);
   if (storedSecret) {
-    return storedSecret;
+    await setSessionSecret(LEGACY_REPOSITORY_SOURCE_SESSION_SECRET_KEY, '');
+    return;
   }
 
   const legacySecret = await getSessionSecret(LEGACY_REPOSITORY_SOURCE_SESSION_SECRET_KEY);
   if (!legacySecret) {
-    return '';
+    return;
   }
 
   await setSessionSecret(REPOSITORY_SOURCE_SESSION_SECRET_KEY, legacySecret);
   await setSessionSecret(LEGACY_REPOSITORY_SOURCE_SESSION_SECRET_KEY, '');
-  return legacySecret;
+}
+
+export async function hydrateConnectionSecret(): Promise<string> {
+  const storedSecret = await getSessionSecret(REPOSITORY_SOURCE_SESSION_SECRET_KEY);
+  return storedSecret || '';
 }
 
 export async function persistConnectionConfig(config: SavedConnectionConfig): Promise<void> {
@@ -58,6 +62,4 @@ export async function persistConnectionConfig(config: SavedConnectionConfig): Pr
   };
   saveStoredObject(window.sessionStorage, REPOSITORY_SOURCE_SESSION_CONFIG_KEY, safeConfig);
   await setSessionSecret(REPOSITORY_SOURCE_SESSION_SECRET_KEY, config.personalAccessToken);
-  await setSessionSecret(LEGACY_REPOSITORY_SOURCE_SESSION_SECRET_KEY, '');
-  clearLegacyRepositorySourceStorage();
 }

--- a/src/renderer/features/repository-source/presentation/hooks/useRepositorySource.ts
+++ b/src/renderer/features/repository-source/presentation/hooks/useRepositorySource.ts
@@ -8,7 +8,7 @@ import { useRepositorySourceSnapshotPersistence } from './useRepositorySourceSna
 
 export function useRepositorySource() {
   const configHook = useRepositorySourceConfig();
-  const { config, configRef, updateConfig, selectProjectConfig, hydrateSecret } = configHook;
+  const { config, configRef, updateConfig, selectProjectConfig, hydrateSecret, migrateLegacyStorage } = configHook;
   const { applyHydratedSecret } = configHook;
   const { activeProviderName, baseScopeLabel } = useRepositorySourceMetadata(config);
   const persistSnapshot = useRepositorySourceSnapshotPersistence(configRef);
@@ -50,6 +50,7 @@ export function useRepositorySource() {
   });
 
   useRepositorySourceBootstrap({
+    migrateLegacyStorage,
     applyHydratedSecret,
     hydrateSecret,
     refreshPullRequests,

--- a/src/renderer/features/repository-source/presentation/hooks/useRepositorySourceBootstrap.ts
+++ b/src/renderer/features/repository-source/presentation/hooks/useRepositorySourceBootstrap.ts
@@ -3,12 +3,14 @@ import { hasMinimumPullRequestSyncConfig } from '../../application/repositorySou
 import type { SavedConnectionConfig } from '../../types';
 
 interface UseRepositorySourceBootstrapOptions {
+  migrateLegacyStorage: () => Promise<void>;
   hydrateSecret: () => Promise<string>;
   applyHydratedSecret: (value: string) => SavedConnectionConfig;
   refreshPullRequests: () => Promise<void>;
 }
 
 export function useRepositorySourceBootstrap({
+  migrateLegacyStorage,
   hydrateSecret,
   applyHydratedSecret,
   refreshPullRequests,
@@ -16,7 +18,8 @@ export function useRepositorySourceBootstrap({
   React.useEffect(() => {
     let isMounted = true;
 
-    void hydrateSecret()
+    void migrateLegacyStorage()
+      .then(() => hydrateSecret())
       .then((personalAccessToken) => {
         if (!personalAccessToken || !isMounted) {
           return;
@@ -32,5 +35,5 @@ export function useRepositorySourceBootstrap({
     return () => {
       isMounted = false;
     };
-  }, [applyHydratedSecret, hydrateSecret, refreshPullRequests]);
+  }, [applyHydratedSecret, hydrateSecret, migrateLegacyStorage, refreshPullRequests]);
 }

--- a/src/renderer/features/repository-source/presentation/hooks/useRepositorySourceConfig.ts
+++ b/src/renderer/features/repository-source/presentation/hooks/useRepositorySourceConfig.ts
@@ -2,6 +2,7 @@ import React from 'react';
 import {
   hydrateConnectionSecret,
   loadConnectionConfig,
+  migrateLegacyRepositorySourceStorage,
   persistConnectionConfig,
 } from '../../data/repositorySourceStorage';
 import { getRepositorySourceProviderBehavior } from '../../application/repositorySourceProviderBehavior';
@@ -15,6 +16,7 @@ interface UseRepositorySourceConfigResult {
   selectProjectConfig: (project: string) => void;
   applyHydratedSecret: (value: string) => SavedConnectionConfig;
   hydrateSecret: () => Promise<string>;
+  migrateLegacyStorage: () => Promise<void>;
 }
 
 export function useRepositorySourceConfig(): UseRepositorySourceConfigResult {
@@ -69,6 +71,7 @@ export function useRepositorySourceConfig(): UseRepositorySourceConfigResult {
   }, []);
 
   const hydrateSecret = React.useCallback(() => hydrateConnectionSecret(), []);
+  const migrateLegacyStorage = React.useCallback(() => migrateLegacyRepositorySourceStorage(), []);
 
   return {
     config,
@@ -77,5 +80,6 @@ export function useRepositorySourceConfig(): UseRepositorySourceConfigResult {
     selectProjectConfig,
     applyHydratedSecret,
     hydrateSecret,
+    migrateLegacyStorage,
   };
 }

--- a/tests/integration/renderer/repository-source-context.dom.test.js
+++ b/tests/integration/renderer/repository-source-context.dom.test.js
@@ -5,6 +5,7 @@ jest.mock('../../../src/renderer/features/repository-source/data/repositorySourc
   loadConnectionConfig: jest.fn(),
   persistConnectionConfig: jest.fn().mockResolvedValue(undefined),
   hydrateConnectionSecret: jest.fn(),
+  migrateLegacyRepositorySourceStorage: jest.fn().mockResolvedValue(undefined),
 }));
 
 jest.mock('../../../src/renderer/features/repository-source/presentation/hooks/useRepositorySourceController', () => ({

--- a/tests/unit/renderer/repository-source-config-hooks.dom.test.js
+++ b/tests/unit/renderer/repository-source-config-hooks.dom.test.js
@@ -4,6 +4,7 @@ jest.mock('../../../src/renderer/features/repository-source/data/repositorySourc
   loadConnectionConfig: jest.fn(),
   persistConnectionConfig: jest.fn().mockResolvedValue(undefined),
   hydrateConnectionSecret: jest.fn(),
+  migrateLegacyRepositorySourceStorage: jest.fn().mockResolvedValue(undefined),
 }));
 
 const storage = require('../../../src/renderer/features/repository-source/data/repositorySourceStorage');
@@ -180,6 +181,7 @@ describe('repository source config hooks', () => {
     }));
 
     renderHook(() => useRepositorySourceBootstrap({
+      migrateLegacyStorage: jest.fn().mockResolvedValue(undefined),
       hydrateSecret: jest.fn().mockResolvedValue('pat-restored'),
       applyHydratedSecret,
       refreshPullRequests,
@@ -196,6 +198,7 @@ describe('repository source config hooks', () => {
     const applyHydratedSecret = jest.fn();
 
     renderHook(() => useRepositorySourceBootstrap({
+      migrateLegacyStorage: jest.fn().mockResolvedValue(undefined),
       hydrateSecret: jest.fn().mockRejectedValue(new Error('boom')),
       applyHydratedSecret,
       refreshPullRequests,
@@ -214,6 +217,7 @@ describe('repository source config hooks', () => {
     const applyHydratedSecret = jest.fn();
 
     renderHook(() => useRepositorySourceBootstrap({
+      migrateLegacyStorage: jest.fn().mockResolvedValue(undefined),
       hydrateSecret: jest.fn().mockResolvedValue(''),
       applyHydratedSecret,
       refreshPullRequests,
@@ -239,6 +243,7 @@ describe('repository source config hooks', () => {
     }));
 
     renderHook(() => useRepositorySourceBootstrap({
+      migrateLegacyStorage: jest.fn().mockResolvedValue(undefined),
       hydrateSecret: jest.fn().mockResolvedValue('pat-restored'),
       applyHydratedSecret,
       refreshPullRequests,
@@ -249,6 +254,25 @@ describe('repository source config hooks', () => {
     });
 
     expect(refreshPullRequests).not.toHaveBeenCalled();
+  });
+
+  test('useRepositorySourceBootstrap corre la migracion legacy antes de hidratar el secreto', async () => {
+    const migrateLegacyStorage = jest.fn().mockResolvedValue(undefined);
+    const hydrateSecret = jest.fn().mockResolvedValue('');
+
+    renderHook(() => useRepositorySourceBootstrap({
+      migrateLegacyStorage,
+      hydrateSecret,
+      applyHydratedSecret: jest.fn(),
+      refreshPullRequests: jest.fn(),
+    }));
+
+    await waitFor(() => {
+      expect(migrateLegacyStorage).toHaveBeenCalled();
+      expect(hydrateSecret).toHaveBeenCalled();
+    });
+
+    expect(migrateLegacyStorage.mock.invocationCallOrder[0]).toBeLessThan(hydrateSecret.mock.invocationCallOrder[0]);
   });
 
   test('useRepositorySourceDerived calcula nombres seleccionados y readiness', () => {

--- a/tests/unit/renderer/repository-source-storage.dom.test.js
+++ b/tests/unit/renderer/repository-source-storage.dom.test.js
@@ -11,7 +11,7 @@ describe('repository source storage', () => {
     expect(storage.loadConnectionConfig()).toEqual(storage.defaultConnectionConfig);
   });
 
-  test('loadConnectionConfig limpia legacy localStorage y conserva config segura', () => {
+  test('loadConnectionConfig conserva config segura sin tocar la migracion legacy', () => {
     window.sessionStorage.setItem(storage.REPOSITORY_SOURCE_SESSION_CONFIG_KEY, JSON.stringify({
       provider: 'github',
       organization: 'acme',
@@ -30,8 +30,8 @@ describe('repository source storage', () => {
       repositoryId: 'repo-a',
       personalAccessToken: '',
     });
-    expect(window.localStorage.getItem('checkpr.azure.config')).toBeNull();
-    expect(window.localStorage.getItem('checkpr.azure.saved-contexts')).toBeNull();
+    expect(window.localStorage.getItem('checkpr.azure.config')).toBe('legacy');
+    expect(window.localStorage.getItem('checkpr.azure.saved-contexts')).toBe('legacy-contexts');
   });
 
   test('persistConnectionConfig guarda config segura y secreto en sesion', async () => {
@@ -72,7 +72,7 @@ describe('repository source storage', () => {
     await expect(storage.hydrateConnectionSecret()).resolves.toBe('stored-secret');
   });
 
-  test('hydrateConnectionSecret migra el secreto legacy si existe', async () => {
+  test('migrateLegacyRepositorySourceStorage migra el secreto legacy si existe', async () => {
     window.electronApi.invoke.mockImplementation(async (channel, payload) => {
       if (channel === 'session-secrets:get' && payload === storage.REPOSITORY_SOURCE_SESSION_SECRET_KEY) {
         return { ok: true, data: '' };
@@ -85,7 +85,7 @@ describe('repository source storage', () => {
       return { ok: true, data: null };
     });
 
-    await expect(storage.hydrateConnectionSecret()).resolves.toBe('legacy-secret');
+    await expect(storage.migrateLegacyRepositorySourceStorage()).resolves.toBeUndefined();
     expect(window.electronApi.invoke).toHaveBeenCalledWith('session-secrets:set', {
       key: storage.REPOSITORY_SOURCE_SESSION_SECRET_KEY,
       value: 'legacy-secret',
@@ -94,6 +94,19 @@ describe('repository source storage', () => {
       key: 'checkpr.azure.session.pat',
       value: '',
     });
+  });
+
+  test('hydrateConnectionSecret solo lee el secreto actual', async () => {
+    window.electronApi.invoke.mockImplementation(async (channel, key) => {
+      if (channel === 'session-secrets:get' && key === storage.REPOSITORY_SOURCE_SESSION_SECRET_KEY) {
+        return { ok: true, data: '' };
+      }
+
+      return { ok: true, data: 'legacy-secret' };
+    });
+
+    await expect(storage.hydrateConnectionSecret()).resolves.toBe('');
+    expect(window.electronApi.invoke).not.toHaveBeenCalledWith('session-secrets:get', 'checkpr.azure.session.pat');
   });
 
   test('loadConnectionConfig tolera JSON invalido en sesion', () => {
@@ -139,17 +152,18 @@ describe('repository source storage', () => {
     }
   });
 
-  test('persistConnectionConfig limpia storage legacy y el secreto azure anterior', async () => {
+  test('migrateLegacyRepositorySourceStorage limpia storage legacy y el secreto azure anterior', async () => {
     window.localStorage.setItem('checkpr.azure.config', 'legacy');
     window.localStorage.setItem('checkpr.azure.saved-contexts', 'legacy-contexts');
-    window.electronApi.invoke.mockResolvedValue({ ok: true, data: null });
+    window.electronApi.invoke.mockImplementation(async (channel, key) => {
+      if (channel === 'session-secrets:get' && key === storage.REPOSITORY_SOURCE_SESSION_SECRET_KEY) {
+        return { ok: true, data: 'secret' };
+      }
 
-    await storage.persistConnectionConfig({
-      ...storage.defaultConnectionConfig,
-      provider: 'github',
-      organization: 'acme',
-      personalAccessToken: 'secret',
+      return { ok: true, data: null };
     });
+
+    await storage.migrateLegacyRepositorySourceStorage();
 
     expect(window.localStorage.getItem('checkpr.azure.config')).toBeNull();
     expect(window.localStorage.getItem('checkpr.azure.saved-contexts')).toBeNull();


### PR DESCRIPTION
## Resumen
- extrae la migración legacy de Azure a una rutina explícita de bootstrap
- deja `loadConnectionConfig`, `hydrateConnectionSecret` y `persistConnectionConfig` libres de side effects de migración
- agrega cobertura para la nueva secuencia de migración y para el orden bootstrap -> hydrate

## Motivación
La compatibilidad con claves legacy seguía mezclada con el camino caliente del feature. Eso hacía que leer config, hidratar el secreto o persistir cualquier cambio tuviera responsabilidad extra de migración. Con este ajuste, la migración se ejecuta una vez al arrancar el feature y el storage vuelve a tener una intención más simple y predecible.

## Validación
- `npm test -- --runInBand tests/unit/renderer/repository-source-storage.dom.test.js tests/unit/renderer/repository-source-config-hooks.dom.test.js tests/integration/renderer/repository-source-context.dom.test.js tests/integration/renderer/use-repository-source-hooks.dom.test.js`

Closes #48
