### PR TITLE
refactor: aplicar SRP en TitleBar separando lógica de window controls

### DIFF
--- a/src/renderer/shared/layout/TitleBar.tsx
+++ b/src/renderer/shared/layout/TitleBar.tsx
@@ -5,20 +5,10 @@ import {
   Squares2X2Icon,
   XMarkIcon,
 } from '@heroicons/react/24/outline';
-import {
-  getElectronApi,
-  subscribeToWindowStateChange,
-  invokeElectronApi,
-} from '../../shared/electron/electronBridge';
+import { useWindowControlsState } from './useWindowControlsState';
 
 const dragRegionStyle = { WebkitAppRegion: 'drag' } as React.CSSProperties & { WebkitAppRegion: 'drag' };
 const noDragRegionStyle = { WebkitAppRegion: 'no-drag' } as React.CSSProperties & { WebkitAppRegion: 'no-drag' };
-
-type WindowControlChannel =
-  | 'window-controls:get-state'
-  | 'window-controls:minimize'
-  | 'window-controls:toggle-maximize'
-  | 'window-controls:close';
 
 const pageMetadata: Record<string, { title: string }> = {
   '/': {
@@ -38,57 +28,6 @@ const pageMetadata: Record<string, { title: string }> = {
 const defaultMetadata = {
   title: 'CheckPR',
 };
-
-function detectRendererPlatform(): NodeJS.Platform {
-  if (typeof navigator === 'undefined') {
-    return 'win32';
-  }
-
-  const platformHint = (
-    (navigator as Navigator & { userAgentData?: { platform?: string } }).userAgentData?.platform
-    ?? navigator.platform
-    ?? ''
-  ).toLowerCase();
-
-  if (platformHint.includes('mac')) {
-    return 'darwin';
-  }
-
-  if (platformHint.includes('win')) {
-    return 'win32';
-  }
-
-  if (platformHint.includes('linux')) {
-    return 'linux';
-  }
-
-  return 'win32';
-}
-
-function isWindowControlsState(value: unknown): value is WindowControlsState {
-  if (!value || typeof value !== 'object') {
-    return false;
-  }
-
-  const candidate = value as Partial<WindowControlsState>;
-  return typeof candidate.isMaximized === 'boolean'
-    && typeof candidate.isFullScreen === 'boolean'
-    && typeof candidate.platform === 'string';
-}
-
-async function invokeWindowControl(channel: WindowControlChannel): Promise<WindowControlsState | null> {
-  if (!getElectronApi()) {
-    return null;
-  }
-
-  const response = await invokeElectronApi<unknown>(channel);
-
-  if (response === null) {
-    return null;
-  }
-
-  return isWindowControlsState(response) ? response : null;
-}
 
 interface TitleBarProps {
   pathname: string;
@@ -216,55 +155,13 @@ const DesktopWindowControls = ({
 
 const TitleBar = ({ pathname }: TitleBarProps) => {
   const metadata = pageMetadata[pathname] ?? defaultMetadata;
-  const supportsWindowControls = Boolean(getElectronApi()?.onWindowStateChange);
-  const [windowState, setWindowState] = React.useState<WindowControlsState>({
-    isMaximized: false,
-    isFullScreen: false,
-    platform: detectRendererPlatform(),
-  });
-
-  React.useEffect(() => {
-    let isSubscribed = true;
-
-    invokeWindowControl('window-controls:get-state')
-      .then((state) => {
-        if (state && isSubscribed) {
-          setWindowState(state);
-        }
-      })
-      .catch(() => undefined);
-
-    const unsubscribe = subscribeToWindowStateChange((state) => {
-      if (isSubscribed) {
-        setWindowState(state);
-      }
-    });
-
-    return () => {
-      isSubscribed = false;
-      unsubscribe();
-    };
-  }, []);
-
-  const handleMinimize = React.useCallback(async () => {
-    const nextState = await invokeWindowControl('window-controls:minimize');
-
-    if (nextState) {
-      setWindowState(nextState);
-    }
-  }, []);
-
-  const handleToggleMaximize = React.useCallback(async () => {
-    const nextState = await invokeWindowControl('window-controls:toggle-maximize');
-
-    if (nextState) {
-      setWindowState(nextState);
-    }
-  }, []);
-
-  const handleClose = React.useCallback(async () => {
-    await invokeWindowControl('window-controls:close');
-  }, []);
+  const {
+    supportsWindowControls,
+    windowState,
+    handleMinimize,
+    handleToggleMaximize,
+    handleClose,
+  } = useWindowControlsState();
 
   const isMacOS = supportsWindowControls && windowState.platform === 'darwin';
 

--- a/src/renderer/shared/layout/useWindowControlsState.ts
+++ b/src/renderer/shared/layout/useWindowControlsState.ts
@@ -1,0 +1,123 @@
+import React from 'react';
+import {
+  getElectronApi,
+  invokeElectronApi,
+  subscribeToWindowStateChange,
+} from '../../shared/electron/electronBridge';
+
+type WindowControlChannel =
+  | 'window-controls:get-state'
+  | 'window-controls:minimize'
+  | 'window-controls:toggle-maximize'
+  | 'window-controls:close';
+
+function detectRendererPlatform(): NodeJS.Platform {
+  if (typeof navigator === 'undefined') {
+    return 'win32';
+  }
+
+  const platformHint = (
+    (navigator as Navigator & { userAgentData?: { platform?: string } }).userAgentData?.platform
+    ?? navigator.platform
+    ?? ''
+  ).toLowerCase();
+
+  if (platformHint.includes('mac')) {
+    return 'darwin';
+  }
+
+  if (platformHint.includes('win')) {
+    return 'win32';
+  }
+
+  if (platformHint.includes('linux')) {
+    return 'linux';
+  }
+
+  return 'win32';
+}
+
+function isWindowControlsState(value: unknown): value is WindowControlsState {
+  if (!value || typeof value !== 'object') {
+    return false;
+  }
+
+  const candidate = value as Partial<WindowControlsState>;
+  return typeof candidate.isMaximized === 'boolean'
+    && typeof candidate.isFullScreen === 'boolean'
+    && typeof candidate.platform === 'string';
+}
+
+async function invokeWindowControl(channel: WindowControlChannel): Promise<WindowControlsState | null> {
+  if (!getElectronApi()) {
+    return null;
+  }
+
+  const response = await invokeElectronApi<unknown>(channel);
+
+  if (response === null) {
+    return null;
+  }
+
+  return isWindowControlsState(response) ? response : null;
+}
+
+export function useWindowControlsState() {
+  const supportsWindowControls = Boolean(getElectronApi()?.onWindowStateChange);
+  const [windowState, setWindowState] = React.useState<WindowControlsState>({
+    isMaximized: false,
+    isFullScreen: false,
+    platform: detectRendererPlatform(),
+  });
+
+  React.useEffect(() => {
+    let isSubscribed = true;
+
+    invokeWindowControl('window-controls:get-state')
+      .then((state) => {
+        if (state && isSubscribed) {
+          setWindowState(state);
+        }
+      })
+      .catch(() => undefined);
+
+    const unsubscribe = subscribeToWindowStateChange((state) => {
+      if (isSubscribed) {
+        setWindowState(state);
+      }
+    });
+
+    return () => {
+      isSubscribed = false;
+      unsubscribe();
+    };
+  }, []);
+
+  const handleMinimize = React.useCallback(async () => {
+    const nextState = await invokeWindowControl('window-controls:minimize');
+
+    if (nextState) {
+      setWindowState(nextState);
+    }
+  }, []);
+
+  const handleToggleMaximize = React.useCallback(async () => {
+    const nextState = await invokeWindowControl('window-controls:toggle-maximize');
+
+    if (nextState) {
+      setWindowState(nextState);
+    }
+  }, []);
+
+  const handleClose = React.useCallback(async () => {
+    await invokeWindowControl('window-controls:close');
+  }, []);
+
+  return {
+    supportsWindowControls,
+    windowState,
+    handleMinimize,
+    handleToggleMaximize,
+    handleClose,
+  };
+}


### PR DESCRIPTION
## Resumen
Este PR implementa el Issue #91 aplicando el principio **SRP (Single Responsibility Principle)** en el módulo de title bar.

Se separó la lógica de estado/efectos de controles de ventana (detección de plataforma, suscripción a eventos IPC, invocación de acciones minimize/maximize/close) en un hook dedicado, dejando `TitleBar` enfocado en composición y render UI.

Closes #91

## Problema previo
`TitleBar` concentraba responsabilidades heterogéneas:
- detección de plataforma del renderer
- validación y normalización de estado de ventana
- invocación de canales IPC de controles de ventana
- suscripción/desuscripción a cambios de estado
- renderización de controles y layout

Esto elevaba el acoplamiento interno y hacía menos predecible el impacto de cambios en lógica de integración con Electron.

## Cambios realizados
1. Nuevo hook `useWindowControlsState`
- Archivo: `src/renderer/shared/layout/useWindowControlsState.ts`
- Responsabilidades encapsuladas:
  - `detectRendererPlatform`
  - guard de tipo `isWindowControlsState`
  - invocación segura de canales de window controls
  - sincronización inicial con `window-controls:get-state`
  - suscripción a `onWindowStateChange`
  - acciones `handleMinimize`, `handleToggleMaximize`, `handleClose`

2. Simplificación de `TitleBar`
- Archivo: `src/renderer/shared/layout/TitleBar.tsx`
- El componente ahora:
  - consume `useWindowControlsState`
  - decide variante visual (macOS vs desktop)
  - renderiza estructura y botones
- Se removió lógica de integración/side effects del componente principal.

## Impacto arquitectónico
- Mejora la cohesión: lógica de runtime/IPC queda en un módulo especializado.
- Reduce acoplamiento accidental del componente visual.
- Facilita pruebas unitarias y futuros cambios en estrategia de control de ventana.

## Validación ejecutada
- `npm run typecheck`
- `npx jest tests/unit/renderer/title-bar.dom.test.js --runInBand`
- `guard:commit` ejecutado por hook pre-commit (incluye lint, typecheck, arquitectura, solid y tests)
- `guard:push` ejecutado por hook pre-push (incluye quality gates completos, cobertura y build)

Resultado: todo en verde.

## Riesgos y mitigaciones
- Riesgo: regresión en sincronización de estado de ventana al mover efectos.
- Mitigación: se preservó la secuencia original de bootstrap/suscripción y se validó con suite existente.

## Notas de compatibilidad
- No hay cambios de contrato público para consumidores de `TitleBar`.
- No hay cambios en canales IPC ni payloads.
