### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/quality-gate.yml
+++ b/.github/workflows/quality-gate.yml
@@ -11,6 +11,9 @@ on:
       - 'chore/**'
       - 'perf/**'
 
+permissions:
+  contents: read
+
 jobs:
   quality-gate:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/IanStuardo-Dev/electron-checkPR/security/code-scanning/1](https://github.com/IanStuardo-Dev/electron-checkPR/security/code-scanning/1)

In general, to fix this type of issue you add an explicit `permissions` block either at the top level of the workflow (applies to all jobs) or within each job that should have restricted permissions. For a quality gate that only checks code, the minimal required permission is typically `contents: read` so the workflow can check out the repository; write permissions are not needed.

For this specific workflow in `.github/workflows/quality-gate.yml`, the simplest, least-disruptive fix is to add a `permissions:` block at the workflow root (same indentation level as `on:` and `jobs:`) specifying `contents: read`. This documents the intent and ensures the `GITHUB_TOKEN` is limited even if repository defaults are permissive. No other changes, imports, or additional configuration are necessary, since none of the existing steps require write access.

Concretely:
- Edit `.github/workflows/quality-gate.yml`.
- Insert a `permissions:` section after the `on:` block (or before it, order doesn’t matter, but we’ll use after for clarity).
- Set `contents: read` under `permissions`.
No other lines in the file need to be changed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
