### PR TITLE
refactor: explicitar el readiness en useRepositorySourceEffects

### DIFF
--- a/src/renderer/features/repository-source/presentation/hooks/useRepositorySourceEffects.ts
+++ b/src/renderer/features/repository-source/presentation/hooks/useRepositorySourceEffects.ts
@@ -21,19 +21,41 @@ export function useRepositorySourceEffects({
     resetDisconnectedState,
     setShouldLoadRepositories,
   } = state;
+  const repositoryReadinessConfig = React.useMemo(
+    () => ({
+      provider: config.provider,
+      organization: config.organization,
+      project: config.project,
+      repositoryId: config.repositoryId,
+      personalAccessToken: config.personalAccessToken,
+      targetReviewer: config.targetReviewer,
+    }),
+    [
+      config.organization,
+      config.personalAccessToken,
+      config.project,
+      config.provider,
+      config.repositoryId,
+      config.targetReviewer,
+    ],
+  );
+  const hasMinimumConfig = React.useMemo(
+    () => hasMinimumRepositoryConfig(repositoryReadinessConfig),
+    [repositoryReadinessConfig],
+  );
 
   React.useEffect(() => {
-    if (!hasMinimumRepositoryConfig(config)) {
+    if (!hasMinimumConfig) {
       resetDisconnectedState();
     }
-  }, [config.organization, config.personalAccessToken, config.project, config.provider, resetDisconnectedState]);
+  }, [hasMinimumConfig, resetDisconnectedState]);
 
   React.useEffect(() => {
     if (!shouldLoadRepositories) {
       return;
     }
 
-    if (hasMinimumRepositoryConfig(config)) {
+    if (hasMinimumConfig) {
       void refreshRepositories(configRef.current).finally(() => {
         setShouldLoadRepositories(false);
       });
@@ -42,11 +64,8 @@ export function useRepositorySourceEffects({
 
     setShouldLoadRepositories(false);
   }, [
-    config.organization,
-    config.personalAccessToken,
-    config.project,
-    config.provider,
     configRef,
+    hasMinimumConfig,
     refreshRepositories,
     setShouldLoadRepositories,
     shouldLoadRepositories,


### PR DESCRIPTION
## Resumen
- derivar explícitamente la condición de configuración mínima antes de los efectos
- hacer que `useRepositorySourceEffects` dependa de ese valor estable en vez de leer `config` de forma implícita
- eliminar el warning de `react-hooks/exhaustive-deps` en este hook sin cambiar comportamiento

## Validación local
- `npm test -- --runInBand tests/integration/renderer/use-repository-source-hooks.dom.test.js`
- `npm run lint`
- `npm run typecheck`
- `npm run analyze:architecture:boundaries`
- `npm run analyze:cycles`
- `npm run analyze:duplicates`
- `npm run test:coverage`
- `npm run build`

## Notas
- este cambio deja limpio `useRepositorySourceEffects`; ya no queda el warning previo en ese archivo
- el paso `analyze:architecture:layers` no pudo correrse localmente porque `depcruise` no resuelve en esta instalación

Closes #87
