### PR TITLE
refactor: dividir registerAnalysisIpc en handlers y resolución de secretos

### DIFF
--- a/src/main/ipc/analysis-api-key-resolver.ts
+++ b/src/main/ipc/analysis-api-key-resolver.ts
@@ -1,0 +1,16 @@
+import { CODEX_SESSION_API_KEY } from '../../constants/session-secrets';
+import type { SessionSecretsStore } from './session-secrets';
+
+export interface AnalysisApiKeyResolverPort {
+  readCodexApiKey(): string;
+}
+
+export function createAnalysisApiKeyResolver(
+  sessionSecretsStore: SessionSecretsStore,
+): AnalysisApiKeyResolverPort {
+  return {
+    readCodexApiKey() {
+      return sessionSecretsStore.get(CODEX_SESSION_API_KEY);
+    },
+  };
+}

--- a/src/main/ipc/analysis-handlers.ts
+++ b/src/main/ipc/analysis-handlers.ts
@@ -1,0 +1,52 @@
+import type { PullRequestAnalysisPreview, RepositorySnapshotPreview } from '../../types/analysis';
+import type { RepositoryAnalysisService } from '../../services/analysis/repository-analysis.service';
+import type { PullRequestAnalysisService } from '../../services/analysis/pull-request-analysis.service';
+import type { AnalysisApiKeyResolverPort } from './analysis-api-key-resolver';
+import { sanitizePullRequestAnalysisPayload } from './pull-request-analysis.sanitizer';
+import { sanitizeRepositoryAnalysisPayload } from './repository-analysis.sanitizer';
+
+export interface AnalysisIpcHandlers {
+  previewRepositorySnapshot(payload: unknown): Promise<RepositorySnapshotPreview>;
+  runRepositoryAnalysis(payload: unknown): Promise<unknown>;
+  cancelRepositoryAnalysis(requestId: string): Promise<void>;
+  previewPullRequestAiReviews(payload: unknown): Promise<PullRequestAnalysisPreview[]>;
+  runPullRequestAiReviews(payload: unknown): Promise<unknown>;
+  cancelPullRequestAiReviews(requestId: string): Promise<void>;
+}
+
+export function createAnalysisIpcHandlers(
+  repositoryAnalysisService: RepositoryAnalysisService,
+  pullRequestAnalysisService: PullRequestAnalysisService,
+  apiKeyResolver: AnalysisApiKeyResolverPort,
+): AnalysisIpcHandlers {
+  const readCodexApiKey = () => apiKeyResolver.readCodexApiKey();
+
+  return {
+    previewRepositorySnapshot(payload) {
+      return repositoryAnalysisService.previewSnapshot(
+        sanitizeRepositoryAnalysisPayload(payload, readCodexApiKey()),
+      );
+    },
+    runRepositoryAnalysis(payload) {
+      return repositoryAnalysisService.runAnalysis(
+        sanitizeRepositoryAnalysisPayload(payload, readCodexApiKey()),
+      );
+    },
+    async cancelRepositoryAnalysis(requestId) {
+      repositoryAnalysisService.cancelAnalysis(requestId);
+    },
+    previewPullRequestAiReviews(payload) {
+      return pullRequestAnalysisService.previewBatch(
+        sanitizePullRequestAnalysisPayload(payload, readCodexApiKey()),
+      );
+    },
+    runPullRequestAiReviews(payload) {
+      return pullRequestAnalysisService.analyzeBatch(
+        sanitizePullRequestAnalysisPayload(payload, readCodexApiKey()),
+      );
+    },
+    async cancelPullRequestAiReviews(requestId) {
+      pullRequestAnalysisService.cancelAnalysis(requestId);
+    },
+  };
+}

--- a/src/main/ipc/analysis.ts
+++ b/src/main/ipc/analysis.ts
@@ -1,37 +1,29 @@
 import type { PullRequestAnalysisPreview, RepositorySnapshotPreview } from '../../types/analysis';
-import type { RepositoryAnalysisService } from '../../services/analysis/repository-analysis.service';
-import type { PullRequestAnalysisService } from '../../services/analysis/pull-request-analysis.service';
-import type { SessionSecretsStore } from './session-secrets';
-import { CODEX_SESSION_API_KEY } from '../../constants/session-secrets';
 import { registerHandle } from './shared';
+import type { AnalysisIpcHandlers } from './analysis-handlers';
 import { sanitizePullRequestAnalysisPayload } from './pull-request-analysis.sanitizer';
 import { sanitizeRepositoryAnalysisPayload } from './repository-analysis.sanitizer';
 
 export const sanitizeAnalysisPayload = sanitizeRepositoryAnalysisPayload;
 export { sanitizePullRequestAnalysisPayload };
 
