### PR TITLE
refactor: separar el builder del runtime en provider registry

### DIFF
--- a/src/services/providers/repository-provider.composition.ts
+++ b/src/services/providers/repository-provider.composition.ts
@@ -1,11 +1,11 @@
 import type { RepositoryProviderPort } from './repository-provider.port';
 import type { RepositoryProviderModule } from './repository-provider.module';
-import { RepositoryProviderRegistry } from './repository-provider.registry';
+import { RepositoryProviderRegistryBuilder } from './repository-provider.registry';
 
 export function createRepositoryProviderRegistry(providers: RepositoryProviderPort[] = []) {
-  const registry = new RepositoryProviderRegistry();
-  registry.registerMany(providers);
-  return registry;
+  const registryBuilder = new RepositoryProviderRegistryBuilder();
+  registryBuilder.registerMany(providers);
+  return registryBuilder.build();
 }
 
 export function createRepositoryProviderRegistryFromModules(modules: RepositoryProviderModule[] = []) {

--- a/src/services/providers/repository-provider.registry.ts
+++ b/src/services/providers/repository-provider.registry.ts
@@ -1,16 +1,15 @@
 import type { RepositoryProviderKind } from '../../types/repository';
 import type { RepositoryProviderPort } from './repository-provider.port';
 
-export class RepositoryProviderRegistry {
-  private readonly providers = new Map<RepositoryProviderKind, RepositoryProviderPort>();
+export interface RepositoryProviderRegistry {
+  get(kind: RepositoryProviderKind): RepositoryProviderPort;
+  list(): RepositoryProviderPort[];
+}
 
-  register(provider: RepositoryProviderPort): void {
-    this.providers.set(provider.kind, provider);
-  }
-
-  registerMany(providers: RepositoryProviderPort[]): void {
-    providers.forEach((provider) => this.register(provider));
-  }
+class InMemoryRepositoryProviderRegistry implements RepositoryProviderRegistry {
+  constructor(
+    private readonly providers: ReadonlyMap<RepositoryProviderKind, RepositoryProviderPort>,
+  ) {}
 
   get(kind: RepositoryProviderKind): RepositoryProviderPort {
     const provider = this.providers.get(kind);
@@ -24,8 +23,24 @@ export class RepositoryProviderRegistry {
   list(): RepositoryProviderPort[] {
     return Array.from(this.providers.values());
   }
+}
+
+export class RepositoryProviderRegistryBuilder {
+  private readonly providers = new Map<RepositoryProviderKind, RepositoryProviderPort>();
+
+  register(provider: RepositoryProviderPort): void {
+    this.providers.set(provider.kind, provider);
+  }
+
+  registerMany(providers: RepositoryProviderPort[]): void {
+    providers.forEach((provider) => this.register(provider));
+  }
 
   clear(): void {
     this.providers.clear();
+  }
+
+  build(): RepositoryProviderRegistry {
+    return new InMemoryRepositoryProviderRegistry(new Map(this.providers));
   }
 }

--- a/tests/unit/services/repository-provider.registry.test.js
+++ b/tests/unit/services/repository-provider.registry.test.js
@@ -1,10 +1,10 @@
 const {
-  RepositoryProviderRegistry,
+  RepositoryProviderRegistryBuilder,
 } = require('../../../src/services/providers/repository-provider.registry');
 
-describe('RepositoryProviderRegistry', () => {
-  test('registra y resuelve providers', () => {
-    const registry = new RepositoryProviderRegistry();
+describe('RepositoryProviderRegistryBuilder', () => {
+  test('registra y resuelve providers en el runtime generado', () => {
+    const registryBuilder = new RepositoryProviderRegistryBuilder();
     const provider = {
       kind: 'github',
       getProjects: jest.fn(),
@@ -14,13 +14,14 @@ describe('RepositoryProviderRegistry', () => {
       getRepositorySnapshot: jest.fn(),
     };
 
-    registry.register(provider);
+    registryBuilder.register(provider);
+    const registry = registryBuilder.build();
 
     expect(registry.get('github')).toBe(provider);
   });
 
-  test('permite usar una instancia aislada del registry', () => {
-    const registry = new RepositoryProviderRegistry();
+  test('permite generar runtimes aislados desde el builder', () => {
+    const registryBuilder = new RepositoryProviderRegistryBuilder();
     const provider = {
       kind: 'gitlab',
       getProjects: jest.fn(),
@@ -30,26 +31,37 @@ describe('RepositoryProviderRegistry', () => {
       getRepositorySnapshot: jest.fn(),
     };
 
-    registry.register(provider);
+    registryBuilder.register(provider);
+    const registry = registryBuilder.build();
 
     expect(registry.get('gitlab')).toBe(provider);
     expect(registry.list()).toHaveLength(1);
   });
 
-  test('registerMany agrega multiples providers y clear los elimina', () => {
-    const registry = new RepositoryProviderRegistry();
-    registry.registerMany([
+  test('registerMany agrega multiples providers y clear limpia el builder', () => {
+    const registryBuilder = new RepositoryProviderRegistryBuilder();
+    registryBuilder.registerMany([
       { kind: 'github' },
       { kind: 'gitlab' },
     ]);
 
-    expect(registry.list()).toHaveLength(2);
-    registry.clear();
-    expect(registry.list()).toHaveLength(0);
+    expect(registryBuilder.build().list()).toHaveLength(2);
+    registryBuilder.clear();
+    expect(registryBuilder.build().list()).toHaveLength(0);
+  });
+
+  test('el runtime generado no cambia si el builder muta despues', () => {
+    const registryBuilder = new RepositoryProviderRegistryBuilder();
+    registryBuilder.register({ kind: 'github' });
+
+    const runtimeRegistry = registryBuilder.build();
+    registryBuilder.register({ kind: 'azure-devops' });
+
+    expect(runtimeRegistry.list()).toEqual([{ kind: 'github' }]);
   });
 
   test('get lanza error si el provider no existe', () => {
-    const registry = new RepositoryProviderRegistry();
+    const registry = new RepositoryProviderRegistryBuilder().build();
     expect(() => registry.get('azure-devops')).toThrow(/aun no esta registrado/i);
   });
 });


### PR DESCRIPTION
## Resumen
- separar el contrato runtime del registry (`get` y `list`) del builder mutable usado en composición
- hacer que la composición construya un runtime ya cerrado en vez de exponer mutaciones a consumidores
- ajustar la suite del registry para validar snapshots runtime independientes del builder

## Validación local
- `npm test -- --runInBand tests/unit/services/repository-provider.registry.test.js tests/unit/services/repository-provider.composition.test.js tests/unit/main/main.test.js`
- `npm run lint`
- `npm run typecheck`
- `npm run analyze:architecture:boundaries`
- `npm run analyze:cycles`
- `npm run analyze:duplicates`
- `npm run test:coverage`
- `npm run build`

## Notas
- `lint` sigue mostrando 2 warnings preexistentes en `src/renderer/features/repository-source/presentation/hooks/useRepositorySourceEffects.ts`.
- El paso `analyze:architecture:layers` no pudo correrse localmente porque `depcruise` no resuelve en esta instalación.

Closes #76
