### PR TITLE
refactor: invertir la dependencia de SessionSecretsStore en main

### DIFF
--- a/src/main/application-bootstrap.ts
+++ b/src/main/application-bootstrap.ts
@@ -1,4 +1,5 @@
 import { registerIpcHandlers } from './ipc/register';
+import { SessionSecretsStore } from './ipc/session-secrets';
 import { createWindow } from './main-window';
 import { buildDefaultRepositoryProviderModules } from '../services/providers/repository-provider.bootstrap';
 import { createRepositoryProviderRegistryFromModules } from '../services/providers/repository-provider.composition';
@@ -25,6 +26,11 @@ export function createApplicationServices() {
 
 export function bootstrapMainProcess() {
   const { providerRegistry, repositoryAnalysisService, pullRequestAnalysisService } = createApplicationServices();
-  registerIpcHandlers(providerRegistry, repositoryAnalysisService, pullRequestAnalysisService);
+  registerIpcHandlers(
+    providerRegistry,
+    repositoryAnalysisService,
+    pullRequestAnalysisService,
+    new SessionSecretsStore(),
+  );
   return createWindow();
 }

--- a/src/main/ipc/register.ts
+++ b/src/main/ipc/register.ts
@@ -2,18 +2,19 @@ import { registerAnalysisIpc } from './analysis';
 import { createAnalysisIpcHandlers } from './analysis-handlers';
 import { createAnalysisApiKeyResolver } from './analysis-api-key-resolver';
 import { registerRepositoryProviderIpc } from './repository-providers';
-import { registerSessionSecretsIpc, SessionSecretsStore } from './session-secrets';
+import { registerSessionSecretsIpc } from './session-secrets';
 import { registerWindowControlsIpc } from './window-controls';
 import type { RepositoryProviderRegistry } from '../../services/providers/repository-provider.registry';
 import type { RepositoryAnalysisService } from '../../services/analysis/repository-analysis.service';
 import type { PullRequestAnalysisService } from '../../services/analysis/pull-request-analysis.service';
+import type { SessionSecretsStore } from './session-secrets';
 
 export function registerIpcHandlers(
   providerRegistry: RepositoryProviderRegistry,
   repositoryAnalysisService: RepositoryAnalysisService,
   pullRequestAnalysisService: PullRequestAnalysisService,
+  sessionSecretsStore: SessionSecretsStore,
 ): void {
-  const sessionSecretsStore = new SessionSecretsStore();
   registerRepositoryProviderIpc(providerRegistry);
   registerAnalysisIpc(createAnalysisIpcHandlers(
     repositoryAnalysisService,

--- a/tests/unit/main/ipc.register.test.js
+++ b/tests/unit/main/ipc.register.test.js
@@ -15,7 +15,6 @@ jest.mock('../../../src/main/ipc/analysis-api-key-resolver', () => ({
 }));
 
 jest.mock('../../../src/main/ipc/session-secrets', () => ({
-  SessionSecretsStore: jest.fn(),
   registerSessionSecretsIpc: jest.fn(),
 }));
 
@@ -27,7 +26,7 @@ const { registerRepositoryProviderIpc } = require('../../../src/main/ipc/reposit
 const { registerAnalysisIpc } = require('../../../src/main/ipc/analysis');
 const { createAnalysisIpcHandlers } = require('../../../src/main/ipc/analysis-handlers');
 const { createAnalysisApiKeyResolver } = require('../../../src/main/ipc/analysis-api-key-resolver');
-const { SessionSecretsStore, registerSessionSecretsIpc } = require('../../../src/main/ipc/session-secrets');
+const { registerSessionSecretsIpc } = require('../../../src/main/ipc/session-secrets');
 const { registerWindowControlsIpc } = require('../../../src/main/ipc/window-controls');
 const { registerIpcHandlers } = require('../../../src/main/ipc/register');
 
@@ -37,9 +36,8 @@ describe('ipc register', () => {
     const repositoryAnalysisService = { runAnalysis: jest.fn(), cancelAnalysis: jest.fn() };
     const pullRequestAnalysisService = { analyzeBatch: jest.fn() };
     const sessionSecretsStoreInstance = {};
-    SessionSecretsStore.mockImplementation(() => sessionSecretsStoreInstance);
 
-    registerIpcHandlers(providerRegistry, repositoryAnalysisService, pullRequestAnalysisService);
+    registerIpcHandlers(providerRegistry, repositoryAnalysisService, pullRequestAnalysisService, sessionSecretsStoreInstance);
 
     expect(registerRepositoryProviderIpc).toHaveBeenCalledWith(providerRegistry);
     expect(createAnalysisApiKeyResolver).toHaveBeenCalledWith(sessionSecretsStoreInstance);
@@ -49,7 +47,6 @@ describe('ipc register', () => {
       { kind: 'api-key-resolver' },
     );
     expect(registerAnalysisIpc).toHaveBeenCalledWith({ kind: 'analysis-handlers' });
-    expect(SessionSecretsStore).toHaveBeenCalled();
     expect(registerSessionSecretsIpc).toHaveBeenCalledWith(sessionSecretsStoreInstance);
     expect(registerWindowControlsIpc).toHaveBeenCalled();
   });

--- a/tests/unit/main/main.test.js
+++ b/tests/unit/main/main.test.js
@@ -35,6 +35,11 @@ jest.mock('../../../src/main/ipc/register', () => ({
   registerIpcHandlers: jest.fn(),
 }));
 
+jest.mock('../../../src/main/ipc/session-secrets', () => ({
+  SessionSecretsStore: jest.fn().mockImplementation(() => ({ kind: 'session-secrets-store' })),
+  registerSessionSecretsIpc: jest.fn(),
+}));
+
 jest.mock('../../../src/main/ipc/window-controls', () => ({
   attachWindowStateSync: jest.fn(),
 }));
@@ -46,9 +51,9 @@ jest.mock('../../../src/services/providers/repository-provider.bootstrap', () =>
 }));
 
 const { registerIpcHandlers } = require('../../../src/main/ipc/register');
+const { SessionSecretsStore } = require('../../../src/main/ipc/session-secrets');
 const { attachWindowStateSync } = require('../../../src/main/ipc/window-controls');
 const {
-  buildDefaultRepositoryProviderPorts,
   buildDefaultRepositoryProviderModules,
   registerDefaultRepositoryProviders,
 } = require('../../../src/services/providers/repository-provider.bootstrap');
@@ -159,7 +164,13 @@ describe('main process bootstrap', () => {
     expect(buildDefaultRepositoryProviderModules).toHaveBeenCalled();
     expect(createRepositoryProviderRegistryFromModules).toHaveBeenCalled();
     expect(registerDefaultRepositoryProviders).not.toHaveBeenCalled();
-    expect(registerIpcHandlers).toHaveBeenCalled();
+    expect(SessionSecretsStore).toHaveBeenCalled();
+    expect(registerIpcHandlers).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.anything(),
+      expect.anything(),
+      { kind: 'session-secrets-store' },
+    );
     expect(browserWindowMock).toHaveBeenCalled();
   });
 
@@ -167,7 +178,12 @@ describe('main process bootstrap', () => {
     readyCallback();
 
     expect(buildDefaultRepositoryProviderModules).toHaveBeenCalled();
-    expect(registerIpcHandlers).toHaveBeenCalled();
+    expect(registerIpcHandlers).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.anything(),
+      expect.anything(),
+      { kind: 'session-secrets-store' },
+    );
   });
 
   test('window-all-closed cierra la app fuera de macOS', () => {


### PR DESCRIPTION
## Resumen
- mover la creación de `SessionSecretsStore` al bootstrap principal
- hacer que `registerIpcHandlers` reciba el store como dependencia explícita
- ajustar la suite de main para validar la inyección y no la construcción interna

## Validación local
- `npm test -- --runInBand tests/unit/main/ipc.register.test.js tests/unit/main/main.test.js`
- `npm run lint`
- `npm run typecheck`
- `npm run analyze:architecture:boundaries`
- `npm run analyze:cycles`
- `npm run analyze:duplicates`
- `npm run test:coverage`
- `npm run build`

## Notas
- `lint` sigue mostrando 2 warnings preexistentes en `src/renderer/features/repository-source/presentation/hooks/useRepositorySourceEffects.ts`.
- El paso `analyze:architecture:layers` no pudo correrse localmente porque `depcruise` no resuelve en esta instalación.

Closes #73
