### PR TITLE
refactor: reemplazar ReturnType entre hooks por contratos explícitos

### DIFF
--- a/src/renderer/features/repository-source/presentation/hooks/repositorySourceHookContracts.ts
+++ b/src/renderer/features/repository-source/presentation/hooks/repositorySourceHookContracts.ts
@@ -1,0 +1,19 @@
+import type { RepositorySourceDiagnosticsPort, RepositorySourceStatePort } from '../../application/repositorySourceApiPorts';
+import type { RepositorySourceDiagnostics } from '../../types';
+
+export interface RepositorySourceDiagnosticsController extends RepositorySourceDiagnosticsPort {
+  diagnostics: RepositorySourceDiagnostics;
+  resetDiagnosticsError(): void;
+}
+
+export interface RepositorySourceActionStatePort {
+  resetForConfigChange(name: string, value: string): void;
+  setIsConnectionPanelOpen(value: boolean): void;
+  markProjectSelection(project: string): void;
+}
+
+export interface RepositorySourceEffectsStatePort extends RepositorySourceStatePort {
+  shouldLoadRepositories: boolean;
+  resetDisconnectedState(): void;
+  setShouldLoadRepositories(value: boolean): void;
+}

--- a/src/renderer/features/repository-source/presentation/hooks/useRepositoryDiagnostics.ts
+++ b/src/renderer/features/repository-source/presentation/hooks/useRepositoryDiagnostics.ts
@@ -1,8 +1,9 @@
 import React from 'react';
 import { buildDiagnostics } from '../../application/repositorySourceDiagnostics';
 import type { RepositorySourceDiagnostics, SavedConnectionConfig } from '../../types';
+import type { RepositorySourceDiagnosticsController } from './repositorySourceHookContracts';
 
-export function useRepositoryDiagnostics(initialConfig: SavedConnectionConfig) {
+export function useRepositoryDiagnostics(initialConfig: SavedConnectionConfig): RepositorySourceDiagnosticsController {
   const [diagnostics, setDiagnostics] = React.useState<RepositorySourceDiagnostics>(
     () => buildDiagnostics(null, initialConfig),
   );

--- a/src/renderer/features/repository-source/presentation/hooks/useRepositorySourceActions.ts
+++ b/src/renderer/features/repository-source/presentation/hooks/useRepositorySourceActions.ts
@@ -1,11 +1,13 @@
 import React from 'react';
 import type { SavedConnectionConfig } from '../../types';
-import type { useRepositoryDiagnostics } from './useRepositoryDiagnostics';
-import type { useRepositorySourceState } from './useRepositorySourceState';
+import type {
+  RepositorySourceActionStatePort,
+  RepositorySourceDiagnosticsController,
+} from './repositorySourceHookContracts';
 
 interface UseRepositorySourceActionsOptions {
-  state: ReturnType<typeof useRepositorySourceState>;
-  diagnostics: ReturnType<typeof useRepositoryDiagnostics>;
+  state: RepositorySourceActionStatePort;
+  diagnostics: RepositorySourceDiagnosticsController;
 }
 
 export function useRepositorySourceActions({

--- a/src/renderer/features/repository-source/presentation/hooks/useRepositorySourceApi.ts
+++ b/src/renderer/features/repository-source/presentation/hooks/useRepositorySourceApi.ts
@@ -4,17 +4,19 @@ import { createRepositorySourceApi } from '../../application/repositorySourceApi
 import { repositorySourceFetcher } from '../../data/repositorySourceFetcher';
 import type { RepositorySourceFetcherPort } from '../../data/repositorySourceFetcher';
 import type { SavedConnectionConfig } from '../../types';
-import type { useRepositoryDiagnostics } from './useRepositoryDiagnostics';
+import type {
+  RepositorySourceDiagnosticsController,
+  RepositorySourceEffectsStatePort,
+} from './repositorySourceHookContracts';
 import { useRepositorySourceEffects } from './useRepositorySourceEffects';
-import type { useRepositorySourceState } from './useRepositorySourceState';
 
 interface UseRepositorySourceApiOptions {
   config: SavedConnectionConfig;
   configRef: React.MutableRefObject<SavedConnectionConfig>;
   activeProviderName: string;
   scopeLabel: string;
-  state: ReturnType<typeof useRepositorySourceState>;
-  diagnostics: ReturnType<typeof useRepositoryDiagnostics>;
+  state: RepositorySourceEffectsStatePort;
+  diagnostics: RepositorySourceDiagnosticsController;
   onPersistSnapshot: (pullRequests: ReviewItem[], capturedAt: Date, scopeLabel: string, targetReviewer?: string) => void;
   fetcher?: RepositorySourceFetcherPort;
 }

--- a/src/renderer/features/repository-source/presentation/hooks/useRepositorySourceEffects.ts
+++ b/src/renderer/features/repository-source/presentation/hooks/useRepositorySourceEffects.ts
@@ -1,12 +1,12 @@
 import React from 'react';
 import { hasMinimumRepositoryConfig } from '../../application/repositorySourceRules';
 import type { SavedConnectionConfig } from '../../types';
-import type { useRepositorySourceState } from './useRepositorySourceState';
+import type { RepositorySourceEffectsStatePort } from './repositorySourceHookContracts';
 
 interface UseRepositorySourceEffectsOptions {
   config: SavedConnectionConfig;
   configRef: React.MutableRefObject<SavedConnectionConfig>;
-  state: ReturnType<typeof useRepositorySourceState>;
+  state: RepositorySourceEffectsStatePort;
   refreshRepositories: (nextConfig?: SavedConnectionConfig) => Promise<unknown[]>;
 }
 


### PR DESCRIPTION
## Resumen
- reemplaza contratos cruzados basados en `ReturnType<typeof ...>` por interfaces explícitas entre hooks
- define puertos pequeños para actions, effects y diagnostics controller
- deja a los hooks dependiendo de superficies más pequeñas y estables

## Impacto SOLID
- mejora `ISP` porque cada hook depende solo del subconjunto que realmente usa
- mejora `DIP` porque los contratos dejan de ser el shape accidental de otro hook
- reduce fragilidad al refactorizar `useRepositorySourceState` y `useRepositoryDiagnostics`

## Validación
- `npm test -- --runInBand tests/integration/renderer/use-repository-source-hooks.dom.test.js tests/unit/renderer/repository-source-operations.dom.test.js tests/unit/renderer/repository-source-config-hooks.dom.test.js`

Closes #62
