### PR TITLE
refactor(repository-analysis): extraer run state manager de corridas (SRP)

### DIFF
--- a/src/services/analysis/repository-analysis.run-state.ts
+++ b/src/services/analysis/repository-analysis.run-state.ts
@@ -1,0 +1,65 @@
+export interface RepositoryAnalysisActiveRun {
+  cancelled: boolean;
+  controller: AbortController | null;
+  timeoutId: NodeJS.Timeout | null;
+}
+
+const CANCELLED_BEFORE_REMOTE_ERROR = 'El analisis fue cancelado antes de iniciar la consulta remota.';
+
+export class RepositoryAnalysisRunStateManager {
+  readonly activeRuns = new Map<string, RepositoryAnalysisActiveRun>();
+
+  registerRun(requestId: string): void {
+    this.activeRuns.set(requestId, {
+      cancelled: false,
+      controller: null,
+      timeoutId: null,
+    });
+  }
+
+  createRemoteController(requestId: string, timeoutMs: number): AbortController {
+    const controller = new AbortController();
+    const timeoutId = setTimeout(() => controller.abort('timeout'), timeoutMs);
+    const activeRun = this.activeRuns.get(requestId);
+
+    if (activeRun) {
+      activeRun.controller = controller;
+      activeRun.timeoutId = timeoutId;
+    }
+
+    return controller;
+  }
+
+  cancelRun(requestId: string): void {
+    const activeRun = this.activeRuns.get(requestId);
+    if (!activeRun) {
+      return;
+    }
+
+    activeRun.cancelled = true;
+    if (activeRun.controller) {
+      activeRun.controller.abort('cancelled');
+      this.cleanupRun(requestId);
+    }
+  }
+
+  assertNotCancelled(requestId: string): void {
+    if (this.activeRuns.get(requestId)?.cancelled) {
+      this.cleanupRun(requestId);
+      throw new Error(CANCELLED_BEFORE_REMOTE_ERROR);
+    }
+  }
+
+  cleanupRun(requestId: string): void {
+    const activeRun = this.activeRuns.get(requestId);
+    if (!activeRun) {
+      return;
+    }
+
+    if (activeRun.timeoutId) {
+      clearTimeout(activeRun.timeoutId);
+    }
+
+    this.activeRuns.delete(requestId);
+  }
+}

--- a/src/services/analysis/repository-analysis.service.ts
+++ b/src/services/analysis/repository-analysis.service.ts
@@ -6,6 +6,7 @@ import type {
   SnapshotProviderPort,
 } from './repository-analysis.ports';
 import { buildRepositoryAnalysisPreview } from './repository-analysis.preview';
