### PR TITLE
refactor(pr-analysis): extraer item analyzer y simplificar orquestador (SRP)

### DIFF
--- a/src/services/analysis/pull-request-analysis.item-analyzer.ts
+++ b/src/services/analysis/pull-request-analysis.item-analyzer.ts
@@ -1,0 +1,117 @@
+import type { PullRequestAiReview, PullRequestAnalysisBatchRequest, PullRequestAnalysisPreview } from '../../types/analysis';
+import type {
+  PullRequestAnalysisClientPort,
+  PullRequestAnalysisPromptBuilderPort,
+  PullRequestAnalysisResponseParserPort,
+  PullRequestAnalysisSnapshotProviderPort,
+} from './pull-request-analysis.ports';
+import { buildPullRequestAnalysisPreview } from './pull-request-analysis.preview';
+
+export interface PullRequestAnalysisItemAnalyzerDependencies {
+  snapshotProvider: PullRequestAnalysisSnapshotProviderPort;
+  promptBuilder: PullRequestAnalysisPromptBuilderPort;
+  analysisClient: PullRequestAnalysisClientPort;
+  responseParser: PullRequestAnalysisResponseParserPort;
+}
+
+export interface PullRequestAnalysisItemRunContext {
+  onControllerCreated?: (controller: AbortController) => void;
+  onControllerDisposed?: (controller: AbortController) => void;
+}
+
+const DEFAULT_ITEM_ANALYSIS_TIMEOUT_MS = 60_000;
+
+export class PullRequestAnalysisItemAnalyzer {
+  private readonly snapshotProvider: PullRequestAnalysisSnapshotProviderPort;
+  private readonly promptBuilder: PullRequestAnalysisPromptBuilderPort;
+  private readonly analysisClient: PullRequestAnalysisClientPort;
+  private readonly responseParser: PullRequestAnalysisResponseParserPort;
+
+  constructor({
+    snapshotProvider,
+    promptBuilder,
+    analysisClient,
+    responseParser,
+  }: PullRequestAnalysisItemAnalyzerDependencies) {
+    this.snapshotProvider = snapshotProvider;
+    this.promptBuilder = promptBuilder;
+    this.analysisClient = analysisClient;
+    this.responseParser = responseParser;
+  }
+
+  async analyzeItem(
+    request: PullRequestAnalysisBatchRequest,
+    item: PullRequestAnalysisBatchRequest['items'][number],
+    runContext: PullRequestAnalysisItemRunContext = {},
+  ): Promise<PullRequestAiReview> {
+    const snapshot = await this.snapshotProvider.getSnapshot(request.source, item.pullRequest, request.snapshotPolicy);
+    const preview = buildPullRequestAnalysisPreview(snapshot, Boolean(request.snapshotPolicy?.strictMode));
+
+    if (preview.lacksPatchCoverage) {
+      return this.toOmittedReview(item, preview.partialReason || preview.sensitivity.summary);
+    }
+
+    if (preview.strictModeWouldBlock) {
+      return this.toOmittedReview(item, this.buildStrictModeCoverageNote(preview));
+    }
+
+    const prompt = this.promptBuilder.build(request, snapshot);
+    const timeoutMs = request.timeoutMs ?? DEFAULT_ITEM_ANALYSIS_TIMEOUT_MS;
+    const controller = new AbortController();
+    const timeoutId = setTimeout(() => controller.abort('timeout'), timeoutMs);
+    runContext.onControllerCreated?.(controller);
+
+    try {
+      const rawText = await this.analysisClient.analyze({ request, prompt, signal: controller.signal });
+      const parsed = this.responseParser.parse(rawText);
+
+      return {
+        pullRequestId: item.pullRequest.id,
+        repository: item.pullRequest.repository,
+        status: 'analyzed',
+        riskScore: Math.max(0, Math.min(100, Math.round(parsed.riskScore))),
+        shortSummary: parsed.shortSummary,
+        topConcerns: parsed.topConcerns,
+        reviewChecklist: parsed.reviewChecklist,
+        coverageNote: snapshot.partialReason,
+      };
+    } catch (error) {
+      return {
+        pullRequestId: item.pullRequest.id,
+        repository: item.pullRequest.repository,
+        status: 'error',
+        topConcerns: [],
+        reviewChecklist: [],
+        error: error instanceof Error
+          ? error.message
+          : 'No fue posible analizar el PR.',
+      };
+    } finally {
+      clearTimeout(timeoutId);
+      runContext.onControllerDisposed?.(controller);
+    }
+  }
+
+  private toOmittedReview(
+    item: PullRequestAnalysisBatchRequest['items'][number],
+    coverageNote: string,
+  ): PullRequestAiReview {
+    return {
+      pullRequestId: item.pullRequest.id,
+      repository: item.pullRequest.repository,
+      status: 'omitted',
+      topConcerns: [],
+      reviewChecklist: [],
+      coverageNote,
+    };
+  }
+
+  private buildStrictModeCoverageNote(preview: PullRequestAnalysisPreview): string {
+    const blockedBySensitiveConfig = preview.sensitivity.hasSensitiveConfigFiles && !preview.sensitivity.hasSecretPatterns;
+    return preview.lacksPatchCoverage
+      ? 'PR omitido por modo estricto: el snapshot no incluye diff textual suficiente para una revision segura.'
+      : blockedBySensitiveConfig
+        ? 'PR omitido por modo estricto: se detectaron archivos potencialmente sensibles y la cobertura del diff es incompleta.'
+        : 'PR omitido por modo estricto y señales sensibles en el diff.';
+  }
+}

