### PR TITLE
refactor: simplificar RepositorySourceProviderCatalog

### DIFF
--- a/src/renderer/features/repository-source/presentation/components/RepositorySourceProviderCard.tsx
+++ b/src/renderer/features/repository-source/presentation/components/RepositorySourceProviderCard.tsx
@@ -3,7 +3,7 @@ import { ArrowRightIcon, CheckCircleIcon, ChevronDownIcon, ChevronUpIcon, Circle
 import type { RepositoryProviderDefinition } from '../../../../../types/repository';
 import { SettingsSectionCard, SettingsStatusBadge, SettingsSurfaceCard, settingsButtonClassName } from '../../../../ui/configuration/ConfigurationPrimitives';
 
-interface RepositoryProviderCardProps {
+interface RepositorySourceProviderCardProps {
   provider: RepositoryProviderDefinition;
   isActive?: boolean;
   isConfigured?: boolean;
@@ -19,7 +19,7 @@ const statusLabel: Record<RepositoryProviderDefinition['status'], string> = {
   todo: 'Backlog',
 };
 
-const RepositoryProviderCard = ({
+export default function RepositorySourceProviderCard({
   provider,
   isActive = false,
   isConfigured = false,
@@ -27,7 +27,7 @@ const RepositoryProviderCard = ({
   onToggleExpand,
   onActivate,
   children,
-}: RepositoryProviderCardProps) => {
+}: RepositorySourceProviderCardProps) {
   const badgeTone = provider.status === 'available'
     ? 'emerald'
     : provider.status === 'planned'
@@ -93,6 +93,4 @@ const RepositoryProviderCard = ({
       ) : null}
     </SettingsSectionCard>
   );
-};
-
-export default RepositoryProviderCard;
+}

--- a/src/renderer/features/repository-source/presentation/components/RepositorySourceProviderCatalog.tsx
+++ b/src/renderer/features/repository-source/presentation/components/RepositorySourceProviderCatalog.tsx
@@ -3,6 +3,7 @@ import type { RepositoryProviderKind, RepositoryProviderDefinition, RepositoryPr
 import { repositoryProviders } from '../../providers';
 import type { SavedConnectionConfig } from '../../types';
 import ConnectionPanel from './ConnectionPanel';
+import RepositorySourceProviderCard from './RepositorySourceProviderCard';
 
 interface RepositorySourceProviderCatalogProps {
   activeProvider: RepositoryProviderDefinition | null;
@@ -20,15 +21,6 @@ interface RepositorySourceProviderCatalogProps {
   selectProject: (project: string) => void;
   updateConfig: (name: keyof SavedConnectionConfig, value: string) => void;
   refreshPullRequests: () => void;
-  renderProviderCard: (props: {
-    provider: RepositoryProviderDefinition;
-    isActive: boolean;
-    isConfigured: boolean;
-    expanded: boolean;
-    onToggleExpand?: () => void;
-    onActivate?: () => void;
-    children?: React.ReactNode;
-  }) => React.ReactNode;
 }
 
 export function RepositorySourceProviderCatalog({
@@ -47,7 +39,6 @@ export function RepositorySourceProviderCatalog({
   selectProject,
   updateConfig,
   refreshPullRequests,
-  renderProviderCard,
 }: RepositorySourceProviderCatalogProps) {
   const [expandedProviderKind, setExpandedProviderKind] = React.useState<RepositoryProviderKind | ''>(config.provider);
 
@@ -57,40 +48,44 @@ export function RepositorySourceProviderCatalog({
 
   return (
     <>
-      {repositoryProviders.map((provider) => renderProviderCard({
-        provider,
-        isActive: provider.kind === activeProvider?.kind,
-        isConfigured: provider.kind === activeProvider?.kind && isConnectionReady,
-        expanded: provider.kind === activeProvider?.kind && expandedProviderKind === provider.kind,
-        onToggleExpand: provider.status === 'available' && provider.kind === activeProvider?.kind
-          ? () => setExpandedProviderKind((current: RepositoryProviderKind | '') => (current === provider.kind ? '' : provider.kind))
-          : undefined,
-        onActivate: provider.status === 'available' && provider.kind !== activeProvider?.kind
-          ? () => {
-            updateConfig('provider', provider.kind);
-            setExpandedProviderKind(provider.kind);
-          }
-          : undefined,
-        children: provider.kind === activeProvider?.kind ? (
-          <ConnectionPanel
-            providerName={activeProviderName}
-            providerKind={provider.kind}
-            isConnected={isConnectionReady}
-            config={config}
-            error={error}
-            projectDiscoveryWarning={projectDiscoveryWarning}
-            isLoading={isLoading}
-            projects={projects}
-            projectsLoading={projectsLoading}
-            repositories={repositories}
-            repositoriesLoading={repositoriesLoading}
-            onDiscoverProjects={discoverProjects}
-            onSelectProject={selectProject}
-            onConfigChange={updateConfig}
-            onRefresh={refreshPullRequests}
-          />
-        ) : null,
-      }))}
+      {repositoryProviders.map((provider) => (
+        <RepositorySourceProviderCard
+          key={provider.kind}
+          provider={provider}
+          isActive={provider.kind === activeProvider?.kind}
+          isConfigured={provider.kind === activeProvider?.kind && isConnectionReady}
+          expanded={provider.kind === activeProvider?.kind && expandedProviderKind === provider.kind}
+          onToggleExpand={provider.status === 'available' && provider.kind === activeProvider?.kind
+            ? () => setExpandedProviderKind((current: RepositoryProviderKind | '') => (current === provider.kind ? '' : provider.kind))
+            : undefined}
+          onActivate={provider.status === 'available' && provider.kind !== activeProvider?.kind
+            ? () => {
+              updateConfig('provider', provider.kind);
+              setExpandedProviderKind(provider.kind);
+            }
+            : undefined}
+        >
+          {provider.kind === activeProvider?.kind ? (
+            <ConnectionPanel
+              providerName={activeProviderName}
+              providerKind={provider.kind}
+              isConnected={isConnectionReady}
+              config={config}
+              error={error}
+              projectDiscoveryWarning={projectDiscoveryWarning}
+              isLoading={isLoading}
+              projects={projects}
+              projectsLoading={projectsLoading}
+              repositories={repositories}
+              repositoriesLoading={repositoriesLoading}
+              onDiscoverProjects={discoverProjects}
+              onSelectProject={selectProject}
+              onConfigChange={updateConfig}
+              onRefresh={refreshPullRequests}
+            />
+          ) : null}
+        </RepositorySourceProviderCard>
+      ))}
     </>
   );
 }

--- a/src/renderer/features/settings/presentation/components/SettingsProviderModal.tsx
+++ b/src/renderer/features/settings/presentation/components/SettingsProviderModal.tsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import type { RepositoryProviderDefinition } from '../../../../../types/repository';
 import { RepositorySourceProviderCatalog } from '../../../repository-source';
-import RepositoryProviderCard from './RepositoryProviderCard';
 import SettingsSectionModal from './SettingsSectionModal';
 import type { SettingsProviderConnectionProps } from './SettingsProvider.types';
 
@@ -28,12 +27,6 @@ const SettingsProviderModal = ({
       <RepositorySourceProviderCatalog
         activeProvider={activeProvider}
         {...connection}
-        renderProviderCard={(providerCardProps) => (
-          <RepositoryProviderCard
-            key={providerCardProps.provider.kind}
-            {...providerCardProps}
-          />
-        )}
       />
     </SettingsSectionModal>
   );


### PR DESCRIPTION
## Resumen
- elimina el `renderProviderCard` del catálogo de providers
- mueve la tarjeta visual al propio feature `repository-source`
- deja `SettingsProviderModal` consumiendo un contrato más simple y directo

## Motivación
`RepositorySourceProviderCatalog` estaba modelado como si fuera una abstracción altamente reutilizable, pero en la práctica tenía un solo consumidor y una sola representación válida. Ese render prop agregaba complejidad accidental, volvía más opaco el contrato y repartía una responsabilidad visual del feature en Settings. Con este cambio, el catálogo vuelve a ser una pieza KISS: conoce su propio card y expone solo las acciones de negocio que realmente necesita.

## Validación
- `npm test -- --runInBand tests/integration/renderer/settings.page.dom.test.js tests/integration/renderer/repository-source-context.dom.test.js tests/unit/renderer/repository-source-config-hooks.dom.test.js`

Closes #47
