### PR TITLE
refactor: extraer adapter compartido para la Responses API

### DIFF
--- a/src/services/analysis/openai-responses.adapter.ts
+++ b/src/services/analysis/openai-responses.adapter.ts
@@ -1,0 +1,52 @@
+export interface OpenAIResponsesJsonSchemaRequest {
+  apiKey: string;
+  model: string;
+  systemPrompt: string;
+  userPrompt: string;
+  schemaName: string;
+  schema: unknown;
+  signal: AbortSignal;
+}
+
+export class OpenAIResponsesAdapter {
+  async createJsonSchemaResponse(input: OpenAIResponsesJsonSchemaRequest): Promise<{
+    response: Response;
+    rawText: string;
+  }> {
+    const response = await fetch('https://api.openai.com/v1/responses', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${input.apiKey}`,
+      },
+      signal: input.signal,
+      body: JSON.stringify({
+        model: input.model,
+        store: false,
+        input: [
+          {
+            role: 'system',
+            content: [{ type: 'input_text', text: input.systemPrompt }],
+          },
+          {
+            role: 'user',
+            content: [{ type: 'input_text', text: input.userPrompt }],
+          },
+        ],
+        text: {
+          format: {
+            type: 'json_schema',
+            name: input.schemaName,
+            schema: input.schema,
+            strict: true,
+          },
+        },
+      }),
+    });
+
+    return {
+      response,
+      rawText: await response.text(),
+    };
+  }
+}

--- a/src/services/analysis/pull-request-analysis.openai-client.ts
+++ b/src/services/analysis/pull-request-analysis.openai-client.ts
@@ -1,5 +1,6 @@
 import type { PullRequestAnalysisBatchRequest } from '../../types/analysis';
 import { retryWithBackoff } from '../../shared/request-control';
+import { OpenAIResponsesAdapter } from './openai-responses.adapter';
 import type { PullRequestAnalysisClientPort, PullRequestAnalysisPromptPayload } from './pull-request-analysis.ports';
 
 const PULL_REQUEST_ANALYSIS_SCHEMA = {
@@ -21,44 +22,25 @@ const PULL_REQUEST_ANALYSIS_SCHEMA = {
 } as const;
 
 export class OpenAIPullRequestAnalysisClient implements PullRequestAnalysisClientPort {
+  constructor(
+    private readonly responsesAdapter: OpenAIResponsesAdapter = new OpenAIResponsesAdapter(),
+  ) {}
+
   async analyze(input: {
     request: PullRequestAnalysisBatchRequest;
     prompt: PullRequestAnalysisPromptPayload;
     signal: AbortSignal;
   }): Promise<string> {
     return retryWithBackoff(async () => {
-      const response = await fetch('https://api.openai.com/v1/responses', {
-        method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
-          Authorization: `Bearer ${input.request.apiKey}`,
-        },
+      const { response, rawText } = await this.responsesAdapter.createJsonSchemaResponse({
+        apiKey: input.request.apiKey,
+        model: input.request.model,
+        systemPrompt: input.prompt.systemPrompt,
+        userPrompt: input.prompt.userPrompt,
+        schemaName: 'pull_request_analysis',
+        schema: PULL_REQUEST_ANALYSIS_SCHEMA,
         signal: input.signal,
-        body: JSON.stringify({
-          model: input.request.model,
-          store: false,
-          input: [
-            {
-              role: 'system',
-              content: [{ type: 'input_text', text: input.prompt.systemPrompt }],
-            },
-            {
-              role: 'user',
-              content: [{ type: 'input_text', text: input.prompt.userPrompt }],
-            },
-          ],
-          text: {
-            format: {
-              type: 'json_schema',
-              name: 'pull_request_analysis',
-              schema: PULL_REQUEST_ANALYSIS_SCHEMA,
-              strict: true,
-            },
-          },
-        }),
       });
-
-      const rawText = await response.text();
       if (!response.ok) {
         throw new Error(`Codex PR analysis failed (${response.status}): ${rawText.slice(0, 500) || response.statusText}`);
       }

--- a/src/services/analysis/repository-analysis.openai-client.ts
+++ b/src/services/analysis/repository-analysis.openai-client.ts
@@ -1,4 +1,5 @@
 import type { RepositoryAnalysisRequest } from '../../types/analysis';
+import { OpenAIResponsesAdapter } from './openai-responses.adapter';
 import type { AnalysisClientPort, AnalysisPromptPayload } from './repository-analysis.ports';
 
 const ANALYSIS_SCHEMA = {
@@ -51,45 +52,25 @@ function compactText(value: string, maxLength = 2400): string {
 }
 
 export class OpenAIRepositoryAnalysisClient implements AnalysisClientPort {
+  constructor(
+    private readonly responsesAdapter: OpenAIResponsesAdapter = new OpenAIResponsesAdapter(),
+  ) {}
+
   async analyze(input: {
     request: RepositoryAnalysisRequest;
     prompt: AnalysisPromptPayload;
     signal: AbortSignal;
   }): Promise<string> {
     const { request, prompt, signal } = input;
-
-    const response = await fetch('https://api.openai.com/v1/responses', {
-      method: 'POST',
-      headers: {
-        'Content-Type': 'application/json',
-        Authorization: `Bearer ${request.apiKey}`,
-      },
+    const { response, rawText } = await this.responsesAdapter.createJsonSchemaResponse({
+      apiKey: request.apiKey,
+      model: request.model,
+      systemPrompt: prompt.systemPrompt,
+      userPrompt: prompt.userPrompt,
+      schemaName: 'repository_analysis',
+      schema: ANALYSIS_SCHEMA,
       signal,
-      body: JSON.stringify({
-        model: request.model,
-        store: false,
-        input: [
-          {
-            role: 'system',
-            content: [{ type: 'input_text', text: prompt.systemPrompt }],
-          },
-          {
-            role: 'user',
-            content: [{ type: 'input_text', text: prompt.userPrompt }],
-          },
-        ],
-        text: {
-          format: {
-            type: 'json_schema',
-            name: 'repository_analysis',
-            schema: ANALYSIS_SCHEMA,
-            strict: true,
-          },
-        },
-      }),
     });
-
-    const rawText = await response.text();
     if (!response.ok) {
       const detail = compactText(rawText, 600) || response.statusText;
 

--- a/tests/unit/services/openai-responses.adapter.test.js
+++ b/tests/unit/services/openai-responses.adapter.test.js
@@ -1,0 +1,46 @@
+const { OpenAIResponsesAdapter } = require('../../../src/services/analysis/openai-responses.adapter');
+
+describe('openai responses adapter', () => {
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  test('construye el payload json_schema para la Responses API', async () => {
+    const adapter = new OpenAIResponsesAdapter();
+    global.fetch = jest.fn().mockResolvedValue(new Response('{"ok":true}', {
+      status: 200,
+      headers: { 'content-type': 'application/json' },
+    }));
+
+    const result = await adapter.createJsonSchemaResponse({
+      apiKey: 'sk-test',
+      model: 'gpt-5.2-codex',
+      systemPrompt: 'system',
+      userPrompt: 'user',
+      schemaName: 'demo_schema',
+      schema: { type: 'object' },
+      signal: new AbortController().signal,
+    });
+
+    expect(result.rawText).toBe('{"ok":true}');
+    expect(result.response.ok).toBe(true);
+    expect(global.fetch).toHaveBeenCalledWith('https://api.openai.com/v1/responses', expect.objectContaining({
+      method: 'POST',
+      headers: expect.objectContaining({
+        Authorization: 'Bearer sk-test',
+        'Content-Type': 'application/json',
+      }),
+    }));
+
+    const payload = JSON.parse(global.fetch.mock.calls[0][1].body);
+    expect(payload.model).toBe('gpt-5.2-codex');
+    expect(payload.input[0].content[0].text).toBe('system');
+    expect(payload.input[1].content[0].text).toBe('user');
+    expect(payload.text.format).toEqual({
+      type: 'json_schema',
+      name: 'demo_schema',
+      schema: { type: 'object' },
+      strict: true,
+    });
+  });
+});


### PR DESCRIPTION
## Resumen
- extraer un adapter compartido para construir requests `json_schema` hacia la Responses API
- dejar que cada cliente conserve su propia politica de retry y mapeo de errores
- agregar cobertura unitaria directa para el adapter nuevo

## Validación local
- `npm test -- --runInBand tests/unit/services/openai-responses.adapter.test.js tests/unit/services/repository-analysis-parts.test.js tests/unit/services/pull-request-analysis.parts.test.js`
- `npm run lint`
- `npm run typecheck`
- `npm run analyze:architecture:boundaries`
- `npm run analyze:cycles`
- `npm run analyze:duplicates`
- `npm run test:coverage`
- `npm run build`

## Notas
- `lint` sigue mostrando 2 warnings preexistentes en `src/renderer/features/repository-source/presentation/hooks/useRepositorySourceEffects.ts`.
- El paso `analyze:architecture:layers` no pudo correrse localmente porque `depcruise` no resuelve en esta instalación.

Closes #74
