### PR TITLE
refactor: aplicar OCP en resolución de source para repository analysis

### DIFF
--- a/src/services/analysis/repository-analysis.snapshot-provider.ts
+++ b/src/services/analysis/repository-analysis.snapshot-provider.ts
@@ -1,21 +1,20 @@
 import type { RepositoryAnalysisRequest } from '../../types/analysis';
 import type { SnapshotProviderPort } from './repository-analysis.ports';
 import type { RepositoryProviderRegistry } from '../providers/repository-provider.registry';
+import {
+  resolveRepositoryAnalysisSourceConfig,
+  type RepositoryAnalysisSourceResolver,
+} from './repository-analysis.source-resolver';
 
 export class RepositoryAnalysisSnapshotProvider implements SnapshotProviderPort {
   constructor(
     private readonly providerRegistry: RepositoryProviderRegistry,
+    private readonly sourceResolver: RepositoryAnalysisSourceResolver = resolveRepositoryAnalysisSourceConfig,
   ) {}
 
   async getSnapshot(request: RepositoryAnalysisRequest) {
     const provider = this.providerRegistry.get(request.source.provider);
-    const sourceConfig = {
-      ...request.source,
-      repositoryId: request.repositoryId,
-      project: request.source.provider === 'azure-devops'
-        ? request.source.project
-        : request.repositoryId || request.source.project,
-    };
+    const sourceConfig = this.sourceResolver(request);
 
     const options = {
       branchName: request.branchName,

--- a/src/services/analysis/repository-analysis.source-resolver.ts
+++ b/src/services/analysis/repository-analysis.source-resolver.ts
@@ -1,0 +1,41 @@
+import type { RepositoryAnalysisRequest } from '../../types/analysis';
+import type { RepositoryConnectionConfig, RepositoryProviderKind } from '../../types/repository';
+
+export type RepositoryAnalysisSourceResolver = (
+  request: RepositoryAnalysisRequest,
+) => RepositoryConnectionConfig;
+
+type ProviderSourceResolver = (
+  request: RepositoryAnalysisRequest,
+  defaultResolver: RepositoryAnalysisSourceResolver,
+) => RepositoryConnectionConfig;
+
+function resolveDefaultSource(request: RepositoryAnalysisRequest): RepositoryConnectionConfig {
+  return {
+    ...request.source,
+    repositoryId: request.repositoryId,
+    project: request.repositoryId || request.source.project,
+  };
+}
+
+function resolveAzureDevopsSource(request: RepositoryAnalysisRequest): RepositoryConnectionConfig {
+  return {
+    ...request.source,
+    repositoryId: request.repositoryId,
+    project: request.source.project,
+  };
+}
+
+const providerSourceResolvers: Partial<Record<RepositoryProviderKind, ProviderSourceResolver>> = {
+  'azure-devops': (request) => resolveAzureDevopsSource(request),
+};
+
+export function resolveRepositoryAnalysisSourceConfig(request: RepositoryAnalysisRequest): RepositoryConnectionConfig {
+  const providerResolver = providerSourceResolvers[request.source.provider];
+
+  if (!providerResolver) {
+    return resolveDefaultSource(request);
+  }
+
+  return providerResolver(request, resolveDefaultSource);
+}

--- a/tests/unit/services/repository-analysis.snapshot-provider.test.js
+++ b/tests/unit/services/repository-analysis.snapshot-provider.test.js
@@ -1,0 +1,82 @@
+const {
+  RepositoryAnalysisSnapshotProvider,
+} = require('../../../src/services/analysis/repository-analysis.snapshot-provider');
+const {
+  resolveRepositoryAnalysisSourceConfig,
+} = require('../../../src/services/analysis/repository-analysis.source-resolver');
+
+function buildRequest(provider, overrides = {}) {
+  return {
+    requestId: 'request-1',
+    source: {
+      provider,
+      organization: 'acme',
+      project: 'platform',
+      repositoryId: 'legacy-repository',
+      personalAccessToken: 'pat',
+      targetReviewer: 'qa-user',
+    },
+    repositoryId: 'new-repository',
+    branchName: 'main',
+    model: 'gpt-5-mini',
+    apiKey: 'sk-test',
+    analysisDepth: 'standard',
+    maxFilesPerRun: 120,
+    includeTests: true,
+    snapshotPolicy: {
+      excludedPathPatterns: '**/*.snap',
+      strictMode: false,
+    },
+    ...overrides,
+  };
+}
+
+describe('repository analysis source resolver', () => {
+  test('mantiene el project original para Azure DevOps', () => {
+    const request = buildRequest('azure-devops');
+
+    expect(resolveRepositoryAnalysisSourceConfig(request)).toEqual({
+      ...request.source,
+      repositoryId: request.repositoryId,
+      project: request.source.project,
+    });
+  });
+
+  test('para providers no Azure usa repositoryId como project si viene informado', () => {
+    const request = buildRequest('github');
+
+    expect(resolveRepositoryAnalysisSourceConfig(request)).toEqual({
+      ...request.source,
+      repositoryId: request.repositoryId,
+      project: request.repositoryId,
+    });
+  });
+});
+
+describe('RepositoryAnalysisSnapshotProvider', () => {
+  test('resuelve source config y options antes de pedir snapshot al provider', async () => {
+    const getRepositorySnapshot = jest.fn().mockResolvedValue({ ok: true });
+    const providerRegistry = {
+      get: jest.fn().mockReturnValue({ getRepositorySnapshot }),
+    };
+    const request = buildRequest('gitlab');
+    const snapshotProvider = new RepositoryAnalysisSnapshotProvider(providerRegistry);
+
+    await expect(snapshotProvider.getSnapshot(request)).resolves.toEqual({ ok: true });
+
+    expect(providerRegistry.get).toHaveBeenCalledWith('gitlab');
+    expect(getRepositorySnapshot).toHaveBeenCalledWith(
+      {
+        ...request.source,
+        repositoryId: request.repositoryId,
+        project: request.repositoryId,
+      },
+      {
+        branchName: request.branchName,
+        maxFiles: request.maxFilesPerRun,
+        includeTests: request.includeTests,
+        excludedPathPatterns: request.snapshotPolicy.excludedPathPatterns,
+      },
+    );
+  });
+});


### PR DESCRIPTION
## Resumen
Este PR implementa el Issue #92 aplicando **OCP (Open/Closed Principle)** en la construcción del `sourceConfig` para análisis de repositorio.

Se removió el condicional directo por provider dentro de `RepositoryAnalysisSnapshotProvider` y se introdujo una estrategia de resolución por proveedor en un módulo dedicado.

Closes #92

## Problema previo
En `RepositoryAnalysisSnapshotProvider` existía lógica condicional inline:
- si provider era `azure-devops`, se mantenía `source.project`
- para otros providers, `project` se resolvía con `repositoryId || source.project`

Este diseño obligaba a modificar una clase central cada vez que aparecía un caso nuevo de provider, reduciendo extensibilidad y aumentando riesgo de regresión.

## Cambios realizados
1. Nuevo resolvedor de source config
- Archivo nuevo: `src/services/analysis/repository-analysis.source-resolver.ts`
- Se agregó:
  - `RepositoryAnalysisSourceResolver`
  - `resolveRepositoryAnalysisSourceConfig(request)`
  - estrategia por provider con mapa de resolvers (`providerSourceResolvers`)
  - fallback por defecto para providers no específicos

2. Refactor del snapshot provider
- Archivo: `src/services/analysis/repository-analysis.snapshot-provider.ts`
- Cambios:
  - inyección opcional de `sourceResolver` en constructor
  - uso de `this.sourceResolver(request)` en lugar de condicional hardcodeado

3. Cobertura de pruebas
- Archivo nuevo: `tests/unit/services/repository-analysis.snapshot-provider.test.js`
- Casos validados:
  - Azure DevOps mantiene `project` original
  - Providers no Azure usan `repositoryId` como `project` cuando existe
  - `RepositoryAnalysisSnapshotProvider` invoca provider con source+options esperados

## Por qué mejora OCP
- El proveedor principal (`RepositoryAnalysisSnapshotProvider`) ya no necesita cambios para sumar variaciones de resolución.
- Nuevos comportamientos se agregan en el resolvedor por estrategia, minimizando modificación de código estable.

## Validación ejecutada
- `npm run typecheck`
- `npx jest tests/unit/services/repository-analysis.snapshot-provider.test.js --runInBand`
- `guard:commit` (lint, typecheck, arquitectura, solid, suite de tests)
- `guard:push` (quality check completo, coverage, build)

Resultado: todo en verde.

## Riesgos y mitigaciones
- Riesgo: divergencia de comportamiento en providers existentes.
- Mitigación: tests explícitos para Azure y no-Azure, más validación end-to-end de quality gates.

## Notas
- No se alteraron contratos IPC.
- No se cambiaron payloads de análisis.
- El cambio es transparente para el renderer y para consumidores del servicio.