-export function registerAnalysisIpc(
-  repositoryAnalysisService: RepositoryAnalysisService,
-  pullRequestAnalysisService: PullRequestAnalysisService,
-  sessionSecretsStore: SessionSecretsStore,
-): void {
-  const readCodexApiKey = () => sessionSecretsStore.get(CODEX_SESSION_API_KEY);
+export function registerAnalysisIpc(handlers: AnalysisIpcHandlers): void {
   registerHandle<unknown, RepositorySnapshotPreview>('analysis:previewRepositorySnapshot', async (payload) => (
-    repositoryAnalysisService.previewSnapshot(sanitizeRepositoryAnalysisPayload(payload, readCodexApiKey()))
+    handlers.previewRepositorySnapshot(payload)
   ));
   registerHandle<unknown, unknown>('analysis:runRepositoryAnalysis', async (payload) => (
-    repositoryAnalysisService.runAnalysis(sanitizeRepositoryAnalysisPayload(payload, readCodexApiKey()))
+    handlers.runRepositoryAnalysis(payload)
   ));
   registerHandle<string, void>('analysis:cancelRepositoryAnalysis', async (requestId) => {
-    repositoryAnalysisService.cancelAnalysis(requestId);
+    await handlers.cancelRepositoryAnalysis(requestId);
   });
   registerHandle<unknown, PullRequestAnalysisPreview[]>('analysis:previewPullRequestAiReviews', async (payload) => (
-    pullRequestAnalysisService.previewBatch(sanitizePullRequestAnalysisPayload(payload, readCodexApiKey()))
+    handlers.previewPullRequestAiReviews(payload)
   ));
   registerHandle<unknown, unknown>('analysis:runPullRequestAiReviews', async (payload) => (
-    pullRequestAnalysisService.analyzeBatch(sanitizePullRequestAnalysisPayload(payload, readCodexApiKey()))
+    handlers.runPullRequestAiReviews(payload)
   ));
   registerHandle<string, void>('analysis:cancelPullRequestAiReviews', async (requestId) => {
-    pullRequestAnalysisService.cancelAnalysis(requestId);
+    await handlers.cancelPullRequestAiReviews(requestId);
   });
 }

--- a/src/main/ipc/register.ts
+++ b/src/main/ipc/register.ts
@@ -1,4 +1,6 @@
 import { registerAnalysisIpc } from './analysis';
+import { createAnalysisIpcHandlers } from './analysis-handlers';
+import { createAnalysisApiKeyResolver } from './analysis-api-key-resolver';
 import { registerRepositoryProviderIpc } from './repository-providers';
 import { registerSessionSecretsIpc, SessionSecretsStore } from './session-secrets';
 import { registerWindowControlsIpc } from './window-controls';
@@ -13,7 +15,11 @@ export function registerIpcHandlers(
 ): void {
   const sessionSecretsStore = new SessionSecretsStore();
   registerRepositoryProviderIpc(providerRegistry);
-  registerAnalysisIpc(repositoryAnalysisService, pullRequestAnalysisService, sessionSecretsStore);
+  registerAnalysisIpc(createAnalysisIpcHandlers(
+    repositoryAnalysisService,
+    pullRequestAnalysisService,
+    createAnalysisApiKeyResolver(sessionSecretsStore),
+  ));
   registerSessionSecretsIpc(sessionSecretsStore);
   registerWindowControlsIpc();
 }

--- a/tests/unit/main/ipc.analysis.test.js
+++ b/tests/unit/main/ipc.analysis.test.js
@@ -4,6 +4,7 @@ jest.mock('../../../src/main/ipc/shared', () => ({
 
 const { registerHandle } = require('../../../src/main/ipc/shared');
 const analysisShared = require('../../../src/main/ipc/analysis.shared');
+const { createAnalysisIpcHandlers } = require('../../../src/main/ipc/analysis-handlers');
 const {
   sanitizeAnalysisPayload,
   sanitizePullRequestAnalysisPayload,
@@ -131,7 +132,11 @@ describe('analysis ipc', () => {
       get: jest.fn().mockReturnValue('sk-session'),
     };
 
-    registerAnalysisIpc(repositoryAnalysisService, pullRequestAnalysisService, sessionSecretsStore);
+    registerAnalysisIpc(createAnalysisIpcHandlers(
+      repositoryAnalysisService,
+      pullRequestAnalysisService,
+      { readCodexApiKey: () => sessionSecretsStore.get() },
+    ));
 
     expect(registerHandle).toHaveBeenCalledTimes(6);
     const previewHandler = registerHandle.mock.calls[0][1];
@@ -254,6 +259,51 @@ describe('analysis ipc', () => {
     expect(pullRequestAnalysisService.previewBatch).toHaveBeenCalled();
     expect(pullRequestAnalysisService.analyzeBatch).toHaveBeenCalled();
     expect(pullRequestAnalysisService.cancelAnalysis).toHaveBeenCalledWith('pr-ai-1');
+  });
+
+  test('createAnalysisIpcHandlers encapsula sanitizacion y resolucion de api key', async () => {
+    const repositoryAnalysisService = {
+      previewSnapshot: jest.fn().mockResolvedValue({ repository: 'repo-a' }),
+      runAnalysis: jest.fn().mockResolvedValue({ summary: 'ok' }),
+      cancelAnalysis: jest.fn(),
+    };
+    const pullRequestAnalysisService = {
+      previewBatch: jest.fn().mockResolvedValue([]),
+      analyzeBatch: jest.fn().mockResolvedValue([]),
+      cancelAnalysis: jest.fn(),
+    };
+
+    const handlers = createAnalysisIpcHandlers(
+      repositoryAnalysisService,
+      pullRequestAnalysisService,
+      { readCodexApiKey: () => 'sk-session' },
+    );
+
+    await handlers.runRepositoryAnalysis({
+      requestId: 'req-1',
+      source: {
+        provider: 'github',
+        organization: 'acme',
+        project: 'repo-a',
+        repositoryId: 'repo-a',
+        personalAccessToken: 'pat',
+      },
+      repositoryId: 'repo-a',
+      branchName: 'main',
+      model: 'gpt-5.2-codex',
+      apiKey: '',
+      analysisDepth: 'standard',
+      maxFilesPerRun: 50,
+      includeTests: false,
+      timeoutMs: 90000,
+    });
+
+    expect(repositoryAnalysisService.runAnalysis).toHaveBeenCalledWith(expect.objectContaining({
+      apiKey: 'sk-session',
+      source: expect.objectContaining({
+        provider: 'github',
+      }),
+    }));
   });
 
   test('sanitizePullRequestAnalysisPayload normaliza source y items', () => {

--- a/tests/unit/main/ipc.register.test.js
+++ b/tests/unit/main/ipc.register.test.js
@@ -6,6 +6,14 @@ jest.mock('../../../src/main/ipc/analysis', () => ({
   registerAnalysisIpc: jest.fn(),
 }));
 
+jest.mock('../../../src/main/ipc/analysis-handlers', () => ({
+  createAnalysisIpcHandlers: jest.fn(() => ({ kind: 'analysis-handlers' })),
+}));
+
+jest.mock('../../../src/main/ipc/analysis-api-key-resolver', () => ({
+  createAnalysisApiKeyResolver: jest.fn(() => ({ kind: 'api-key-resolver' })),
+}));
+
 jest.mock('../../../src/main/ipc/session-secrets', () => ({
   SessionSecretsStore: jest.fn(),
   registerSessionSecretsIpc: jest.fn(),
@@ -17,6 +25,8 @@ jest.mock('../../../src/main/ipc/window-controls', () => ({
 
 const { registerRepositoryProviderIpc } = require('../../../src/main/ipc/repository-providers');
 const { registerAnalysisIpc } = require('../../../src/main/ipc/analysis');
+const { createAnalysisIpcHandlers } = require('../../../src/main/ipc/analysis-handlers');
+const { createAnalysisApiKeyResolver } = require('../../../src/main/ipc/analysis-api-key-resolver');
 const { SessionSecretsStore, registerSessionSecretsIpc } = require('../../../src/main/ipc/session-secrets');
 const { registerWindowControlsIpc } = require('../../../src/main/ipc/window-controls');
 const { registerIpcHandlers } = require('../../../src/main/ipc/register');
@@ -32,11 +42,13 @@ describe('ipc register', () => {
     registerIpcHandlers(providerRegistry, repositoryAnalysisService, pullRequestAnalysisService);
 
     expect(registerRepositoryProviderIpc).toHaveBeenCalledWith(providerRegistry);
-    expect(registerAnalysisIpc).toHaveBeenCalledWith(
+    expect(createAnalysisApiKeyResolver).toHaveBeenCalledWith(sessionSecretsStoreInstance);
+    expect(createAnalysisIpcHandlers).toHaveBeenCalledWith(
       repositoryAnalysisService,
       pullRequestAnalysisService,
-      sessionSecretsStoreInstance,
+      { kind: 'api-key-resolver' },
     );
+    expect(registerAnalysisIpc).toHaveBeenCalledWith({ kind: 'analysis-handlers' });
     expect(SessionSecretsStore).toHaveBeenCalled();
     expect(registerSessionSecretsIpc).toHaveBeenCalledWith(sessionSecretsStoreInstance);
     expect(registerWindowControlsIpc).toHaveBeenCalled();


### PR DESCRIPTION
## Resumen
- extrae un resolver de API key para analysis
- crea factories de handlers IPC para repository analysis y PR AI review
- deja `registerAnalysisIpc` como registrador de handlers ya preparados en vez de concentrar sanitización, secretos y servicios concretos

## Impacto SOLID
- mejora `SRP` porque el módulo de registro ya no mezcla handlers, sanitización y resolución de secretos
- mejora `DIP` porque la resolución de API key queda detrás de un puerto pequeño
- mejora `ISP` porque repository analysis y PR AI review pueden validarse como handlers separados

## Validación local
- `npm test -- --runInBand tests/unit/main/ipc.analysis.test.js tests/unit/main/ipc.register.test.js tests/unit/main/main.test.js`
- gate local equivalente corrido: `lint`, `typecheck`, `analyze:architecture:boundaries`, `analyze:cycles`, `analyze:duplicates`, `test:coverage`, `build`

## Nota
- el paso `analyze:architecture:layers` del script estándar no pudo ejecutarse con `depcruise` en esta instalación local porque el binario no está resolviendo correctamente en el entorno actual; el resto del gate sí quedó corrido de forma local.

Closes #72
