### PR TITLE
refactor: reemplazar el bootstrap hardcodeado de providers por módulos

### DIFF
--- a/src/main/application-bootstrap.ts
+++ b/src/main/application-bootstrap.ts
@@ -1,14 +1,14 @@
 import { registerIpcHandlers } from './ipc/register';
 import { createWindow } from './main-window';
-import { buildDefaultRepositoryProviderPorts } from '../services/providers/repository-provider.bootstrap';
-import { createRepositoryProviderRegistry } from '../services/providers/repository-provider.composition';
+import { buildDefaultRepositoryProviderModules } from '../services/providers/repository-provider.bootstrap';
+import { createRepositoryProviderRegistryFromModules } from '../services/providers/repository-provider.composition';
 import { RepositoryAnalysisSnapshotProvider } from '../services/analysis/repository-analysis.snapshot-provider';
 import { PullRequestAnalysisSnapshotProvider } from '../services/analysis/pull-request-analysis.snapshot-provider';
 import { createRepositoryAnalysisService } from '../services/analysis/repository-analysis.factory';
 import { createPullRequestAnalysisService } from '../services/analysis/pull-request-analysis.factory';
 
 export function createApplicationServices() {
-  const providerRegistry = createRepositoryProviderRegistry(buildDefaultRepositoryProviderPorts());
+  const providerRegistry = createRepositoryProviderRegistryFromModules(buildDefaultRepositoryProviderModules());
   const repositoryAnalysisService = createRepositoryAnalysisService({
     snapshotProvider: new RepositoryAnalysisSnapshotProvider(providerRegistry),
   });

--- a/src/services/azure/azure.provider-module.ts
+++ b/src/services/azure/azure.provider-module.ts
@@ -1,0 +1,11 @@
+import type { RepositoryProviderModule } from '../providers/repository-provider.module';
+import { pullRequestService } from './pr.service';
+
+export const azureProviderModule: RepositoryProviderModule = {
+  kind: 'azure-devops',
+  createPort() {
+    return Object.assign(pullRequestService, {
+      kind: 'azure-devops' as const,
+    });
+  },
+};

--- a/src/services/github/github.provider-module.ts
+++ b/src/services/github/github.provider-module.ts
@@ -1,0 +1,11 @@
+import type { RepositoryProviderModule } from '../providers/repository-provider.module';
+import { gitHubRepositoryService } from './repository.service';
+
+export const githubProviderModule: RepositoryProviderModule = {
+  kind: 'github',
+  createPort() {
+    return Object.assign(gitHubRepositoryService, {
+      kind: 'github' as const,
+    });
+  },
+};

--- a/src/services/gitlab/gitlab.provider-module.ts
+++ b/src/services/gitlab/gitlab.provider-module.ts
@@ -1,0 +1,11 @@
+import type { RepositoryProviderModule } from '../providers/repository-provider.module';
+import { gitLabRepositoryService } from './repository.service';
+
+export const gitlabProviderModule: RepositoryProviderModule = {
+  kind: 'gitlab',
+  createPort() {
+    return Object.assign(gitLabRepositoryService, {
+      kind: 'gitlab' as const,
+    });
+  },
+};

--- a/src/services/providers/repository-provider.bootstrap.ts
+++ b/src/services/providers/repository-provider.bootstrap.ts
@@ -1,22 +1,17 @@
-import { pullRequestService } from '../azure/pr.service';
-import { gitHubRepositoryService } from '../github/repository.service';
-import { gitLabRepositoryService } from '../gitlab/repository.service';
-import type { RepositoryProviderKind } from '../../types/repository';
-import type { RepositoryProviderPort, RepositoryProviderService } from './repository-provider.port';
+import { azureProviderModule } from '../azure/azure.provider-module';
+import { githubProviderModule } from '../github/github.provider-module';
+import { gitlabProviderModule } from '../gitlab/gitlab.provider-module';
+import type { RepositoryProviderPort } from './repository-provider.port';
+import type { RepositoryProviderModule } from './repository-provider.module';
 
-function createProviderPort(
-  kind: RepositoryProviderKind,
-  service: RepositoryProviderService,
-): RepositoryProviderPort {
-  return Object.assign(service, {
-    kind,
-  });
+export function buildDefaultRepositoryProviderModules(): RepositoryProviderModule[] {
+  return [
+    azureProviderModule,
+    githubProviderModule,
+    gitlabProviderModule,
+  ];
 }
 
 export function buildDefaultRepositoryProviderPorts(): RepositoryProviderPort[] {
-  return [
-    createProviderPort('azure-devops', pullRequestService),
-    createProviderPort('github', gitHubRepositoryService),
-    createProviderPort('gitlab', gitLabRepositoryService),
-  ];
+  return buildDefaultRepositoryProviderModules().map((module) => module.createPort());
 }

--- a/src/services/providers/repository-provider.composition.ts
+++ b/src/services/providers/repository-provider.composition.ts
@@ -1,4 +1,5 @@
 import type { RepositoryProviderPort } from './repository-provider.port';
+import type { RepositoryProviderModule } from './repository-provider.module';
 import { RepositoryProviderRegistry } from './repository-provider.registry';
 
 export function createRepositoryProviderRegistry(providers: RepositoryProviderPort[] = []) {
@@ -7,3 +8,6 @@ export function createRepositoryProviderRegistry(providers: RepositoryProviderPo
   return registry;
 }
 
+export function createRepositoryProviderRegistryFromModules(modules: RepositoryProviderModule[] = []) {
+  return createRepositoryProviderRegistry(modules.map((module) => module.createPort()));
+}

--- a/src/services/providers/repository-provider.module.ts
+++ b/src/services/providers/repository-provider.module.ts
@@ -1,0 +1,7 @@
+import type { RepositoryProviderKind } from '../../types/repository';
+import type { RepositoryProviderPort } from './repository-provider.port';
+
+export interface RepositoryProviderModule {
+  readonly kind: RepositoryProviderKind;
+  createPort(): RepositoryProviderPort;
+}

--- a/tests/unit/main/main.test.js
+++ b/tests/unit/main/main.test.js
@@ -41,6 +41,7 @@ jest.mock('../../../src/main/ipc/window-controls', () => ({
 
 jest.mock('../../../src/services/providers/repository-provider.bootstrap', () => ({
   buildDefaultRepositoryProviderPorts: jest.fn(() => []),
+  buildDefaultRepositoryProviderModules: jest.fn(() => []),
   registerDefaultRepositoryProviders: jest.fn(),
 }));
 
@@ -48,8 +49,16 @@ const { registerIpcHandlers } = require('../../../src/main/ipc/register');
 const { attachWindowStateSync } = require('../../../src/main/ipc/window-controls');
 const {
   buildDefaultRepositoryProviderPorts,
+  buildDefaultRepositoryProviderModules,
   registerDefaultRepositoryProviders,
 } = require('../../../src/services/providers/repository-provider.bootstrap');
+jest.mock('../../../src/services/providers/repository-provider.composition', () => ({
+  createRepositoryProviderRegistry: jest.fn(() => ({ get: jest.fn(), list: jest.fn(() => []) })),
+  createRepositoryProviderRegistryFromModules: jest.fn(() => ({ get: jest.fn(), list: jest.fn(() => []) })),
+}));
+const {
+  createRepositoryProviderRegistryFromModules,
+} = require('../../../src/services/providers/repository-provider.composition');
 const main = require('../../../src/main');
 const { app, BrowserWindow } = require('electron');
 
@@ -147,7 +156,8 @@ describe('main process bootstrap', () => {
   test('bootstrapMainProcess registra providers, ipc y crea ventana', () => {
     main.bootstrapMainProcess();
 
-    expect(buildDefaultRepositoryProviderPorts).toHaveBeenCalled();
+    expect(buildDefaultRepositoryProviderModules).toHaveBeenCalled();
+    expect(createRepositoryProviderRegistryFromModules).toHaveBeenCalled();
     expect(registerDefaultRepositoryProviders).not.toHaveBeenCalled();
     expect(registerIpcHandlers).toHaveBeenCalled();
     expect(browserWindowMock).toHaveBeenCalled();
@@ -156,7 +166,7 @@ describe('main process bootstrap', () => {
   test('cuando app esta lista ejecuta bootstrapMainProcess', () => {
     readyCallback();
 
-    expect(buildDefaultRepositoryProviderPorts).toHaveBeenCalled();
+    expect(buildDefaultRepositoryProviderModules).toHaveBeenCalled();
     expect(registerIpcHandlers).toHaveBeenCalled();
   });
 

--- a/tests/unit/services/repository-provider.bootstrap.test.js
+++ b/tests/unit/services/repository-provider.bootstrap.test.js
@@ -2,6 +2,13 @@ const bootstrap = require('../../../src/services/providers/repository-provider.b
 const { pullRequestService } = require('../../../src/services/azure/pr.service');
 
 describe('repository provider bootstrap', () => {
+  test('construye los modules por defecto sin depender de estado global', () => {
+    const modules = bootstrap.buildDefaultRepositoryProviderModules();
+
+    expect(modules).toHaveLength(3);
+    expect(modules.map((module) => module.kind)).toEqual(['azure-devops', 'github', 'gitlab']);
+  });
+
   test('construye los providers por defecto sin depender de estado global', () => {
     const providers = bootstrap.buildDefaultRepositoryProviderPorts();
 
@@ -10,7 +17,7 @@ describe('repository provider bootstrap', () => {
   });
 
   test('cada provider port expone las funciones del servicio subyacente', () => {
-    const [azureProvider] = bootstrap.buildDefaultRepositoryProviderPorts();
+    const [azureProvider] = bootstrap.buildDefaultRepositoryProviderModules().map((module) => module.createPort());
 
     expect(typeof azureProvider.getProjects).toBe('function');
     expect(typeof azureProvider.getRepositories).toBe('function');
@@ -21,7 +28,7 @@ describe('repository provider bootstrap', () => {
   });
 
   test('el provider delega las llamadas al servicio concreto', async () => {
-    const [azureProvider] = bootstrap.buildDefaultRepositoryProviderPorts();
+    const [azureProvider] = bootstrap.buildDefaultRepositoryProviderModules().map((module) => module.createPort());
     jest.spyOn(pullRequestService, 'getProjects').mockResolvedValueOnce([{ id: '1', name: 'Core' }]);
     jest.spyOn(pullRequestService, 'getRepositories').mockResolvedValueOnce([{ id: 'repo', name: 'repo' }]);
     jest.spyOn(pullRequestService, 'getBranches').mockResolvedValueOnce([{ name: 'main', objectId: '1', isDefault: true }]);

--- a/tests/unit/services/repository-provider.composition.test.js
+++ b/tests/unit/services/repository-provider.composition.test.js
@@ -1,9 +1,20 @@
-const { createRepositoryProviderRegistry } = require('../../../src/services/providers/repository-provider.composition');
-const { buildDefaultRepositoryProviderPorts } = require('../../../src/services/providers/repository-provider.bootstrap');
+const {
+  createRepositoryProviderRegistry,
+  createRepositoryProviderRegistryFromModules,
+} = require('../../../src/services/providers/repository-provider.composition');
+const {
+  buildDefaultRepositoryProviderPorts,
+  buildDefaultRepositoryProviderModules,
+} = require('../../../src/services/providers/repository-provider.bootstrap');
 
 describe('repository provider composition', () => {
   test('crea un registry poblado con providers por defecto', () => {
     const registry = createRepositoryProviderRegistry(buildDefaultRepositoryProviderPorts());
+    expect(registry.list().map((provider) => provider.kind)).toEqual(['azure-devops', 'github', 'gitlab']);
+  });
+
+  test('crea un registry poblado desde modules enchufables', () => {
+    const registry = createRepositoryProviderRegistryFromModules(buildDefaultRepositoryProviderModules());
     expect(registry.list().map((provider) => provider.kind)).toEqual(['azure-devops', 'github', 'gitlab']);
   });
 });


### PR DESCRIPTION
## Resumen
- introduce `RepositoryProviderModule` como contrato enchufable para providers backend
- mueve Azure, GitHub y GitLab a módulos explícitos por provider
- hace que `application-bootstrap` componga el registry desde módulos en lugar de services concretos

## Impacto SOLID
- mejora `OCP` porque agregar un provider operativo ya no obliga a editar el composition root con imports de services concretos
- mejora `DIP` porque el bootstrap depende de módulos/provider manifests y no de implementaciones puntuales
- mejora `SRP` porque la composición del main deja de conocer detalles finos de cada adapter

## Validación
- `npm test -- --runInBand tests/unit/services/repository-provider.bootstrap.test.js tests/unit/services/repository-provider.composition.test.js tests/unit/main/main.test.js tests/unit/services/repository-provider.registry.test.js`

Closes #70
