### PR TITLE
refactor(repository-source): estrategias por provider para requestPath (OCP)

### DIFF
--- a/src/renderer/features/repository-source/application/repositorySourceProviderRegistry.ts
+++ b/src/renderer/features/repository-source/application/repositorySourceProviderRegistry.ts
@@ -108,51 +108,62 @@ const azureBehavior: RepositorySourceProviderBehavior = {
   },
 };
 
-const namespaceBehavior: RepositorySourceProviderBehavior = {
-  mirrorsProjectsAsRepositories: true,
-  buildScopeLabel: buildNamespaceScopeLabel,
-  buildRequestPath(operation, config) {
-    const organization = config.organization.trim();
-    const repository = config.repositoryId?.trim() || config.project.trim();
+function createNamespaceBehavior(
+  buildRequestPath: RepositorySourceProviderBehavior['buildRequestPath'],
+): RepositorySourceProviderBehavior {
+  return {
+    mirrorsProjectsAsRepositories: true,
+    buildScopeLabel: buildNamespaceScopeLabel,
+    buildRequestPath,
+    applyConfigChange: applyGenericConfigChange,
+    applyProjectSelection(current, project) {
+      return {
+        ...current,
+        project,
+        repositoryId: project,
+      };
+    },
+    hasMinimumRepositoryConfig(config) {
+      return Boolean(config.organization && config.personalAccessToken);
+    },
+  };
+}
 
-    if (config.provider === 'github') {
-      if (operation === 'projects' || operation === 'repositories') {
-        return 'https://api.github.com/user/repos';
-      }
+function buildGitHubRequestPath(operation: RepositorySourceOperation, config: SavedConnectionConfig): string {
+  const organization = config.organization.trim();
+  const repository = config.repositoryId?.trim() || config.project.trim();
 
-      if (operation === 'pullRequests') {
-        return repository
-          ? `https://api.github.com/repos/${organization}/${repository}/pulls`
-          : 'https://api.github.com/user/repos -> /repos/{owner}/{repo}/pulls';
-      }
+  if (operation === 'projects' || operation === 'repositories') {
+    return 'https://api.github.com/user/repos';
+  }
 
-      return '';
-    }
+  if (operation === 'pullRequests') {
+    return repository
+      ? `https://api.github.com/repos/${organization}/${repository}/pulls`
+      : 'https://api.github.com/user/repos -> /repos/{owner}/{repo}/pulls';
+  }
 
-    if (operation === 'projects' || operation === 'repositories') {
-      return 'https://gitlab.com/api/v4/projects';
-    }
+  return '';
+}
 
-    if (operation === 'pullRequests') {
-      return repository
-        ? `https://gitlab.com/api/v4/projects/${encodeURIComponent(repository)}/merge_requests`
-        : 'https://gitlab.com/api/v4/projects -> /projects/{id}/merge_requests';
-    }
+function buildGitLabRequestPath(operation: RepositorySourceOperation, config: SavedConnectionConfig): string {
+  const repository = config.repositoryId?.trim() || config.project.trim();
 
-    return '';
-  },
-  applyConfigChange: applyGenericConfigChange,
-  applyProjectSelection(current, project) {
-    return {
-      ...current,
-      project,
-      repositoryId: project,
-    };
-  },
-  hasMinimumRepositoryConfig(config) {
-    return Boolean(config.organization && config.personalAccessToken);
-  },
-};
+  if (operation === 'projects' || operation === 'repositories') {
+    return 'https://gitlab.com/api/v4/projects';
+  }
+
+  if (operation === 'pullRequests') {
+    return repository
+      ? `https://gitlab.com/api/v4/projects/${encodeURIComponent(repository)}/merge_requests`
+      : 'https://gitlab.com/api/v4/projects -> /projects/{id}/merge_requests';
+  }
+
+  return '';
+}
+
+const githubBehavior = createNamespaceBehavior(buildGitHubRequestPath);
+const gitlabBehavior = createNamespaceBehavior(buildGitLabRequestPath);
 
 const repositorySourceProviderRegistry: RepositorySourceProviderEntry[] = [
   {
@@ -169,7 +180,7 @@ const repositorySourceProviderRegistry: RepositorySourceProviderEntry[] = [
     status: 'available',
     description: 'Segundo provider operativo. Soporta owner, repositorios, ramas y Pull Requests abiertos.',
     helperText: 'Usa owner u organizacion y un personal access token clasico o fine-grained con permisos sobre Pull requests y Contents.',
-    behavior: namespaceBehavior,
+    behavior: githubBehavior,
   },
   {
     kind: 'gitlab',
@@ -177,7 +188,7 @@ const repositorySourceProviderRegistry: RepositorySourceProviderEntry[] = [
     status: 'available',
     description: 'Tercer provider operativo. Soporta namespace, proyectos, ramas y Merge Requests abiertos.',
     helperText: 'Usa group/namespace y un personal access token con scopes de lectura sobre API y repositorios.',
-    behavior: namespaceBehavior,
+    behavior: gitlabBehavior,
   },
   {
     kind: 'bitbucket',

--- a/tests/unit/renderer/repository-source-helpers.test.js
+++ b/tests/unit/renderer/repository-source-helpers.test.js
@@ -138,6 +138,47 @@ describe('repository source helpers', () => {
     expect(providerBehavior.getRepositorySourceProviderBehavior('bitbucket')).toBeNull();
   });
 
+  test('cada provider namespace resuelve su requestPath sin condicionales compartidos', () => {
+    const githubBehavior = providerBehavior.getRepositorySourceProviderBehavior('github');
+    const gitlabBehavior = providerBehavior.getRepositorySourceProviderBehavior('gitlab');
+
+    const githubPullRequestsPath = githubBehavior.buildRequestPath('pullRequests', {
+      provider: 'github',
+      organization: 'acme',
+      project: '',
+      repositoryId: 'repo-a',
+      personalAccessToken: '',
+      targetReviewer: '',
+    });
+    const gitlabPullRequestsPath = gitlabBehavior.buildRequestPath('pullRequests', {
+      provider: 'gitlab',
+      organization: 'acme/platform',
+      project: '',
+      repositoryId: 'acme/platform/repo-a',
+      personalAccessToken: '',
+      targetReviewer: '',
+    });
+
+    expect(githubPullRequestsPath).toBe('https://api.github.com/repos/acme/repo-a/pulls');
+    expect(gitlabPullRequestsPath).toBe(`https://gitlab.com/api/v4/projects/${encodeURIComponent('acme/platform/repo-a')}/merge_requests`);
+    expect(githubBehavior.buildRequestPath(null, {
+      provider: 'github',
+      organization: 'acme',
+      project: '',
+      repositoryId: '',
+      personalAccessToken: '',
+      targetReviewer: '',
+    })).toBe('');
+    expect(gitlabBehavior.buildRequestPath(null, {
+      provider: 'gitlab',
+      organization: 'acme',
+      project: '',
+      repositoryId: '',
+      personalAccessToken: '',
+      targetReviewer: '',
+    })).toBe('');
+  });
+
   test('hasMinimumProjectDiscoveryConfig y hasMinimumRepositoryConfig validan por provider', () => {
     expect(rules.hasMinimumProjectDiscoveryConfig({
       provider: 'github',


### PR DESCRIPTION
## Resumen
Este PR implementa el issue #97 para mejorar el cumplimiento de **Open/Closed Principle (OCP)** en el registro de providers de `repository source`.

Antes, la lógica para construir el `requestPath` de providers con namespace estaba centralizada en un comportamiento compartido que evaluaba internamente `config.provider` para bifurcar entre GitHub y GitLab. Aunque funcionaba, obligaba a modificar una pieza común cada vez que cambiaba o se agregaba un provider.

Con este cambio, cada provider declara su estrategia de construcción de `requestPath` de forma explícita, eliminando el condicional cruzado y reduciendo el riesgo de regresiones al extender soporte.

Closes #97

## Problema detectado
- El comportamiento de namespace era parcialmente compartido y dependía de un `if` interno por provider.
- Eso introduce acoplamiento entre providers y un punto de cambio múltiple en una sola unidad.
- Afecta OCP porque la extensión de providers requería tocar una implementación genérica existente.

## Solución aplicada
### 1) Estrategias explícitas por provider
En `repositorySourceProviderRegistry.ts`:
- Se eliminó el comportamiento `namespaceBehavior` con condicional interno por provider.
- Se introdujo `createNamespaceBehavior(buildRequestPath)` para inyectar la estrategia de path.
- Se agregaron funciones dedicadas:
  - `buildGitHubRequestPath(...)`
  - `buildGitLabRequestPath(...)`
- Se definieron comportamientos concretos:
  - `githubBehavior`
  - `gitlabBehavior`
- El registro (`providerBehaviorRegistry`) ahora asocia cada provider a su estrategia explícita.

### 2) Cobertura de pruebas orientada a OCP
En `repository-source-helpers.test.js`:
- Se añadió un test que valida que cada provider namespace resuelve su `requestPath` correcto sin depender de una rama condicional compartida.
- Se verifica fallback de operación nula (`noop`) para mantener seguridad de comportamiento.

## Validación ejecutada
Se ejecutó y pasó exitosamente:
- `npm run typecheck`
- `npx jest tests/unit/renderer/repository-source-helpers.test.js --runInBand`
- Hooks de commit con suite completa (`guard:commit`): lint, typecheck, arquitectura, SOLID y Jest

## Impacto esperado
- Menor acoplamiento entre providers.
- Mayor facilidad para extender providers sin tocar ramas condicionales globales.
- Mejor trazabilidad de comportamiento por provider.
- Mejora del score de OCP en el módulo de selección/configuración de repositorio.

## Riesgos y mitigaciones
- Riesgo: diferencias sutiles en construcción de rutas.
- Mitigación: test específico de rutas por provider + pruebas existentes del flujo de helpers.

## Checklist
- [x] Refactor enfocado a OCP sin ampliar alcance funcional
- [x] Pruebas actualizadas para cubrir el nuevo diseño
- [x] Sin cambios de contrato público hacia UI
- [x] Issue vinculado y cerrado por PR
