### PR TITLE
refactor: descomponer la fachada principal de repository source

### DIFF
--- a/src/renderer/features/repository-source/presentation/hooks/useRepositorySource.ts
+++ b/src/renderer/features/repository-source/presentation/hooks/useRepositorySource.ts
@@ -1,101 +1,23 @@
-import React from 'react';
-import { getRepositoryProvider } from '../../providers';
-import { buildScopeLabel, getProviderDisplayName } from '../../application/repositorySourceDiagnostics';
-import { repositorySourceConfigStorageAdapter } from '../../data/repositorySourceConfigStorageAdapter';
-import { useRepositorySourceBootstrap } from './useRepositorySourceBootstrap';
-import { useRepositorySourceConfig } from './useRepositorySourceConfig';
 import { useRepositorySourceDerived } from './useRepositorySourceDerived';
-import { useRepositorySourceController } from './useRepositorySourceController';
-import { useRepositorySourceSnapshotPersistence } from './useRepositorySourceSnapshotPersistence';
+import { useRepositorySourceCoordinator } from './useRepositorySourceCoordinator';
+import { useRepositorySourceViewModel } from './useRepositorySourceViewModel';
+import { useRepositorySourceWiring } from './useRepositorySourceWiring';
 
 export function useRepositorySource() {
-  const configHook = useRepositorySourceConfig({
-    storage: repositorySourceConfigStorageAdapter,
-  });
-  const { config, configRef, updateConfig, selectProjectConfig, hydrateSecret, migrateLegacyStorage } = configHook;
-  const { applyHydratedSecret } = configHook;
-  const persistSnapshot = useRepositorySourceSnapshotPersistence(configRef);
-  const activeProvider = React.useMemo(() => getRepositoryProvider(config.provider), [config.provider]);
-  const activeProviderName = React.useMemo(() => getProviderDisplayName(activeProvider), [activeProvider]);
-  const baseScopeLabel = React.useMemo(() => buildScopeLabel(config, null, null), [config]);
-
-  const {
-    pullRequests,
-    projects,
-    repositories,
-    error,
-    projectDiscoveryWarning,
-    isLoading,
-    projectsLoading,
-    repositoriesLoading,
-    lastUpdatedAt,
-    hasSuccessfulConnection,
-    diagnostics,
-    isConnectionPanelOpen,
-    resetForConfigChange,
-    refreshPullRequests,
-    discoverProjects,
-    selectProject,
-    openPullRequest,
-    openConnectionPanel,
-  } = useRepositorySourceController({
-    config,
-    configRef,
-    activeProviderName,
-    scopeLabel: baseScopeLabel,
-    onPersistSnapshot: persistSnapshot,
-  });
+  const wiring = useRepositorySourceWiring();
+  const controller = useRepositorySourceCoordinator({ wiring });
 
   const derived = useRepositorySourceDerived({
-    config,
-    projects,
-    repositories,
-    pullRequests,
-    lastUpdatedAt,
-    hasSuccessfulConnection,
+    config: wiring.config,
+    projects: controller.projects,
+    repositories: controller.repositories,
+    pullRequests: controller.pullRequests,
+    lastUpdatedAt: controller.lastUpdatedAt,
+    hasSuccessfulConnection: controller.hasSuccessfulConnection,
   });
-
-  useRepositorySourceBootstrap({
-    migrateLegacyStorage,
-    applyHydratedSecret,
-    hydrateSecret,
-    refreshPullRequests,
+  return useRepositorySourceViewModel({
+    wiring,
+    controller,
+    derived,
   });
-
-  const handleConfigChange = React.useCallback((name: keyof typeof config, value: string) => {
-    resetForConfigChange(name, value);
-    updateConfig(name, value);
-  }, [resetForConfigChange, updateConfig]);
-
-  const handleProjectSelect = React.useCallback((project: string) => {
-    selectProject(project);
-    selectProjectConfig(project);
-  }, [selectProject, selectProjectConfig]);
-
-  return {
-    activeProvider,
-    activeProviderName,
-    config,
-    error,
-    isLoading,
-    projects,
-    projectsLoading,
-    projectDiscoveryWarning,
-    repositories,
-    repositoriesLoading,
-    hasCredentialsInSession: derived.hasCredentialsInSession,
-    hasSuccessfulConnection,
-    isConnectionReady: derived.isConnectionReady,
-    diagnostics,
-    selectedProjectName: derived.selectedProjectName,
-    selectedRepositoryName: derived.selectedRepositoryName,
-    summary: derived.summary,
-    isConnectionPanelOpen,
-    updateConfig: handleConfigChange,
-    discoverProjects,
-    selectProject: handleProjectSelect,
-    refreshPullRequests,
-    openPullRequest,
-    openConnectionPanel,
-  };
 }

--- a/src/renderer/features/repository-source/presentation/hooks/useRepositorySourceCoordinator.ts
+++ b/src/renderer/features/repository-source/presentation/hooks/useRepositorySourceCoordinator.ts
@@ -1,0 +1,28 @@
+import { useRepositorySourceBootstrap } from './useRepositorySourceBootstrap';
+import { useRepositorySourceController } from './useRepositorySourceController';
+import type { ReturnTypeUseRepositorySourceWiring } from './useRepositorySourceViewModel.types';
+
+interface UseRepositorySourceCoordinatorOptions {
+  wiring: ReturnTypeUseRepositorySourceWiring;
+}
+
+export function useRepositorySourceCoordinator({
+  wiring,
+}: UseRepositorySourceCoordinatorOptions) {
+  const controller = useRepositorySourceController({
+    config: wiring.config,
+    configRef: wiring.configRef,
+    activeProviderName: wiring.activeProviderName,
+    scopeLabel: wiring.baseScopeLabel,
+    onPersistSnapshot: wiring.persistSnapshot,
+  });
+
+  useRepositorySourceBootstrap({
+    migrateLegacyStorage: wiring.migrateLegacyStorage,
+    applyHydratedSecret: wiring.applyHydratedSecret,
+    hydrateSecret: wiring.hydrateSecret,
+    refreshPullRequests: controller.refreshPullRequests,
+  });
+
+  return controller;
+}

--- a/src/renderer/features/repository-source/presentation/hooks/useRepositorySourceViewModel.ts
+++ b/src/renderer/features/repository-source/presentation/hooks/useRepositorySourceViewModel.ts
@@ -1,0 +1,57 @@
+import React from 'react';
+import type { SavedConnectionConfig } from '../../types';
+import type { ReturnTypeUseRepositorySourceController } from './useRepositorySourceViewModel.types';
+import type { ReturnTypeUseRepositorySourceDerived } from './useRepositorySourceViewModel.types';
+import type { ReturnTypeUseRepositorySourceWiring } from './useRepositorySourceViewModel.types';
+
+interface UseRepositorySourceViewModelOptions {
+  wiring: ReturnTypeUseRepositorySourceWiring;
+  controller: ReturnTypeUseRepositorySourceController;
+  derived: ReturnTypeUseRepositorySourceDerived;
+}
+
+export function useRepositorySourceViewModel({
+  wiring,
+  controller,
+  derived,
+}: UseRepositorySourceViewModelOptions) {
+  const { configHook, config, activeProvider, activeProviderName } = wiring;
+  const { updateConfig, selectProjectConfig } = configHook;
+
+  const handleConfigChange = React.useCallback((name: keyof SavedConnectionConfig, value: string) => {
+    controller.resetForConfigChange(name, value);
+    updateConfig(name, value);
+  }, [controller, updateConfig]);
+
+  const handleProjectSelect = React.useCallback((project: string) => {
+    controller.selectProject(project);
+    selectProjectConfig(project);
+  }, [controller, selectProjectConfig]);
+
+  return {
+    activeProvider,
+    activeProviderName,
+    config,
+    error: controller.error,
+    isLoading: controller.isLoading,
+    projects: controller.projects,
+    projectsLoading: controller.projectsLoading,
+    projectDiscoveryWarning: controller.projectDiscoveryWarning,
+    repositories: controller.repositories,
+    repositoriesLoading: controller.repositoriesLoading,
+    hasCredentialsInSession: derived.hasCredentialsInSession,
+    hasSuccessfulConnection: controller.hasSuccessfulConnection,
+    isConnectionReady: derived.isConnectionReady,
+    diagnostics: controller.diagnostics,
+    selectedProjectName: derived.selectedProjectName,
+    selectedRepositoryName: derived.selectedRepositoryName,
+    summary: derived.summary,
+    isConnectionPanelOpen: controller.isConnectionPanelOpen,
+    updateConfig: handleConfigChange,
+    discoverProjects: controller.discoverProjects,
+    selectProject: handleProjectSelect,
+    refreshPullRequests: controller.refreshPullRequests,
+    openPullRequest: controller.openPullRequest,
+    openConnectionPanel: controller.openConnectionPanel,
+  };
+}

--- a/src/renderer/features/repository-source/presentation/hooks/useRepositorySourceViewModel.types.ts
+++ b/src/renderer/features/repository-source/presentation/hooks/useRepositorySourceViewModel.types.ts
@@ -1,0 +1,7 @@
+import type { useRepositorySourceController } from './useRepositorySourceController';
+import type { useRepositorySourceDerived } from './useRepositorySourceDerived';
+import type { useRepositorySourceWiring } from './useRepositorySourceWiring';
+
+export type ReturnTypeUseRepositorySourceController = ReturnType<typeof useRepositorySourceController>;
+export type ReturnTypeUseRepositorySourceDerived = ReturnType<typeof useRepositorySourceDerived>;
+export type ReturnTypeUseRepositorySourceWiring = ReturnType<typeof useRepositorySourceWiring>;

--- a/src/renderer/features/repository-source/presentation/hooks/useRepositorySourceWiring.ts
+++ b/src/renderer/features/repository-source/presentation/hooks/useRepositorySourceWiring.ts
@@ -1,0 +1,30 @@
+import React from 'react';
+import { buildScopeLabel, getProviderDisplayName } from '../../application/repositorySourceDiagnostics';
+import { repositorySourceConfigStorageAdapter } from '../../data/repositorySourceConfigStorageAdapter';
+import { getRepositoryProvider } from '../../providers';
+import { useRepositorySourceConfig } from './useRepositorySourceConfig';
+import { useRepositorySourceSnapshotPersistence } from './useRepositorySourceSnapshotPersistence';
+
+export function useRepositorySourceWiring() {
+  const configHook = useRepositorySourceConfig({
+    storage: repositorySourceConfigStorageAdapter,
+  });
+  const { config, configRef, hydrateSecret, migrateLegacyStorage, applyHydratedSecret } = configHook;
+  const persistSnapshot = useRepositorySourceSnapshotPersistence(configRef);
+  const activeProvider = React.useMemo(() => getRepositoryProvider(config.provider), [config.provider]);
+  const activeProviderName = React.useMemo(() => getProviderDisplayName(activeProvider), [activeProvider]);
+  const baseScopeLabel = React.useMemo(() => buildScopeLabel(config, null, null), [config]);
+
+  return {
+    configHook,
+    config,
+    configRef,
+    persistSnapshot,
+    activeProvider,
+    activeProviderName,
+    baseScopeLabel,
+    hydrateSecret,
+    migrateLegacyStorage,
+    applyHydratedSecret,
+  };
+}


### PR DESCRIPTION
## Resumen
- extraer el wiring concreto de `repository-source` a `useRepositorySourceWiring`
- mover la coordinación controller + bootstrap a `useRepositorySourceCoordinator`
- separar el armado del shape público del feature en `useRepositorySourceViewModel`
- dejar `useRepositorySource` como una fachada delgada y con intención más clara

## Validación local
- `npm test -- --runInBand tests/integration/renderer/use-repository-source-hooks.dom.test.js tests/integration/renderer/repository-source-context.dom.test.js`
- `npm run lint`
- `npm run typecheck`
- `npm run analyze:architecture:boundaries`
- `npm run analyze:cycles`
- `npm run analyze:duplicates`
- `npm run test:coverage`
- `npm run build`

## Notas
- esta rama sigue mostrando 2 warnings preexistentes en `src/renderer/features/repository-source/presentation/hooks/useRepositorySourceEffects.ts`; ese punto quedó cubierto por el issue `#87`
- el paso `analyze:architecture:layers` no pudo correrse localmente porque `depcruise` no resuelve en esta instalación

Closes #86