+import { RepositoryAnalysisRunStateManager } from './repository-analysis.run-state';
 
 interface RepositoryAnalysisServiceDependencies {
   snapshotProvider: SnapshotProviderPort;
@@ -14,21 +15,15 @@ interface RepositoryAnalysisServiceDependencies {
   responseParser: AnalysisResponseParserPort;
 }
 
-interface ActiveAnalysisRun {
-  cancelled: boolean;
-  controller: AbortController | null;
-  timeoutId: NodeJS.Timeout | null;
-}
-
 const DEFAULT_ANALYSIS_TIMEOUT_MS = 90_000;
 
 export class RepositoryAnalysisService {
-  private activeRuns = new Map<string, ActiveAnalysisRun>();
-
   private readonly snapshotProvider: SnapshotProviderPort;
   private readonly promptBuilder: AnalysisPromptBuilderPort;
   private readonly analysisClient: AnalysisClientPort;
   private readonly responseParser: AnalysisResponseParserPort;
+  private readonly runStateManager = new RepositoryAnalysisRunStateManager();
+  readonly activeRuns = this.runStateManager.activeRuns;
 
   constructor({
     snapshotProvider,
@@ -57,28 +52,18 @@ export class RepositoryAnalysisService {
       throw new Error('La API key de Codex es obligatoria para ejecutar el analisis.');
     }
 
-    this.activeRuns.set(request.requestId, {
-      cancelled: false,
-      controller: null,
-      timeoutId: null,
-    });
+    this.runStateManager.registerRun(request.requestId);
 
     try {
       const snapshot = await this.snapshotProvider.getSnapshot(request);
-      this.assertRunNotCancelled(request.requestId);
+      this.runStateManager.assertNotCancelled(request.requestId);
       if (snapshot.files.length === 0) {
         throw new Error('No se encontraron archivos de codigo legibles para analizar en el scope seleccionado.');
       }
 
       const prompt = this.promptBuilder.build(request, snapshot);
       const timeoutMs = request.timeoutMs ?? DEFAULT_ANALYSIS_TIMEOUT_MS;
-      const controller = new AbortController();
-      const timeoutId = setTimeout(() => controller.abort('timeout'), timeoutMs);
-      const activeRun = this.activeRuns.get(request.requestId);
-      if (activeRun) {
-        activeRun.controller = controller;
-        activeRun.timeoutId = timeoutId;
-      }
+      const controller = this.runStateManager.createRemoteController(request.requestId, timeoutMs);
 
       try {
         const rawText = await this.analysisClient.analyze({
@@ -124,40 +109,11 @@ export class RepositoryAnalysisService {
         throw error;
       }
     } finally {
-      this.cleanupRun(request.requestId);
+      this.runStateManager.cleanupRun(request.requestId);
     }
   }
 
   cancelAnalysis(requestId: string): void {
-    const activeRun = this.activeRuns.get(requestId);
-    if (!activeRun) {
-      return;
-    }
-
-    activeRun.cancelled = true;
-    if (activeRun.controller) {
-      activeRun.controller.abort('cancelled');
-      this.cleanupRun(requestId);
-    }
-  }
-
-  private assertRunNotCancelled(requestId: string): void {
-    if (this.activeRuns.get(requestId)?.cancelled) {
-      this.cleanupRun(requestId);
-      throw new Error('El analisis fue cancelado antes de iniciar la consulta remota.');
-    }
-  }
-
-  private cleanupRun(requestId: string): void {
-    const activeRun = this.activeRuns.get(requestId);
-    if (!activeRun) {
-      return;
-    }
-
-    if (activeRun.timeoutId) {
-      clearTimeout(activeRun.timeoutId);
-    }
-
-    this.activeRuns.delete(requestId);
+    this.runStateManager.cancelRun(requestId);
   }
 }

--- a/tests/unit/services/repository-analysis.run-state.test.js
+++ b/tests/unit/services/repository-analysis.run-state.test.js
@@ -1,0 +1,62 @@
+const { RepositoryAnalysisRunStateManager } = require('../../../src/services/analysis/repository-analysis.run-state');
+
+describe('RepositoryAnalysisRunStateManager', () => {
+  afterEach(() => {
+    jest.restoreAllMocks();
+    jest.useRealTimers();
+  });
+
+  test('registerRun y cleanupRun administran el ciclo base de una corrida', () => {
+    const manager = new RepositoryAnalysisRunStateManager();
+
+    manager.registerRun('run-1');
+    expect(manager.activeRuns.has('run-1')).toBe(true);
+
+    manager.cleanupRun('run-1');
+    expect(manager.activeRuns.has('run-1')).toBe(false);
+  });
+
+  test('createRemoteController asocia controller y aborta por timeout', async () => {
+    jest.useFakeTimers();
+    const manager = new RepositoryAnalysisRunStateManager();
+    manager.registerRun('run-timeout');
+
+    const controller = manager.createRemoteController('run-timeout', 250);
+    expect(manager.activeRuns.get('run-timeout').controller).toBe(controller);
+    expect(controller.signal.aborted).toBe(false);
+
+    await jest.advanceTimersByTimeAsync(250);
+
+    expect(controller.signal.aborted).toBe(true);
+    expect(controller.signal.reason).toBe('timeout');
+  });
+
+  test('cancelRun aborta y limpia cuando la corrida ya tiene controller activo', () => {
+    const manager = new RepositoryAnalysisRunStateManager();
+    manager.registerRun('run-cancel-active');
+    const controller = manager.createRemoteController('run-cancel-active', 5000);
+    const abortSpy = jest.spyOn(controller, 'abort');
+
+    manager.cancelRun('run-cancel-active');
+
+    expect(abortSpy).toHaveBeenCalledWith('cancelled');
+    expect(manager.activeRuns.has('run-cancel-active')).toBe(false);
+  });
+
+  test('cancelRun antes de crear controller marca cancelado y assertNotCancelled falla', () => {
+    const manager = new RepositoryAnalysisRunStateManager();
+    manager.registerRun('run-cancelled-before-remote');
+
+    manager.cancelRun('run-cancelled-before-remote');
+
+    expect(() => manager.assertNotCancelled('run-cancelled-before-remote')).toThrow(
+      'El analisis fue cancelado antes de iniciar la consulta remota.',
+    );
+    expect(manager.activeRuns.has('run-cancelled-before-remote')).toBe(false);
+  });
+
+  test('cancelRun ignora requestIds inexistentes', () => {
+    const manager = new RepositoryAnalysisRunStateManager();
+    expect(() => manager.cancelRun('missing-run')).not.toThrow();
+  });
+});


### PR DESCRIPTION
## Resumen
Este PR implementa el issue #99 para mejorar el cumplimiento de **Single Responsibility Principle (SRP)** en `RepositoryAnalysisService`.

Se extrajo la gestión del ciclo de vida de corridas activas (run state) a un módulo dedicado, manteniendo intacto el comportamiento funcional de cancelación, timeout y limpieza.

Closes #99

## Problema original
`RepositoryAnalysisService` mezclaba responsabilidades de negocio del análisis con responsabilidades de infraestructura/estado de ejecución:
- Registro de corridas activas
- Asociación de `AbortController` y `timeoutId`
- Marcado/cancelación de corrida
- Guardas de cancelación previa
- Limpieza del estado interno

Esto aumentaba complejidad y hacía más frágil la evolución del servicio.

## Solución implementada
### 1) Nuevo módulo de run state
Se agregó `src/services/analysis/repository-analysis.run-state.ts` con `RepositoryAnalysisRunStateManager`, responsable de:
- `registerRun(requestId)`
- `createRemoteController(requestId, timeoutMs)`
- `cancelRun(requestId)`
- `assertNotCancelled(requestId)`
- `cleanupRun(requestId)`

El manager encapsula el `Map` de corridas activas y el lifecycle de controller/timeout.

### 2) Servicio principal delega lifecycle
Se actualizó `src/services/analysis/repository-analysis.service.ts` para delegar en el manager:
- Inicio de corrida
- Verificación de cancelación previa al llamado remoto
- Creación/registro de `AbortController` con timeout
- Cancelación explícita por requestId
- Limpieza final en bloque `finally`

Con esto, el servicio queda más enfocado en la orquestación del análisis de repositorio.

### 3) Compatibilidad con pruebas existentes
Se mantiene `activeRuns` expuesto en el servicio vía referencia al manager para no romper contratos de pruebas actuales.

### 4) Nuevas pruebas unitarias del manager
Se agregó `tests/unit/services/repository-analysis.run-state.test.js` con cobertura de:
- Registro y cleanup base
- Asociación de controller y aborto por timeout
- Cancelación con controller activo (abort + cleanup)
- Cancelación previa a controller + validación de bloqueo
- Cancelación de requestId inexistente sin error

## Comportamiento preservado
Sin cambios en:
- Mensajes de error esperados
- Semántica de timeout/cancelación
- Limpieza de `activeRuns`
- Contrato de salida del análisis

## Validación ejecutada
Evidencia en local:
- `npm run typecheck`
- `npx jest tests/unit/services/repository-analysis.run-state.test.js tests/unit/services/repository-analysis.service.test.js tests/unit/services/repository-analysis-parts.test.js --runInBand`
- Hooks automáticos de commit/push (`guard:commit` y `guard:push`) con:
  - lint
  - typecheck
  - arquitectura
  - solid
  - test coverage
  - build

## Riesgos y mitigaciones
- Riesgo: cambios sutiles en la semántica de cancelación/timeout.
- Mitigación: nuevas pruebas enfocadas al manager + cobertura existente del servicio + quality gates completos.

## Checklist
- [x] Módulo de run state creado
- [x] `RepositoryAnalysisService` delega lifecycle de corridas
- [x] Comportamiento de cancelación/timeout preservado
- [x] Cobertura unitaria ampliada
- [x] Validaciones de calidad en verde
