### PR TITLE
refactor: sacar el wiring del fetcher por defecto fuera de useRepositorySourceApi

### DIFF
--- a/src/renderer/features/repository-source/presentation/hooks/useRepositorySourceApi.ts
+++ b/src/renderer/features/repository-source/presentation/hooks/useRepositorySourceApi.ts
@@ -1,7 +1,6 @@
 import React from 'react';
 import type { ReviewItem } from '../../../../../types/repository';
 import { createRepositorySourceApi } from '../../application/repositorySourceApiFactory';
-import { repositorySourceFetcher } from '../../data/repositorySourceFetcher';
 import type { RepositorySourceFetcherPort } from '../../data/repositorySourceFetcher';
 import type { SavedConnectionConfig } from '../../types';
 import type { useRepositoryDiagnostics } from './useRepositoryDiagnostics';
@@ -16,7 +15,7 @@ interface UseRepositorySourceApiOptions {
   state: ReturnType<typeof useRepositorySourceState>;
   diagnostics: ReturnType<typeof useRepositoryDiagnostics>;
   onPersistSnapshot: (pullRequests: ReviewItem[], capturedAt: Date, scopeLabel: string, targetReviewer?: string) => void;
-  fetcher?: RepositorySourceFetcherPort;
+  fetcher: RepositorySourceFetcherPort;
 }
 
 export function useRepositorySourceApi({
@@ -27,7 +26,7 @@ export function useRepositorySourceApi({
   state,
   diagnostics,
   onPersistSnapshot,
-  fetcher = repositorySourceFetcher,
+  fetcher,
 }: UseRepositorySourceApiOptions) {
   const api = React.useMemo(() => createRepositorySourceApi({
     configRef,

--- a/src/renderer/features/repository-source/presentation/hooks/useRepositorySourceController.ts
+++ b/src/renderer/features/repository-source/presentation/hooks/useRepositorySourceController.ts
@@ -1,5 +1,6 @@
 import type React from 'react';
 import type { ReviewItem } from '../../../../../types/repository';
+import { repositorySourceFetcher } from '../../data/repositorySourceFetcher';
 import type { SavedConnectionConfig } from '../../types';
 import { useRepositorySourceActions } from './useRepositorySourceActions';
 import { useRepositoryDiagnostics } from './useRepositoryDiagnostics';
@@ -35,6 +36,7 @@ export function useRepositorySourceController({
     state,
     diagnostics,
     onPersistSnapshot,
+    fetcher: repositorySourceFetcher,
   });
 
   return {

--- a/tests/integration/renderer/use-repository-source-hooks.dom.test.js
+++ b/tests/integration/renderer/use-repository-source-hooks.dom.test.js
@@ -20,6 +20,7 @@ jest.mock('../../../src/renderer/features/repository-source/presentation/hooks/u
 }));
 
 const ipc = require('../../../src/renderer/features/repository-source/data/repositorySourceIpc');
+const { repositorySourceFetcher } = require('../../../src/renderer/features/repository-source/data/repositorySourceFetcher');
 const { useRepositorySourceEffects } = require('../../../src/renderer/features/repository-source/presentation/hooks/useRepositorySourceEffects');
 const { useRepositorySourceState } = require('../../../src/renderer/features/repository-source/presentation/hooks/useRepositorySourceState');
 const { useRepositoryDiagnostics } = require('../../../src/renderer/features/repository-source/presentation/hooks/useRepositoryDiagnostics');
@@ -223,6 +224,7 @@ describe('repository source hooks', () => {
       state,
       diagnostics,
       onPersistSnapshot,
+      fetcher: repositorySourceFetcher,
     }));
 
     await act(async () => {


### PR DESCRIPTION
## Resumen
- saca el `repositorySourceFetcher` por defecto de `useRepositorySourceApi`
- mueve ese wiring al punto de composición más externo (`useRepositorySourceController`)
- ajusta los tests para inyectar el fetcher de forma explícita

## Impacto SOLID
- mejora `DIP` porque el hook API ya no conoce una implementación concreta por defecto
- mejora `SRP` porque `useRepositorySourceApi` queda centrado en coordinar contratos, no en resolver infraestructura
- facilita extender o reemplazar fetchers sin tocar el hook

## Validación
- `npm test -- --runInBand tests/integration/renderer/use-repository-source-hooks.dom.test.js tests/unit/renderer/repository-source-operations.dom.test.js tests/integration/renderer/repository-source-context.dom.test.js`

Closes #64
