### PR TITLE
refactor: invertir la dependencia de storage en useRepositorySourceConfig

### DIFF
--- a/src/renderer/features/repository-source/application/repositorySourceConfigStoragePort.ts
+++ b/src/renderer/features/repository-source/application/repositorySourceConfigStoragePort.ts
@@ -1,0 +1,8 @@
+import type { SavedConnectionConfig } from '../types';
+
+export interface RepositorySourceConfigStoragePort {
+  loadConfig(): SavedConnectionConfig;
+  persistConfig(config: SavedConnectionConfig): Promise<void>;
+  hydrateSecret(): Promise<string>;
+  migrateLegacyStorage(): Promise<void>;
+}

--- a/src/renderer/features/repository-source/data/repositorySourceConfigStorageAdapter.ts
+++ b/src/renderer/features/repository-source/data/repositorySourceConfigStorageAdapter.ts
@@ -1,0 +1,14 @@
+import type { RepositorySourceConfigStoragePort } from '../application/repositorySourceConfigStoragePort';
+import {
+  hydrateConnectionSecret,
+  loadConnectionConfig,
+  migrateLegacyRepositorySourceStorage,
+  persistConnectionConfig,
+} from './repositorySourceStorage';
+
+export const repositorySourceConfigStorageAdapter: RepositorySourceConfigStoragePort = {
+  loadConfig: loadConnectionConfig,
+  persistConfig: persistConnectionConfig,
+  hydrateSecret: hydrateConnectionSecret,
+  migrateLegacyStorage: migrateLegacyRepositorySourceStorage,
+};

--- a/src/renderer/features/repository-source/presentation/hooks/useRepositorySource.ts
+++ b/src/renderer/features/repository-source/presentation/hooks/useRepositorySource.ts
@@ -1,6 +1,7 @@
 import React from 'react';
 import { getRepositoryProvider } from '../../providers';
 import { buildScopeLabel, getProviderDisplayName } from '../../application/repositorySourceDiagnostics';
+import { repositorySourceConfigStorageAdapter } from '../../data/repositorySourceConfigStorageAdapter';
 import { useRepositorySourceBootstrap } from './useRepositorySourceBootstrap';
 import { useRepositorySourceConfig } from './useRepositorySourceConfig';
 import { useRepositorySourceDerived } from './useRepositorySourceDerived';
