### PR TITLE
refactor: unificar la composicion de los servicios de analysis

### DIFF
--- a/src/services/analysis/analysis-service.composition.ts
+++ b/src/services/analysis/analysis-service.composition.ts
@@ -1,0 +1,32 @@
+export interface AnalysisServiceCompositionInput<
+  TSnapshotProvider,
+  TPromptBuilder,
+  TAnalysisClient,
+  TResponseParser,
+> {
+  snapshotProvider: TSnapshotProvider;
+  promptBuilder?: TPromptBuilder;
+  analysisClient?: TAnalysisClient;
+  responseParser?: TResponseParser;
+}
+
+export function resolveAnalysisServiceComposition<
+  TSnapshotProvider,
+  TPromptBuilder,
+  TAnalysisClient,
+  TResponseParser,
+>(
+  input: AnalysisServiceCompositionInput<TSnapshotProvider, TPromptBuilder, TAnalysisClient, TResponseParser>,
+  defaults: {
+    createPromptBuilder: () => TPromptBuilder;
+    createAnalysisClient: () => TAnalysisClient;
+    createResponseParser: () => TResponseParser;
+  },
+) {
+  return {
+    snapshotProvider: input.snapshotProvider,
+    promptBuilder: input.promptBuilder ?? defaults.createPromptBuilder(),
+    analysisClient: input.analysisClient ?? defaults.createAnalysisClient(),
+    responseParser: input.responseParser ?? defaults.createResponseParser(),
+  };
+}

--- a/src/services/analysis/pull-request-analysis.factory.ts
+++ b/src/services/analysis/pull-request-analysis.factory.ts
@@ -4,6 +4,7 @@ import type {
   PullRequestAnalysisResponseParserPort,
   PullRequestAnalysisSnapshotProviderPort,
 } from './pull-request-analysis.ports';
+import { resolveAnalysisServiceComposition } from './analysis-service.composition';
 import { OpenAIPullRequestAnalysisClient } from './pull-request-analysis.openai-client';
 import { PullRequestAnalysisPromptBuilder } from './pull-request-analysis.prompt-builder';
 import { PullRequestAnalysisResponseParser } from './pull-request-analysis.response-parser';
@@ -18,14 +19,18 @@ export interface PullRequestAnalysisServiceDependencies {
 
 export function createPullRequestAnalysisService({
   snapshotProvider,
-  promptBuilder = new PullRequestAnalysisPromptBuilder(),
-  analysisClient = new OpenAIPullRequestAnalysisClient(),
-  responseParser = new PullRequestAnalysisResponseParser(),
+  promptBuilder,
+  analysisClient,
+  responseParser,
 }: PullRequestAnalysisServiceDependencies): PullRequestAnalysisService {
-  return new PullRequestAnalysisService({
+  return new PullRequestAnalysisService(resolveAnalysisServiceComposition({
     snapshotProvider,
     promptBuilder,
     analysisClient,
     responseParser,
-  });
+  }, {
+    createPromptBuilder: () => new PullRequestAnalysisPromptBuilder(),
+    createAnalysisClient: () => new OpenAIPullRequestAnalysisClient(),
+    createResponseParser: () => new PullRequestAnalysisResponseParser(),
+  }));
 }

--- a/src/services/analysis/repository-analysis.factory.ts
+++ b/src/services/analysis/repository-analysis.factory.ts
@@ -1,4 +1,5 @@
 import type { SnapshotProviderPort, AnalysisPromptBuilderPort, AnalysisClientPort, AnalysisResponseParserPort } from './repository-analysis.ports';
+import { resolveAnalysisServiceComposition } from './analysis-service.composition';
 import { OpenAIRepositoryAnalysisClient } from './repository-analysis.openai-client';
 import { RepositoryAnalysisPromptBuilder } from './repository-analysis.prompt-builder';
 import { RepositoryAnalysisResponseParser } from './repository-analysis.response-parser';
@@ -13,14 +14,18 @@ export interface RepositoryAnalysisServiceDependencies {
 
 export function createRepositoryAnalysisService({
   snapshotProvider,
-  promptBuilder = new RepositoryAnalysisPromptBuilder(),
-  analysisClient = new OpenAIRepositoryAnalysisClient(),
-  responseParser = new RepositoryAnalysisResponseParser(),
+  promptBuilder,
+  analysisClient,
+  responseParser,
 }: RepositoryAnalysisServiceDependencies): RepositoryAnalysisService {
-  return new RepositoryAnalysisService({
+  return new RepositoryAnalysisService(resolveAnalysisServiceComposition({
     snapshotProvider,
     promptBuilder,
     analysisClient,
     responseParser,
-  });
+  }, {
+    createPromptBuilder: () => new RepositoryAnalysisPromptBuilder(),
+    createAnalysisClient: () => new OpenAIRepositoryAnalysisClient(),
+    createResponseParser: () => new RepositoryAnalysisResponseParser(),
+  }));
 }

--- a/tests/unit/services/analysis-service.composition.test.js
+++ b/tests/unit/services/analysis-service.composition.test.js
@@ -1,0 +1,24 @@
+const { resolveAnalysisServiceComposition } = require('../../../src/services/analysis/analysis-service.composition');
+
+describe('analysis service composition', () => {
+  test('usa defaults solo cuando faltan dependencias opcionales', () => {
+    const snapshotProvider = { getSnapshot: jest.fn() };
+    const promptBuilder = { build: jest.fn() };
+    const defaults = {
+      createPromptBuilder: jest.fn(() => ({ build: jest.fn() })),
+      createAnalysisClient: jest.fn(() => ({ analyze: jest.fn() })),
+      createResponseParser: jest.fn(() => ({ parse: jest.fn() })),
+    };
+
+    const composition = resolveAnalysisServiceComposition({
+      snapshotProvider,
+      promptBuilder,
+    }, defaults);
+
+    expect(composition.snapshotProvider).toBe(snapshotProvider);
+    expect(composition.promptBuilder).toBe(promptBuilder);
+    expect(defaults.createPromptBuilder).not.toHaveBeenCalled();
+    expect(defaults.createAnalysisClient).toHaveBeenCalledTimes(1);
+    expect(defaults.createResponseParser).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
## Resumen
- extraer una politica compartida de composición para los factories de repository analysis y pull request analysis
- mantener la inyección opcional y los defaults lazy bajo una sola convención
- agregar cobertura unitaria directa para el helper de composición nuevo

## Validación local
- `npm test -- --runInBand tests/unit/services/analysis-service.composition.test.js tests/unit/services/repository-analysis.service.test.js tests/unit/services/pull-request-analysis.service.test.js`
- `npm run lint`
- `npm run typecheck`
- `npm run analyze:architecture:boundaries`
- `npm run analyze:cycles`
- `npm run analyze:duplicates`
- `npm run test:coverage`
- `npm run build`

## Notas
- `lint` sigue mostrando 2 warnings preexistentes en `src/renderer/features/repository-source/presentation/hooks/useRepositorySourceEffects.ts`.
- El paso `analyze:architecture:layers` no pudo correrse localmente porque `depcruise` no resuelve en esta instalación.

Closes #77