--- a/src/services/analysis/pull-request-analysis.service.ts
+++ b/src/services/analysis/pull-request-analysis.service.ts
@@ -7,6 +7,7 @@ import type {
   PullRequestAnalysisSnapshotProviderPort,
 } from './pull-request-analysis.ports';
 import { buildPullRequestAnalysisPreview } from './pull-request-analysis.preview';
+import { PullRequestAnalysisItemAnalyzer } from './pull-request-analysis.item-analyzer';
 
 interface PullRequestAnalysisServiceDependencies {
   snapshotProvider: PullRequestAnalysisSnapshotProviderPort;
@@ -18,9 +19,7 @@ interface PullRequestAnalysisServiceDependencies {
 export class PullRequestAnalysisService {
   private activeRuns = new Map<string, Set<AbortController>>();
   private readonly snapshotProvider: PullRequestAnalysisSnapshotProviderPort;
-  private readonly promptBuilder: PullRequestAnalysisPromptBuilderPort;
-  private readonly analysisClient: PullRequestAnalysisClientPort;
-  private readonly responseParser: PullRequestAnalysisResponseParserPort;
+  private readonly itemAnalyzer: PullRequestAnalysisItemAnalyzer;
 
   constructor({
     snapshotProvider,
@@ -29,9 +28,12 @@ export class PullRequestAnalysisService {
     responseParser,
   }: PullRequestAnalysisServiceDependencies) {
     this.snapshotProvider = snapshotProvider;
-    this.promptBuilder = promptBuilder;
-    this.analysisClient = analysisClient;
-    this.responseParser = responseParser;
+    this.itemAnalyzer = new PullRequestAnalysisItemAnalyzer({
+      snapshotProvider,
+      promptBuilder,
+      analysisClient,
+      responseParser,
+    });
   }
 
   async previewBatch(request: PullRequestAnalysisBatchRequest): Promise<PullRequestAnalysisPreview[]> {
@@ -63,77 +65,22 @@ export class PullRequestAnalysisService {
     }
 
     try {
-      const results = await mapWithConcurrency(request.items, 2, async (item) => {
-        const snapshot = await this.snapshotProvider.getSnapshot(request.source, item.pullRequest, request.snapshotPolicy);
-        const preview = buildPullRequestAnalysisPreview(snapshot, Boolean(request.snapshotPolicy?.strictMode));
-
-        if (preview.lacksPatchCoverage) {
-          return {
-            pullRequestId: item.pullRequest.id,
-            repository: item.pullRequest.repository,
-            status: 'omitted' as const,
-            topConcerns: [],
-            reviewChecklist: [],
-            coverageNote: preview.partialReason || preview.sensitivity.summary,
-          };
-        }
-
-        if (preview.strictModeWouldBlock) {
-          const blockedBySensitiveConfig = preview.sensitivity.hasSensitiveConfigFiles && !preview.sensitivity.hasSecretPatterns;
-          return {
-            pullRequestId: item.pullRequest.id,
-            repository: item.pullRequest.repository,
-            status: 'omitted' as const,
-            topConcerns: [],
-            reviewChecklist: [],
-            coverageNote: preview.lacksPatchCoverage
-              ? 'PR omitido por modo estricto: el snapshot no incluye diff textual suficiente para una revision segura.'
-              : blockedBySensitiveConfig
-                ? 'PR omitido por modo estricto: se detectaron archivos potencialmente sensibles y la cobertura del diff es incompleta.'
-                : 'PR omitido por modo estricto y señales sensibles en el diff.',
-          };
-        }
-
-        const prompt = this.promptBuilder.build(request, snapshot);
-        const timeoutMs = request.timeoutMs ?? 60_000;
-        const controller = new AbortController();
-        const timeoutId = setTimeout(() => controller.abort('timeout'), timeoutMs);
-        if (requestId) {
-          this.activeRuns.get(requestId)?.add(controller);
-        }
-
-        try {
-          const rawText = await this.analysisClient.analyze({ request, prompt, signal: controller.signal });
-          const parsed = this.responseParser.parse(rawText);
-
-          return {
-            pullRequestId: item.pullRequest.id,
-            repository: item.pullRequest.repository,
-            status: 'analyzed' as const,
-            riskScore: Math.max(0, Math.min(100, Math.round(parsed.riskScore))),
-            shortSummary: parsed.shortSummary,
-            topConcerns: parsed.topConcerns,
-            reviewChecklist: parsed.reviewChecklist,
-            coverageNote: snapshot.partialReason,
-          };
-        } catch (error) {
-          return {
-            pullRequestId: item.pullRequest.id,
-            repository: item.pullRequest.repository,
-            status: 'error' as const,
-            topConcerns: [],
-            reviewChecklist: [],
-            error: error instanceof Error
-              ? error.message
-              : 'No fue posible analizar el PR.',
-          };
-        } finally {
-          clearTimeout(timeoutId);
-          if (requestId) {
-            this.activeRuns.get(requestId)?.delete(controller);
-          }
-        }
-      });
+      const results = await mapWithConcurrency(request.items, 2, async (item) => this.itemAnalyzer.analyzeItem(
+        request,
+        item,
+        {
+          onControllerCreated: (controller) => {
+            if (requestId) {
+              this.activeRuns.get(requestId)?.add(controller);
+            }
+          },
+          onControllerDisposed: (controller) => {
+            if (requestId) {
+              this.activeRuns.get(requestId)?.delete(controller);
+            }
+          },
+        },
+      ));
 
       return results;
     } finally {

--- a/tests/unit/services/pull-request-analysis.item-analyzer.test.js
+++ b/tests/unit/services/pull-request-analysis.item-analyzer.test.js
@@ -1,0 +1,215 @@
+const { PullRequestAnalysisItemAnalyzer } = require('../../../src/services/analysis/pull-request-analysis.item-analyzer');
+
+function createRequest(overrides = {}) {
+  return {
+    source: {
+      provider: 'github',
+      organization: 'acme',
+      project: 'repo-a',
+      repositoryId: 'repo-a',
+      personalAccessToken: 'pat',
+    },
+    apiKey: 'sk-live',
+    model: 'gpt-5.2-codex',
+    analysisDepth: 'standard',
+    snapshotPolicy: {
+      excludedPathPatterns: '',
+      strictMode: false,
+    },
+    promptDirectives: {
+      focusAreas: '',
+      customInstructions: '',
+    },
+    items: [
+      {
+        pullRequest: {
+          id: 88,
+          title: 'Actualizar auth',
+          description: 'Ajustes de seguridad',
+          repository: 'repo-a',
+          url: 'https://example.com/pr/88',
+          status: 'active',
+          createdAt: '2026-03-10T10:00:00.000Z',
+          updatedAt: '2026-03-10T12:00:00.000Z',
+          createdBy: { displayName: 'Ian' },
+          sourceBranch: 'feature/auth',
+          targetBranch: 'main',
+          mergeStatus: 'succeeded',
+          isDraft: false,
+          reviewers: [],
+        },
+      },
+    ],
+    ...overrides,
+  };
+}
+
+describe('PullRequestAnalysisItemAnalyzer', () => {
+  test('omite el analisis cuando el snapshot no incluye diff textual', async () => {
+    const analysisClient = { analyze: jest.fn() };
+    const analyzer = new PullRequestAnalysisItemAnalyzer({
+      snapshotProvider: {
+        getSnapshot: jest.fn().mockResolvedValue({
+          provider: 'github',
+          repository: 'repo-a',
+          pullRequestId: 88,
+          title: 'Actualizar auth',
+          description: 'Ajustes de seguridad',
+          author: 'Ian',
+          sourceBranch: 'feature/auth',
+          targetBranch: 'main',
+          reviewers: [],
+          files: [{ path: 'src/auth.ts', status: 'modified' }],
+          totalFilesChanged: 1,
+          truncated: false,
+          partialReason: 'Sin patch textual.',
+        }),
+      },
+      promptBuilder: { build: jest.fn() },
+      analysisClient,
+      responseParser: { parse: jest.fn() },
+    });
+    const request = createRequest();
+
+    const result = await analyzer.analyzeItem(request, request.items[0]);
+
+    expect(result).toEqual(expect.objectContaining({
+      pullRequestId: 88,
+      status: 'omitted',
+      coverageNote: 'Sin patch textual.',
+    }));
+    expect(analysisClient.analyze).not.toHaveBeenCalled();
+  });
+
+  test('en modo estricto usa mensaje de sensibilidad por configuracion', async () => {
+    const analyzer = new PullRequestAnalysisItemAnalyzer({
+      snapshotProvider: {
+        getSnapshot: jest.fn().mockResolvedValue({
+          provider: 'github',
+          repository: 'repo-a',
+          pullRequestId: 88,
+          title: 'Actualizar auth',
+          description: 'Ajustes de seguridad',
+          author: 'Ian',
+          sourceBranch: 'feature/auth',
+          targetBranch: 'main',
+          reviewers: [],
+          files: [
+            { path: '.env', status: 'modified' },
+            { path: 'src/auth.ts', status: 'modified', patch: '+ const enabled = true;' },
+          ],
+          totalFilesChanged: 2,
+          truncated: false,
+          partialReason: 'Patch parcial.',
+        }),
+      },
+      promptBuilder: { build: jest.fn() },
+      analysisClient: { analyze: jest.fn() },
+      responseParser: { parse: jest.fn() },
+    });
+    const request = createRequest({
+      snapshotPolicy: {
+        excludedPathPatterns: '',
+        strictMode: true,
+      },
+    });
+
+    const result = await analyzer.analyzeItem(request, request.items[0]);
+
+    expect(result).toEqual(expect.objectContaining({
+      status: 'omitted',
+      coverageNote: 'PR omitido por modo estricto: se detectaron archivos potencialmente sensibles y la cobertura del diff es incompleta.',
+    }));
+  });
+
+  test('analiza un item valido y libera el AbortController al finalizar', async () => {
+    const onControllerCreated = jest.fn();
+    const onControllerDisposed = jest.fn();
+    const analyzer = new PullRequestAnalysisItemAnalyzer({
+      snapshotProvider: {
+        getSnapshot: jest.fn().mockResolvedValue({
+          provider: 'github',
+          repository: 'repo-a',
+          pullRequestId: 88,
+          title: 'Actualizar auth',
+          description: 'Ajustes de seguridad',
+          author: 'Ian',
+          sourceBranch: 'feature/auth',
+          targetBranch: 'main',
+          reviewers: [],
+          files: [{ path: 'src/auth.ts', status: 'modified', patch: '+ const enabled = true;' }],
+          totalFilesChanged: 1,
+          truncated: false,
+          partialReason: 'Solo se cargo una parte del diff.',
+        }),
+      },
+      promptBuilder: {
+        build: jest.fn().mockReturnValue({ systemPrompt: 'system', userPrompt: 'user' }),
+      },
+      analysisClient: {
+        analyze: jest.fn().mockResolvedValue('raw-output'),
+      },
+      responseParser: {
+        parse: jest.fn().mockReturnValue({
+          riskScore: 105,
+          shortSummary: 'Resumen corto',
+          topConcerns: ['auth'],
+          reviewChecklist: ['agregar tests'],
+        }),
+      },
+    });
+    const request = createRequest({ timeoutMs: 5000 });
+
+    const result = await analyzer.analyzeItem(
+      request,
+      request.items[0],
+      { onControllerCreated, onControllerDisposed },
+    );
+
+    expect(result).toEqual(expect.objectContaining({
+      status: 'analyzed',
+      riskScore: 100,
+      shortSummary: 'Resumen corto',
+      coverageNote: 'Solo se cargo una parte del diff.',
+    }));
+    expect(onControllerCreated).toHaveBeenCalledTimes(1);
+    expect(onControllerDisposed).toHaveBeenCalledTimes(1);
+    expect(onControllerDisposed.mock.calls[0][0]).toBe(onControllerCreated.mock.calls[0][0]);
+  });
+
+  test('cuando el cliente remoto falla con valor no-Error usa mensaje generico', async () => {
+    const analyzer = new PullRequestAnalysisItemAnalyzer({
+      snapshotProvider: {
+        getSnapshot: jest.fn().mockResolvedValue({
+          provider: 'github',
+          repository: 'repo-a',
+          pullRequestId: 88,
+          title: 'Actualizar auth',
+          description: 'Ajustes de seguridad',
+          author: 'Ian',
+          sourceBranch: 'feature/auth',
+          targetBranch: 'main',
+          reviewers: [],
+          files: [{ path: 'src/auth.ts', status: 'modified', patch: '+ const enabled = true;' }],
+          totalFilesChanged: 1,
+          truncated: false,
+        }),
+      },
+      promptBuilder: {
+        build: jest.fn().mockReturnValue({ systemPrompt: 'system', userPrompt: 'user' }),
+      },
+      analysisClient: {
+        analyze: jest.fn().mockRejectedValue('network down'),
+      },
+      responseParser: { parse: jest.fn() },
+    });
+    const request = createRequest();
+
+    const result = await analyzer.analyzeItem(request, request.items[0]);
+
+    expect(result).toEqual(expect.objectContaining({
+      status: 'error',
+      error: 'No fue posible analizar el PR.',
+    }));
+  });
+});


### PR DESCRIPTION
## Resumen
Este PR implementa el issue #98 para mejorar el cumplimiento de **Single Responsibility Principle (SRP)** en el flujo de análisis de Pull Requests.

Se extrajo la lógica de análisis por ítem a un módulo dedicado y `PullRequestAnalysisService` quedó como orquestador del batch y del ciclo de cancelación por request.

Closes #98

## Problema original
`PullRequestAnalysisService.analyzeBatch` concentraba en un solo método:
- Obtención de snapshot por PR
- Evaluación de cobertura/strict mode
- Construcción de prompt
- Manejo de timeout y AbortController
- Llamada remota
- Parseo de respuesta
- Mapeo de errores y shape final del review

Eso hacía más costosa la evolución de reglas por ítem y complicaba pruebas unitarias enfocadas.

## Solución implementada
### 1) Nuevo módulo dedicado: item analyzer
Se agregó `src/services/analysis/pull-request-analysis.item-analyzer.ts`:
- `PullRequestAnalysisItemAnalyzer` con dependencias explícitas (`snapshotProvider`, `promptBuilder`, `analysisClient`, `responseParser`).
- Método `analyzeItem(request, item, runContext)` que encapsula toda la lógica por PR:
  - Previsualización y reglas de omisión
  - Evaluación de bloqueo en strict mode
  - Prompt + llamada remota + parseo
  - Acotado de `riskScore` a `[0..100]`
  - Manejo de errores y mensaje genérico para errores no `Error`
  - Gestión de timeout y hooks de registro/liberación de `AbortController`

### 2) Servicio simplificado como orquestador
Se actualizó `src/services/analysis/pull-request-analysis.service.ts`:
- Mantiene responsabilidades de batch:
  - Validación temprana de `apiKey`
  - Concurrencia (`mapWithConcurrency`)
  - Registro global por `requestId` para cancelación
  - Limpieza final del estado activo
- Delega la lógica por ítem al `PullRequestAnalysisItemAnalyzer`.

### 3) Cobertura de pruebas para la nueva abstracción
Se agregó `tests/unit/services/pull-request-analysis.item-analyzer.test.js` con cobertura de:
- Omisión por falta de diff textual
- Mensaje de bloqueo en strict mode por sensibilidad/configuración
- Flujo analizado exitoso + clamp de score + ciclo create/dispose de controller
- Error remoto no tipado (`non-Error`) con mensaje genérico

## Compatibilidad funcional
Se preserva el comportamiento previo en:
- Reglas de omisión y mensajes de coverage
- Strict mode
- Timeout/cancelación por batch
- Mapping del resultado final por PR

## Validación ejecutada
Evidencia ejecutada en local:
- `npm run typecheck`
- `npx jest tests/unit/services/pull-request-analysis.item-analyzer.test.js tests/unit/services/pull-request-analysis.service.test.js tests/unit/services/pull-request-analysis.parts.test.js --runInBand`
- Hooks automáticos de commit/push (`guard:commit` y `guard:push`) con:
  - lint
  - typecheck
  - arquitectura
  - solid
  - test coverage
  - build

## Riesgos y mitigaciones
- Riesgo: desalineación entre lógica extraída y comportamiento histórico.
- Mitigación: tests específicos del nuevo módulo + tests existentes del servicio + quality gates completos.

## Checklist
- [x] Módulo de análisis por item creado con dependencias explícitas
- [x] Servicio delega en el nuevo módulo y conserva orquestación batch
- [x] Comportamiento preservado (omisión/strict mode/errores/timeout)
- [x] Pruebas unitarias ampliadas
- [x] Validaciones de calidad en verde
