### PR TITLE
refactor: centralizar capabilities de providers y reutilizarlas en IPC

### DIFF
--- a/src/main/ipc/analysis.shared.ts
+++ b/src/main/ipc/analysis.shared.ts
@@ -1,5 +1,10 @@
 import type { RepositoryProviderKind } from '../../types/repository';
 import type { RepositoryAnalysisSnapshotPolicy } from '../../types/analysis/snapshot';
+import {
+  isRepositoryProviderKind,
+  supportsRepositoryProviderCapability,
+  type RepositoryProviderCapability,
+} from '../../services/providers/repository-provider.capabilities';
 
 export function readRequiredString(value: unknown, fieldName: string): string {
   if (typeof value !== 'string' || !value.trim()) {
@@ -9,8 +14,12 @@ export function readRequiredString(value: unknown, fieldName: string): string {
   return value.trim();
 }
 
-export function normalizeProvider(value: unknown, fieldName: string): RepositoryProviderKind {
-  if (value !== 'azure-devops' && value !== 'github' && value !== 'gitlab') {
+export function normalizeProvider(
+  value: unknown,
+  fieldName: string,
+  capability: RepositoryProviderCapability = 'supportsRepositoryAnalysis',
+): RepositoryProviderKind {
+  if (!isRepositoryProviderKind(value) || !supportsRepositoryProviderCapability(value, capability)) {
     throw new Error(`${fieldName} no es valido.`);
   }
 

--- a/src/main/ipc/repository-providers.ts
+++ b/src/main/ipc/repository-providers.ts
@@ -1,6 +1,7 @@
 import { shell } from 'electron';
 import type { RepositoryProviderRegistry } from '../../services/providers/repository-provider.registry';
 import type { RepositoryConnectionConfig, RepositoryProviderKind } from '../../types/repository';
+import { supportsRepositoryProviderCapability } from '../../services/providers/repository-provider.capabilities';
 import { validateExternalUrl } from './external-links';
 import { registerHandle } from './shared';
 
@@ -12,18 +13,31 @@ function readProvider(config: Pick<RepositoryConnectionConfig, 'provider'>): Rep
   return config.provider;
 }
 
+function resolveRepositorySourceProvider(
+  providerRegistry: RepositoryProviderRegistry,
+  config: Pick<RepositoryConnectionConfig, 'provider'>,
+) {
+  const providerKind = readProvider(config);
+
+  if (!supportsRepositoryProviderCapability(providerKind, 'supportsRepositorySource')) {
+    throw new Error(`El provider ${providerKind} aun no soporta operaciones de repository source.`);
+  }
+
+  return providerRegistry.get(providerKind);
+}
+
 export function registerRepositoryProviderIpc(providerRegistry: RepositoryProviderRegistry): void {
   registerHandle<RepositoryConnectionConfig, unknown[]>('repository-source:fetchPullRequests', async (config) => (
-    providerRegistry.get(readProvider(config)).getPullRequests(config)
+    resolveRepositorySourceProvider(providerRegistry, config).getPullRequests(config)
   ));
   registerHandle<RepositoryConnectionConfig, unknown[]>('repository-source:fetchProjects', async (config) => (
-    providerRegistry.get(readProvider(config)).getProjects(config)
+    resolveRepositorySourceProvider(providerRegistry, config).getProjects(config)
   ));
   registerHandle<RepositoryConnectionConfig, unknown[]>('repository-source:fetchRepositories', async (config) => (
-    providerRegistry.get(readProvider(config)).getRepositories(config)
+    resolveRepositorySourceProvider(providerRegistry, config).getRepositories(config)
   ));
   registerHandle<RepositoryConnectionConfig, unknown[]>('repository-source:fetchBranches', async (config) => (
-    providerRegistry.get(readProvider(config)).getBranches(config)
+    resolveRepositorySourceProvider(providerRegistry, config).getBranches(config)
   ));
   registerHandle<string, void>('repository-source:openExternal', async (url) => {
     await shell.openExternal(validateExternalUrl(url));

--- a/src/services/providers/repository-provider.capabilities.ts
+++ b/src/services/providers/repository-provider.capabilities.ts
@@ -1,0 +1,47 @@
+import type { RepositoryProviderKind } from '../../types/repository';
+
+export interface RepositoryProviderCapabilities {
+  supportsRepositorySource: boolean;
+  supportsRepositoryAnalysis: boolean;
+  supportsPullRequestAnalysis: boolean;
+}
+
+const PROVIDER_CAPABILITIES: Record<RepositoryProviderKind, RepositoryProviderCapabilities> = {
+  'azure-devops': {
+    supportsRepositorySource: true,
+    supportsRepositoryAnalysis: true,
+    supportsPullRequestAnalysis: true,
+  },
+  github: {
+    supportsRepositorySource: true,
+    supportsRepositoryAnalysis: true,
+    supportsPullRequestAnalysis: true,
+  },
+  gitlab: {
+    supportsRepositorySource: true,
+    supportsRepositoryAnalysis: true,
+    supportsPullRequestAnalysis: true,
+  },
+  bitbucket: {
+    supportsRepositorySource: false,
+    supportsRepositoryAnalysis: false,
+    supportsPullRequestAnalysis: false,
+  },
+};
+
+export type RepositoryProviderCapability = keyof RepositoryProviderCapabilities;
+
+export function isRepositoryProviderKind(value: unknown): value is RepositoryProviderKind {
+  return typeof value === 'string' && value in PROVIDER_CAPABILITIES;
+}
+
+export function getRepositoryProviderCapabilities(kind: RepositoryProviderKind): RepositoryProviderCapabilities {
+  return PROVIDER_CAPABILITIES[kind];
+}
+
+export function supportsRepositoryProviderCapability(
+  kind: RepositoryProviderKind,
+  capability: RepositoryProviderCapability,
+): boolean {
+  return getRepositoryProviderCapabilities(kind)[capability];
+}

--- a/tests/unit/main/analysis.shared.test.js
+++ b/tests/unit/main/analysis.shared.test.js
@@ -18,6 +18,7 @@ describe('analysis shared helpers', () => {
     expect(normalizeProvider('github', 'provider')).toBe('github');
     expect(normalizeProvider('gitlab', 'provider')).toBe('gitlab');
     expect(() => normalizeProvider('bitbucket', 'provider')).toThrow('provider no es valido.');
+    expect(normalizeProvider('github', 'provider', 'supportsPullRequestAnalysis')).toBe('github');
   });
 
   test('normalizeOptionalString y clampNumber aplican normalizacion defensiva', () => {

--- a/tests/unit/main/ipc.repository-providers.test.js
+++ b/tests/unit/main/ipc.repository-providers.test.js
@@ -59,6 +59,15 @@ describe('repository providers ipc', () => {
     await expect(pullRequestsHandler({ provider: '' })).rejects.toThrow('Selecciona un provider');
   });
 
+  test('rechaza providers sin capability de repository source', async () => {
+    registerRepositoryProviderIpc({ get: jest.fn() });
+    const pullRequestsHandler = registerHandle.mock.calls[0][1];
+
+    await expect(pullRequestsHandler({ provider: 'bitbucket' })).rejects.toThrow(
+      'El provider bitbucket aun no soporta operaciones de repository source.',
+    );
+  });
+
   test('openExternal rechaza URLs no validas', async () => {
     registerRepositoryProviderIpc({ get: jest.fn() });
     const openExternalHandler = registerHandle.mock.calls[4][1];

--- a/tests/unit/services/repository-provider.capabilities.test.js
+++ b/tests/unit/services/repository-provider.capabilities.test.js
@@ -1,0 +1,26 @@
+const {
+  getRepositoryProviderCapabilities,
+  isRepositoryProviderKind,
+  supportsRepositoryProviderCapability,
+} = require('../../../src/services/providers/repository-provider.capabilities');
+
+describe('repository provider capabilities', () => {
+  test('expone capabilities centralizadas para providers implementados', () => {
+    expect(getRepositoryProviderCapabilities('github')).toEqual({
+      supportsRepositorySource: true,
+      supportsRepositoryAnalysis: true,
+      supportsPullRequestAnalysis: true,
+    });
+  });
+
+  test('marca bitbucket como provider conocido pero no soportado', () => {
+    expect(isRepositoryProviderKind('bitbucket')).toBe(true);
+    expect(supportsRepositoryProviderCapability('bitbucket', 'supportsRepositorySource')).toBe(false);
+    expect(supportsRepositoryProviderCapability('bitbucket', 'supportsRepositoryAnalysis')).toBe(false);
+    expect(supportsRepositoryProviderCapability('bitbucket', 'supportsPullRequestAnalysis')).toBe(false);
+  });
+
+  test('ignora valores desconocidos', () => {
+    expect(isRepositoryProviderKind('svn')).toBe(false);
+  });
+});


### PR DESCRIPTION
## Resumen
- crear un catalogo central de capabilities por provider en `services/providers`
- hacer que `analysis.shared` valide providers soportados a partir de ese catalogo y no de una lista hardcodeada
- reutilizar la misma fuente de verdad en `repository-providers` para rechazar providers sin soporte operativo

## Validación local
- `npm test -- --runInBand tests/unit/services/repository-provider.capabilities.test.js tests/unit/main/analysis.shared.test.js tests/unit/main/ipc.repository-providers.test.js`
- `npm run lint`
- `npm run typecheck`
- `npm run analyze:architecture:boundaries`
- `npm run analyze:cycles`
- `npm run analyze:duplicates`
- `npm run test:coverage`
- `npm run build`

## Notas
- `lint` sigue mostrando 2 warnings preexistentes en `src/renderer/features/repository-source/presentation/hooks/useRepositorySourceEffects.ts`.
- El paso `analyze:architecture:layers` no pudo correrse localmente porque `depcruise` no resuelve en esta instalación.

Closes #71
