### PR TITLE
refactor: definir un contrato público explícito para RepositorySourceContext

### DIFF
--- a/src/renderer/features/repository-source/presentation/context/RepositorySourceContext.tsx
+++ b/src/renderer/features/repository-source/presentation/context/RepositorySourceContext.tsx
@@ -1,12 +1,40 @@
 import React from 'react';
+import type { RepositoryProject, RepositoryProviderDefinition, RepositorySummary, ReviewItem } from '../../../../../types/repository';
+import type { DashboardSummary } from '../../../../shared/dashboard/summary.types';
+import type { RepositorySourceDiagnostics, SavedConnectionConfig } from '../../types';
 import { useRepositorySource } from '../hooks/useRepositorySource';
 
-type RepositorySourceValue = ReturnType<typeof useRepositorySource>;
+export interface RepositorySourceContextValue {
+  activeProvider: RepositoryProviderDefinition | null;
+  activeProviderName: string;
+  config: SavedConnectionConfig;
+  error: string | null;
+  isLoading: boolean;
+  projects: RepositoryProject[];
+  projectsLoading: boolean;
+  projectDiscoveryWarning: string | null;
+  repositories: RepositorySummary[];
+  repositoriesLoading: boolean;
+  hasCredentialsInSession: boolean;
+  hasSuccessfulConnection: boolean;
+  isConnectionReady: boolean;
+  diagnostics: RepositorySourceDiagnostics;
+  selectedProjectName: string | null;
+  selectedRepositoryName: string | null;
+  summary: DashboardSummary;
+  isConnectionPanelOpen: boolean;
+  updateConfig(name: keyof SavedConnectionConfig, value: string): void;
+  discoverProjects(): Promise<unknown[] | void>;
+  selectProject(project: string): void;
+  refreshPullRequests(): Promise<ReviewItem[] | void>;
+  openPullRequest(url: string): Promise<void>;
+  openConnectionPanel(): void;
+}
 
-const RepositorySourceContext = React.createContext<RepositorySourceValue | null>(null);
+const RepositorySourceContext = React.createContext<RepositorySourceContextValue | null>(null);
 
 export function RepositorySourceProvider({ children }: { children: React.ReactNode }) {
-  const value = useRepositorySource();
+  const value: RepositorySourceContextValue = useRepositorySource();
 
   return (
     <RepositorySourceContext.Provider value={value}>
@@ -15,7 +43,7 @@ export function RepositorySourceProvider({ children }: { children: React.ReactNo
   );
 }
 
-export function useRepositorySourceContext(): RepositorySourceValue {
+export function useRepositorySourceContext(): RepositorySourceContextValue {
   const value = React.useContext(RepositorySourceContext);
 
   if (!value) {


### PR DESCRIPTION
## Resumen
- define `RepositorySourceContextValue` como contrato público explícito del feature
- elimina la dependencia del contexto respecto a `ReturnType<typeof useRepositorySource>`
- mantiene estable la API pública que consumen Dashboard, Settings y Repository Analysis

## Impacto SOLID
- mejora `ISP` porque la API pública del feature ya no depende del shape accidental de un hook interno
- mejora `DIP` porque el contexto depende de un contrato estable y no de una implementación
- hace más seguro seguir refactorizando `useRepositorySource` sin romper consumidores por accidente

## Validación
- `npm test -- --runInBand tests/integration/renderer/repository-source-context.dom.test.js tests/integration/renderer/dashboard.page.dom.test.js tests/integration/renderer/settings.page.dom.test.js tests/integration/renderer/repository-analysis.page.dom.test.js`

Closes #63