@@ -8,7 +9,9 @@ import { useRepositorySourceController } from './useRepositorySourceController';
 import { useRepositorySourceSnapshotPersistence } from './useRepositorySourceSnapshotPersistence';
 
 export function useRepositorySource() {
-  const configHook = useRepositorySourceConfig();
+  const configHook = useRepositorySourceConfig({
+    storage: repositorySourceConfigStorageAdapter,
+  });
   const { config, configRef, updateConfig, selectProjectConfig, hydrateSecret, migrateLegacyStorage } = configHook;
   const { applyHydratedSecret } = configHook;
   const persistSnapshot = useRepositorySourceSnapshotPersistence(configRef);

--- a/src/renderer/features/repository-source/presentation/hooks/useRepositorySourceConfig.ts
+++ b/src/renderer/features/repository-source/presentation/hooks/useRepositorySourceConfig.ts
@@ -1,13 +1,12 @@
 import React from 'react';
-import {
-  hydrateConnectionSecret,
-  loadConnectionConfig,
-  migrateLegacyRepositorySourceStorage,
-  persistConnectionConfig,
-} from '../../data/repositorySourceStorage';
 import { getRepositorySourceProviderBehavior } from '../../application/repositorySourceProviderBehavior';
+import type { RepositorySourceConfigStoragePort } from '../../application/repositorySourceConfigStoragePort';
 import type { SavedConnectionConfig } from '../../types';
 import type { RepositoryProviderSelection } from '../../../../../types/repository';
+
+interface UseRepositorySourceConfigOptions {
+  storage: RepositorySourceConfigStoragePort;
+}
 
 interface UseRepositorySourceConfigResult {
   config: SavedConnectionConfig;
@@ -19,15 +18,17 @@ interface UseRepositorySourceConfigResult {
   migrateLegacyStorage: () => Promise<void>;
 }
 
-export function useRepositorySourceConfig(): UseRepositorySourceConfigResult {
-  const initialConfig = React.useMemo(() => loadConnectionConfig(), []);
+export function useRepositorySourceConfig({
+  storage,
+}: UseRepositorySourceConfigOptions): UseRepositorySourceConfigResult {
+  const initialConfig = React.useMemo(() => storage.loadConfig(), [storage]);
   const [config, setConfig] = React.useState<SavedConnectionConfig>(initialConfig);
   const configRef = React.useRef<SavedConnectionConfig>(initialConfig);
 
   React.useEffect(() => {
     configRef.current = config;
-    void persistConnectionConfig(config);
-  }, [config]);
+    void storage.persistConfig(config);
+  }, [config, storage]);
 
   const updateConfig = React.useCallback((name: keyof SavedConnectionConfig, value: string) => {
     setConfig((current) => {
@@ -70,8 +71,8 @@ export function useRepositorySourceConfig(): UseRepositorySourceConfigResult {
     return nextConfig;
   }, []);
 
-  const hydrateSecret = React.useCallback(() => hydrateConnectionSecret(), []);
-  const migrateLegacyStorage = React.useCallback(() => migrateLegacyRepositorySourceStorage(), []);
+  const hydrateSecret = React.useCallback(() => storage.hydrateSecret(), [storage]);
+  const migrateLegacyStorage = React.useCallback(() => storage.migrateLegacyStorage(), [storage]);
 
   return {
     config,

--- a/tests/integration/renderer/repository-source-context.dom.test.js
+++ b/tests/integration/renderer/repository-source-context.dom.test.js
@@ -1,18 +1,20 @@
 const React = require('react');
 const { render, screen, waitFor } = require('@testing-library/react');
 
-jest.mock('../../../src/renderer/features/repository-source/data/repositorySourceStorage', () => ({
-  loadConnectionConfig: jest.fn(),
-  persistConnectionConfig: jest.fn().mockResolvedValue(undefined),
-  hydrateConnectionSecret: jest.fn(),
-  migrateLegacyRepositorySourceStorage: jest.fn().mockResolvedValue(undefined),
+jest.mock('../../../src/renderer/features/repository-source/data/repositorySourceConfigStorageAdapter', () => ({
+  repositorySourceConfigStorageAdapter: {
+    loadConfig: jest.fn(),
+    persistConfig: jest.fn().mockResolvedValue(undefined),
+    hydrateSecret: jest.fn(),
+    migrateLegacyStorage: jest.fn().mockResolvedValue(undefined),
+  },
 }));
 
 jest.mock('../../../src/renderer/features/repository-source/presentation/hooks/useRepositorySourceController', () => ({
   useRepositorySourceController: jest.fn(),
 }));
 
-const storage = require('../../../src/renderer/features/repository-source/data/repositorySourceStorage');
+const { repositorySourceConfigStorageAdapter } = require('../../../src/renderer/features/repository-source/data/repositorySourceConfigStorageAdapter');
 const { useRepositorySourceController } = require('../../../src/renderer/features/repository-source/presentation/hooks/useRepositorySourceController');
 const {
   RepositorySourceProvider,
@@ -21,7 +23,7 @@ const {
 
 describe('RepositorySourceProvider integration', () => {
   beforeEach(() => {
-    storage.loadConnectionConfig.mockReturnValue({
+    repositorySourceConfigStorageAdapter.loadConfig.mockReturnValue({
       provider: 'github',
       organization: 'acme',
       project: '',
@@ -29,7 +31,7 @@ describe('RepositorySourceProvider integration', () => {
       personalAccessToken: '',
       targetReviewer: '',
     });
-    storage.hydrateConnectionSecret.mockResolvedValue('gh-token');
+    repositorySourceConfigStorageAdapter.hydrateSecret.mockResolvedValue('gh-token');
     useRepositorySourceController.mockReturnValue({
       pullRequests: [
         {

--- a/tests/unit/renderer/repository-source-config-hooks.dom.test.js
+++ b/tests/unit/renderer/repository-source-config-hooks.dom.test.js
@@ -1,33 +1,30 @@
 const { renderHook, act, waitFor } = require('@testing-library/react');
 
-jest.mock('../../../src/renderer/features/repository-source/data/repositorySourceStorage', () => ({
-  loadConnectionConfig: jest.fn(),
-  persistConnectionConfig: jest.fn().mockResolvedValue(undefined),
-  hydrateConnectionSecret: jest.fn(),
-  migrateLegacyRepositorySourceStorage: jest.fn().mockResolvedValue(undefined),
-}));
-
-const storage = require('../../../src/renderer/features/repository-source/data/repositorySourceStorage');
 const { useRepositorySourceConfig } = require('../../../src/renderer/features/repository-source/presentation/hooks/useRepositorySourceConfig');
 const { useRepositorySourceBootstrap } = require('../../../src/renderer/features/repository-source/presentation/hooks/useRepositorySourceBootstrap');
 const { useRepositorySourceDerived } = require('../../../src/renderer/features/repository-source/presentation/hooks/useRepositorySourceDerived');
 
 describe('repository source config hooks', () => {
+  let storage;
+
   beforeEach(() => {
-    jest.clearAllMocks();
-    storage.loadConnectionConfig.mockReturnValue({
-      provider: '',
-      organization: '',
-      project: '',
-      repositoryId: '',
-      personalAccessToken: '',
-      targetReviewer: '',
-    });
-    storage.hydrateConnectionSecret.mockResolvedValue('');
+    storage = {
+      loadConfig: jest.fn().mockReturnValue({
+        provider: '',
+        organization: '',
+        project: '',
+        repositoryId: '',
+        personalAccessToken: '',
+        targetReviewer: '',
+      }),
+      persistConfig: jest.fn().mockResolvedValue(undefined),
+      hydrateSecret: jest.fn().mockResolvedValue(''),
+      migrateLegacyStorage: jest.fn().mockResolvedValue(undefined),
+    };
   });
 
   test('useRepositorySourceConfig resetea scope al cambiar provider y persiste config segura', async () => {
-    storage.loadConnectionConfig.mockReturnValue({
+    storage.loadConfig.mockReturnValue({
       provider: 'azure-devops',
       organization: 'org-a',
       project: 'project-a',
@@ -36,7 +33,7 @@ describe('repository source config hooks', () => {
       targetReviewer: 'ian',
     });
 
-    const { result } = renderHook(() => useRepositorySourceConfig());
+    const { result } = renderHook(() => useRepositorySourceConfig({ storage }));
 
     await act(async () => {
       result.current.updateConfig('provider', 'github');
@@ -52,7 +49,7 @@ describe('repository source config hooks', () => {
     });
 
     await waitFor(() => {
-      expect(storage.persistConnectionConfig).toHaveBeenLastCalledWith({
+      expect(storage.persistConfig).toHaveBeenLastCalledWith({
         provider: 'github',
         organization: '',
         project: '',
@@ -64,7 +61,7 @@ describe('repository source config hooks', () => {
   });
 
   test('useRepositorySourceConfig asigna repositoryId segun provider al seleccionar proyecto', async () => {
-    storage.loadConnectionConfig.mockReturnValue({
+    storage.loadConfig.mockReturnValue({
       provider: 'github',
       organization: 'acme',
       project: '',
@@ -73,7 +70,7 @@ describe('repository source config hooks', () => {
       targetReviewer: '',
     });
 
-    const { result } = renderHook(() => useRepositorySourceConfig());
+    const { result } = renderHook(() => useRepositorySourceConfig({ storage }));
 
     await act(async () => {
       result.current.selectProjectConfig('repo-a');
@@ -85,7 +82,7 @@ describe('repository source config hooks', () => {
   });
 
   test('useRepositorySourceConfig resetea project y repositoryId al cambiar organization', async () => {
-    storage.loadConnectionConfig.mockReturnValue({
+    storage.loadConfig.mockReturnValue({
       provider: 'azure-devops',
       organization: 'acme',
       project: 'platform',
@@ -94,7 +91,7 @@ describe('repository source config hooks', () => {
       targetReviewer: '',
     });
 
-    const { result } = renderHook(() => useRepositorySourceConfig());
+    const { result } = renderHook(() => useRepositorySourceConfig({ storage }));
 
     await act(async () => {
       result.current.updateConfig('organization', 'other-org');
@@ -111,7 +108,7 @@ describe('repository source config hooks', () => {
   });
 
   test('useRepositorySourceConfig limpia solo repositoryId al cambiar project', async () => {
-    storage.loadConnectionConfig.mockReturnValue({
+    storage.loadConfig.mockReturnValue({
       provider: 'azure-devops',
       organization: 'acme',
       project: 'platform',
@@ -120,7 +117,7 @@ describe('repository source config hooks', () => {
       targetReviewer: '',
     });
 
-    const { result } = renderHook(() => useRepositorySourceConfig());
+    const { result } = renderHook(() => useRepositorySourceConfig({ storage }));
 
     await act(async () => {
       result.current.updateConfig('project', 'platform-v2');
@@ -131,7 +128,7 @@ describe('repository source config hooks', () => {
   });
 
   test('useRepositorySourceConfig mantiene repositoryId vacio al seleccionar proyecto en azure', async () => {
-    storage.loadConnectionConfig.mockReturnValue({
+    storage.loadConfig.mockReturnValue({
       provider: 'azure-devops',
       organization: 'acme',
       project: '',
@@ -140,7 +137,7 @@ describe('repository source config hooks', () => {
       targetReviewer: '',
     });
 
-    const { result } = renderHook(() => useRepositorySourceConfig());
+    const { result } = renderHook(() => useRepositorySourceConfig({ storage }));
 
     await act(async () => {
       result.current.selectProjectConfig('platform');
@@ -151,15 +148,15 @@ describe('repository source config hooks', () => {
   });
 
   test('useRepositorySourceConfig hidrata el secreto desde storage', async () => {
-    storage.hydrateConnectionSecret.mockResolvedValue('pat-session');
+    storage.hydrateSecret.mockResolvedValue('pat-session');
 
-    const { result } = renderHook(() => useRepositorySourceConfig());
+    const { result } = renderHook(() => useRepositorySourceConfig({ storage }));
 
     await expect(result.current.hydrateSecret()).resolves.toBe('pat-session');
   });
 
   test('useRepositorySourceConfig aplica el secreto hidratado sin disparar resets de config', async () => {
-    const { result } = renderHook(() => useRepositorySourceConfig());
+    const { result } = renderHook(() => useRepositorySourceConfig({ storage }));
 
     await act(async () => {
       result.current.applyHydratedSecret('pat-session');


### PR DESCRIPTION
## Resumen
- introduce `RepositorySourceConfigStoragePort` como contrato explícito de configuración/persistencia
- crea un adapter por defecto para el storage actual
- hace que `useRepositorySourceConfig` dependa del puerto y no de funciones concretas de la data layer

## Impacto SOLID
- mejora `DIP` porque presentation ya no depende de implementación concreta
- mejora `SRP` porque el hook queda centrado en coordinar estado/config y no infraestructura
- mejora `ISP` porque los tests pueden inyectar un contrato pequeño en vez de mockear el storage completo

## Validación
- `npm test -- --runInBand tests/unit/renderer/repository-source-config-hooks.dom.test.js tests/integration/renderer/repository-source-context.dom.test.js tests/unit/renderer/repository-source-storage.dom.test.js tests/integration/renderer/use-repository-source-hooks.dom.test.js`

Closes #61
