### PR TITLE
refactor: aclarar el boundary de los adapters por provider

### DIFF
--- a/src/services/azure/azure.provider-module.ts
+++ b/src/services/azure/azure.provider-module.ts
@@ -1,10 +1,10 @@
 import type { RepositoryProviderModule } from '../providers/repository-provider.module';
-import { pullRequestService } from './pr.service';
+import { PullRequestService } from './pr.service';
 
 export const azureProviderModule: RepositoryProviderModule = {
   kind: 'azure-devops',
   createPort() {
-    return Object.assign(pullRequestService, {
+    return Object.assign(new PullRequestService(), {
       kind: 'azure-devops' as const,
     });
   },

--- a/src/services/azure/pr.service.ts
+++ b/src/services/azure/pr.service.ts
@@ -1,7 +1,6 @@
 import type { AzureBranch, AzureConnectionConfig, AzureProject, AzureRepository, PullRequest } from '../../types/azure';
 import type { PullRequestSnapshot, RepositorySnapshot } from '../../types/analysis';
 import type { PullRequestSnapshotOptions, RepositorySnapshotOptions } from '../../types/repository';
-import { normalizeOrganization, normalizeProject, readAzureResponse } from './azure.api';
 import { getAzureBranches, getAzureProjects, getAzureRepositories } from './azure.repositories';
 import { getAzurePullRequests } from './azure.pull-requests';
 import { getAzurePullRequestSnapshot } from './azure.pr-snapshot';
@@ -39,11 +38,3 @@ export class PullRequestService {
     return getAzureRepositorySnapshot(config, options);
   }
 }
-
-export const pullRequestServiceInternals = {
-  normalizeOrganization,
-  normalizeProject,
-  readAzureResponse,
-};
-
-export const pullRequestService = new PullRequestService();

--- a/src/services/github/github.provider-module.ts
+++ b/src/services/github/github.provider-module.ts
@@ -1,10 +1,10 @@
 import type { RepositoryProviderModule } from '../providers/repository-provider.module';
-import { gitHubRepositoryService } from './repository.service';
+import { GitHubRepositoryService } from './repository.service';
 
 export const githubProviderModule: RepositoryProviderModule = {
   kind: 'github',
   createPort() {
-    return Object.assign(gitHubRepositoryService, {
+    return Object.assign(new GitHubRepositoryService(), {
       kind: 'github' as const,
     });
   },

--- a/src/services/github/repository.service.ts
+++ b/src/services/github/repository.service.ts
@@ -1,10 +1,9 @@
 import type { PullRequestSnapshotOptions, RepositoryBranch, RepositoryConnectionConfig, RepositoryProject, RepositorySnapshotOptions, RepositorySummary, ReviewItem } from '../../types/repository';
 import type { PullRequestSnapshot, RepositorySnapshot } from '../../types/analysis';
-import { getGitHubConfig, readGitHubResponse } from './github.api';
 import { getGitHubBranches, getGitHubProjects, getGitHubRepositories } from './github.repositories';
 import { getGitHubPullRequests } from './github.pull-requests';
 import { getGitHubPullRequestSnapshot } from './github.pr-snapshot';
-import { enumerateGitHubContents, getGitHubRepositorySnapshot } from './github.snapshot';
+import { getGitHubRepositorySnapshot } from './github.snapshot';
 
 export class GitHubRepositoryService {
   async getProjects(config: RepositoryConnectionConfig): Promise<RepositoryProject[]> {
@@ -38,11 +37,3 @@ export class GitHubRepositoryService {
     return getGitHubRepositorySnapshot(config, options);
   }
 }
-
-export const gitHubRepositoryServiceInternals = {
-  getGitHubConfig,
-  readGitHubResponse,
-  enumerateGitHubContents,
-};
-
-export const gitHubRepositoryService = new GitHubRepositoryService();

--- a/src/services/gitlab/gitlab.provider-module.ts
+++ b/src/services/gitlab/gitlab.provider-module.ts
@@ -1,10 +1,10 @@
 import type { RepositoryProviderModule } from '../providers/repository-provider.module';
-import { gitLabRepositoryService } from './repository.service';
+import { GitLabRepositoryService } from './repository.service';
 
 export const gitlabProviderModule: RepositoryProviderModule = {
   kind: 'gitlab',
   createPort() {
-    return Object.assign(gitLabRepositoryService, {
+    return Object.assign(new GitLabRepositoryService(), {
       kind: 'gitlab' as const,
     });
   },

--- a/src/services/gitlab/repository.service.ts
+++ b/src/services/gitlab/repository.service.ts
@@ -37,5 +37,3 @@ export class GitLabRepositoryService {
     return getGitLabRepositorySnapshot(config, options);
   }
 }
-
-export const gitLabRepositoryService = new GitLabRepositoryService();

--- a/tests/unit/services/azure-pr.service.test.js
+++ b/tests/unit/services/azure-pr.service.test.js
@@ -1,4 +1,5 @@
-const { PullRequestService, pullRequestServiceInternals } = require('../../../src/services/azure/pr.service');
+const { normalizeOrganization, normalizeProject, readAzureResponse } = require('../../../src/services/azure/azure.api');
+const { PullRequestService } = require('../../../src/services/azure/pr.service');
 
 describe('PullRequestService', () => {
   afterEach(() => {
@@ -6,8 +7,8 @@ describe('PullRequestService', () => {
   });
 
   test('normaliza organization y project desde URLs completas', () => {
-    expect(pullRequestServiceInternals.normalizeOrganization('https://dev.azure.com/EsmaxDevelop/')).toBe('EsmaxDevelop');
-    expect(pullRequestServiceInternals.normalizeProject('https://dev.azure.com/EsmaxDevelop/ProyectoUno/_git/repo')).toBe('ProyectoUno');
+    expect(normalizeOrganization('https://dev.azure.com/EsmaxDevelop/')).toBe('EsmaxDevelop');
+    expect(normalizeProject('https://dev.azure.com/EsmaxDevelop/ProyectoUno/_git/repo')).toBe('ProyectoUno');
   });
 
   test('getProjects mapea la respuesta de Azure', async () => {
@@ -52,7 +53,7 @@ describe('PullRequestService', () => {
     });
 
     await expect(
-      pullRequestServiceInternals.readAzureResponse(response, 'projects request'),
+      readAzureResponse(response, 'projects request'),
     ).rejects.toThrow('Azure DevOps projects request failed (401): unauthorized. Response: Unauthorized');
   });
 });

--- a/tests/unit/services/github-repository.service.test.js
+++ b/tests/unit/services/github-repository.service.test.js
@@ -1,4 +1,5 @@
-const { GitHubRepositoryService, gitHubRepositoryServiceInternals } = require('../../../src/services/github/repository.service');
+const { readGitHubResponse } = require('../../../src/services/github/github.api');
+const { GitHubRepositoryService } = require('../../../src/services/github/repository.service');
 
 describe('GitHubRepositoryService', () => {
   afterEach(() => {
@@ -123,7 +124,7 @@ describe('GitHubRepositoryService', () => {
     });
 
     await expect(
-      gitHubRepositoryServiceInternals.readGitHubResponse(response, 'repositories request'),
+      readGitHubResponse(response, 'repositories request'),
     ).rejects.toThrow('GitHub repositories request failed (403): forbidden. Revisa scopes del token. Response: Forbidden');
   });
 

--- a/tests/unit/services/repository-provider.bootstrap.test.js
+++ b/tests/unit/services/repository-provider.bootstrap.test.js
@@ -1,5 +1,5 @@
 const bootstrap = require('../../../src/services/providers/repository-provider.bootstrap');
-const { pullRequestService } = require('../../../src/services/azure/pr.service');
+const { PullRequestService } = require('../../../src/services/azure/pr.service');
 
 describe('repository provider bootstrap', () => {
   test('construye los modules por defecto sin depender de estado global', () => {
@@ -29,12 +29,12 @@ describe('repository provider bootstrap', () => {
 
   test('el provider delega las llamadas al servicio concreto', async () => {
     const [azureProvider] = bootstrap.buildDefaultRepositoryProviderModules().map((module) => module.createPort());
-    jest.spyOn(pullRequestService, 'getProjects').mockResolvedValueOnce([{ id: '1', name: 'Core' }]);
-    jest.spyOn(pullRequestService, 'getRepositories').mockResolvedValueOnce([{ id: 'repo', name: 'repo' }]);
-    jest.spyOn(pullRequestService, 'getBranches').mockResolvedValueOnce([{ name: 'main', objectId: '1', isDefault: true }]);
-    jest.spyOn(pullRequestService, 'getPullRequests').mockResolvedValueOnce([{ id: 1 }]);
-    jest.spyOn(pullRequestService, 'getPullRequestSnapshot').mockResolvedValueOnce({ repository: 'repo' });
-    jest.spyOn(pullRequestService, 'getRepositorySnapshot').mockResolvedValueOnce({ repository: 'repo', branch: 'main' });
+    jest.spyOn(PullRequestService.prototype, 'getProjects').mockResolvedValueOnce([{ id: '1', name: 'Core' }]);
+    jest.spyOn(PullRequestService.prototype, 'getRepositories').mockResolvedValueOnce([{ id: 'repo', name: 'repo' }]);
+    jest.spyOn(PullRequestService.prototype, 'getBranches').mockResolvedValueOnce([{ name: 'main', objectId: '1', isDefault: true }]);
+    jest.spyOn(PullRequestService.prototype, 'getPullRequests').mockResolvedValueOnce([{ id: 1 }]);
+    jest.spyOn(PullRequestService.prototype, 'getPullRequestSnapshot').mockResolvedValueOnce({ repository: 'repo' });
+    jest.spyOn(PullRequestService.prototype, 'getRepositorySnapshot').mockResolvedValueOnce({ repository: 'repo', branch: 'main' });
 
     const config = { provider: 'azure-devops', organization: 'org', project: 'proj', repositoryId: 'repo', personalAccessToken: 'pat' };
     const pr = { id: 1 };


### PR DESCRIPTION
## Resumen
- eliminar exports `*Internals` y singletons concretos usados como atajo desde los adapters de provider
- hacer que cada provider module construya su propio servicio concreto al crear el port
- ajustar tests para importar helpers reales o espiar prototypes en vez de depender de internals públicos

## Validación local
- `npm test -- --runInBand tests/unit/services/repository-provider.bootstrap.test.js tests/unit/services/github-repository.service.test.js tests/unit/services/azure-pr.service.test.js tests/unit/services/gitlab-repository.service.test.js`
- `npm run lint`
- `npm run typecheck`
- `npm run analyze:architecture:boundaries`
- `npm run analyze:cycles`
- `npm run analyze:duplicates`
- `npm run test:coverage`
- `npm run build`

## Notas
- `lint` sigue mostrando 2 warnings preexistentes en `src/renderer/features/repository-source/presentation/hooks/useRepositorySourceEffects.ts`.
- El paso `analyze:architecture:layers` no pudo correrse localmente porque `depcruise` no resuelve en esta instalación.

Closes #75
