### PR TITLE
feat(settings): agregar boton Guardar para API key de Codex

### DIFF
--- a/src/renderer/app/pages/Settings.tsx
+++ b/src/renderer/app/pages/Settings.tsx
@@ -35,7 +35,11 @@ const Settings = () => {
   const {
     config: codexConfig,
     isReady: isCodexReady,
+    apiKeyNeedsSave: codexApiKeyNeedsSave,
+    isSavingApiKey: isSavingCodexApiKey,
+    apiKeySaveFeedback: codexApiKeySaveFeedback,
     updateConfig: updateCodexConfig,
+    saveApiKey: saveCodexApiKey,
   } = useCodexSettings();
   const handleDiscoverProjects = () => void discoverProjects();
   const handleSelectProject = (project: string) => void selectProject(project);
@@ -82,6 +86,10 @@ const Settings = () => {
           codexConfig={codexConfig}
           isCodexReady={isCodexReady}
           updateCodexConfig={updateCodexConfig}
+          saveCodexApiKey={saveCodexApiKey}
+          codexApiKeyNeedsSave={codexApiKeyNeedsSave}
+          isSavingCodexApiKey={isSavingCodexApiKey}
+          codexApiKeySaveFeedback={codexApiKeySaveFeedback}
         />
 
         <SettingsDiagnosticsSection

--- a/src/renderer/features/settings/presentation/components/CodexIntegrationCard.tsx
+++ b/src/renderer/features/settings/presentation/components/CodexIntegrationCard.tsx
@@ -13,9 +13,24 @@ interface CodexIntegrationCardProps {
   config: CodexIntegrationConfig;
   isReady: boolean;
   onChange: <K extends keyof CodexIntegrationConfig>(key: K, value: CodexIntegrationConfig[K]) => void;
+  onSaveApiKey: () => void | Promise<void>;
+  apiKeyNeedsSave: boolean;
+  isSavingApiKey: boolean;
+  apiKeySaveFeedback: {
+    tone: 'success' | 'error';
+    message: string;
+  } | null;
 }
 
-const CodexIntegrationCard = ({ config, isReady, onChange }: CodexIntegrationCardProps) => {
+const CodexIntegrationCard = ({
+  config,
+  isReady,
+  onChange,
+  onSaveApiKey,
+  apiKeyNeedsSave,
+  isSavingApiKey,
+  apiKeySaveFeedback,
+}: CodexIntegrationCardProps) => {
   const [isAdvancedModalOpen, setIsAdvancedModalOpen] = React.useState(false);
 
   return (
@@ -46,7 +61,14 @@ const CodexIntegrationCard = ({ config, isReady, onChange }: CodexIntegrationCar
         </div>
       )}
     >
-      <CodexIntegrationSettingsGrid config={config} onChange={onChange} />
+      <CodexIntegrationSettingsGrid
+        config={config}
+        onChange={onChange}
+        onSaveApiKey={onSaveApiKey}
+        apiKeyNeedsSave={apiKeyNeedsSave}
+        isSavingApiKey={isSavingApiKey}
+        apiKeySaveFeedback={apiKeySaveFeedback}
+      />
 
       <CodexIntegrationPoliciesModal
         config={config}

--- a/src/renderer/features/settings/presentation/components/CodexIntegrationSettingsGrid.tsx
+++ b/src/renderer/features/settings/presentation/components/CodexIntegrationSettingsGrid.tsx
@@ -2,20 +2,33 @@ import React from 'react';
 import type { CodexIntegrationConfig } from '../../types';
 import {
   SettingsField,
+  SettingsNotice,
   SettingsSelectField,
   SettingsStatTile,
   SettingsToggleCard,
+  settingsButtonClassName,
 } from '../../../../ui/configuration/ConfigurationPrimitives';
 import type { CodexIntegrationChangeHandler } from './CodexIntegration.shared';
 
 interface CodexIntegrationSettingsGridProps {
   config: CodexIntegrationConfig;
   onChange: CodexIntegrationChangeHandler;
+  onSaveApiKey: () => void | Promise<void>;
+  apiKeyNeedsSave: boolean;
+  isSavingApiKey: boolean;
+  apiKeySaveFeedback: {
+    tone: 'success' | 'error';
+    message: string;
+  } | null;
 }
 
 export const CodexIntegrationSettingsGrid = ({
   config,
   onChange,
+  onSaveApiKey,
+  apiKeyNeedsSave,
+  isSavingApiKey,
+  apiKeySaveFeedback,
 }: CodexIntegrationSettingsGridProps) => (
   <>
     <div className="grid gap-4 sm:grid-cols-2 xl:grid-cols-4">
@@ -59,14 +72,34 @@ export const CodexIntegrationSettingsGrid = ({
         })}
       />
 
-      <SettingsField
-        label="API key"
-        type="password"
-        value={config.apiKey}
-        placeholder="sk-..."
-        onChange={(value) => onChange('apiKey', value)}
-        hint="Se guarda solo en sesion, no en disco."
-      />
+      <div className="min-w-0 space-y-3 xl:col-span-2">
+        <SettingsField
+          label="API key"
+          type="password"
+          value={config.apiKey}
+          placeholder="sk-..."
+          onChange={(value) => onChange('apiKey', value)}
+          hint="Se guarda solo en sesion, no en disco."
+        />
+        <div className="flex flex-wrap items-center gap-3">
+          <button
+            type="button"
+            onClick={() => void onSaveApiKey()}
+            disabled={!apiKeyNeedsSave || isSavingApiKey}
+            className={`${settingsButtonClassName} disabled:cursor-not-allowed disabled:opacity-60`}
+          >
+            {isSavingApiKey ? 'Guardando...' : 'Guardar'}
+          </button>
+          {apiKeyNeedsSave ? (
+            <span className="text-xs text-amber-700">Hay cambios sin guardar en la API key.</span>
+          ) : null}
+        </div>
+        {apiKeySaveFeedback ? (
+          <SettingsNotice tone={apiKeySaveFeedback.tone}>
+            {apiKeySaveFeedback.message}
+          </SettingsNotice>
+        ) : null}
+      </div>
 
       <SettingsSelectField
         label="Modelo"

--- a/src/renderer/features/settings/presentation/components/SettingsIntegrationsPanel.tsx
+++ b/src/renderer/features/settings/presentation/components/SettingsIntegrationsPanel.tsx
@@ -32,6 +32,10 @@ export function SettingsIntegrationsSection({
   codexConfig,
   isCodexReady,
   updateCodexConfig,
+  saveCodexApiKey,
+  codexApiKeyNeedsSave,
+  isSavingCodexApiKey,
+  codexApiKeySaveFeedback,
 }: SettingsProviderConnectionProps & {
   activeProvider: RepositoryProviderDefinition | null;
   summary: DashboardSummary;
@@ -40,6 +44,13 @@ export function SettingsIntegrationsSection({
   codexConfig: CodexIntegrationConfig;
   isCodexReady: boolean;
   updateCodexConfig: <K extends keyof CodexIntegrationConfig>(name: K, value: CodexIntegrationConfig[K]) => void;
+  saveCodexApiKey: () => void | Promise<void>;
+  codexApiKeyNeedsSave: boolean;
+  isSavingCodexApiKey: boolean;
+  codexApiKeySaveFeedback: {
+    tone: 'success' | 'error';
+    message: string;
+  } | null;
 }) {
   const [isProviderModalOpen, setIsProviderModalOpen] = React.useState(false);
   const [isCodexModalOpen, setIsCodexModalOpen] = React.useState(false);
@@ -102,6 +113,10 @@ export function SettingsIntegrationsSection({
           config={codexConfig}
           isReady={isCodexReady}
           onChange={updateCodexConfig}
+          onSaveApiKey={saveCodexApiKey}
+          apiKeyNeedsSave={codexApiKeyNeedsSave}
+          isSavingApiKey={isSavingCodexApiKey}
+          apiKeySaveFeedback={codexApiKeySaveFeedback}
         />
       </SettingsSectionModal>
 

--- a/src/renderer/features/settings/presentation/hooks/useCodexSettings.ts
+++ b/src/renderer/features/settings/presentation/hooks/useCodexSettings.ts
@@ -2,10 +2,17 @@ import React from 'react';
 import type { CodexIntegrationConfig } from '../../types';
 import { hasCodexApiKeyInSession, loadCodexConfig, persistCodexConfig } from '../../data/settingsStorage';
 
+interface ApiKeySaveFeedback {
+  tone: 'success' | 'error';
+  message: string;
+}
+
 export function useCodexSettings() {
   const [config, setConfig] = React.useState<CodexIntegrationConfig>(() => loadCodexConfig());
   const [hasPersistedApiKey, setHasPersistedApiKey] = React.useState(false);
-  const [shouldSyncApiKey, setShouldSyncApiKey] = React.useState(false);
+  const [apiKeyNeedsSave, setApiKeyNeedsSave] = React.useState(false);
+  const [isSavingApiKey, setIsSavingApiKey] = React.useState(false);
+  const [apiKeySaveFeedback, setApiKeySaveFeedback] = React.useState<ApiKeySaveFeedback | null>(null);
 
   React.useEffect(() => {
     void hasCodexApiKeyInSession()
@@ -16,25 +23,16 @@ export function useCodexSettings() {
   }, []);
 
   React.useEffect(() => {
-    void persistCodexConfig(config, { syncApiKey: shouldSyncApiKey })
-      .then(() => {
-        if (!shouldSyncApiKey) {
-          return;
-        }
-
-        const hasKey = Boolean(config.apiKey.trim());
-        setHasPersistedApiKey(hasKey);
-        setShouldSyncApiKey(false);
-      })
-      .catch(() => undefined);
-  }, [config, shouldSyncApiKey]);
+    void persistCodexConfig(config).catch(() => undefined);
+  }, [config]);
 
   const updateConfig = React.useCallback(<K extends keyof CodexIntegrationConfig>(
     key: K,
     value: CodexIntegrationConfig[K],
   ) => {
     if (key === 'apiKey') {
-      setShouldSyncApiKey(true);
+      setApiKeyNeedsSave(true);
+      setApiKeySaveFeedback(null);
     }
 
     setConfig((current) => ({
@@ -43,12 +41,43 @@ export function useCodexSettings() {
     }));
   }, []);
 
-  const isReady = Boolean(config.enabled && (config.apiKey.trim() || hasPersistedApiKey));
+  const saveApiKey = React.useCallback(async () => {
+    setIsSavingApiKey(true);
+    setApiKeySaveFeedback(null);
+
+    try {
+      const hasKey = Boolean(config.apiKey.trim());
+      await persistCodexConfig(config, { syncApiKey: true });
+      setHasPersistedApiKey(hasKey);
+      setApiKeyNeedsSave(false);
+      setApiKeySaveFeedback({
+        tone: 'success',
+        message: hasKey
+          ? 'API key guardada en sesion.'
+          : 'API key eliminada de la sesion.',
+      });
+    } catch (error) {
+      setApiKeySaveFeedback({
+        tone: 'error',
+        message: error instanceof Error
+          ? error.message
+          : 'No fue posible guardar la API key de Codex.',
+      });
+    } finally {
+      setIsSavingApiKey(false);
+    }
+  }, [config]);
+
+  const isReady = Boolean(config.enabled && hasPersistedApiKey);
 
   return {
     config,
     isReady,
     hasPersistedApiKey,
+    apiKeyNeedsSave,
+    isSavingApiKey,
+    apiKeySaveFeedback,
     updateConfig,
+    saveApiKey,
   };
 }

--- a/tests/integration/renderer/settings.page.dom.test.js
+++ b/tests/integration/renderer/settings.page.dom.test.js
@@ -82,6 +82,10 @@ describe('Settings page', () => {
       },
       isReady: true,
       updateConfig: jest.fn(),
+      saveApiKey: jest.fn(),
+      apiKeyNeedsSave: false,
+      isSavingApiKey: false,
+      apiKeySaveFeedback: null,
     });
 
     renderWithRouter(React.createElement(Settings));

--- a/tests/integration/renderer/use-codex-settings.dom.test.js
+++ b/tests/integration/renderer/use-codex-settings.dom.test.js
@@ -12,6 +12,7 @@ const { useCodexSettings } = require('../../../src/renderer/features/settings/pr
 
 describe('useCodexSettings', () => {
   beforeEach(() => {
+    storage.persistCodexConfig.mockClear();
     storage.loadCodexConfig.mockReturnValue({
       enabled: false,
       model: 'gpt-5.2-codex',
@@ -57,5 +58,36 @@ describe('useCodexSettings', () => {
     });
 
     expect(result.current.isReady).toBe(true);
+  });
+
+  test('api key requiere guardado explicito para sincronizar sesion', async () => {
+    const { result } = renderHook(() => useCodexSettings());
+
+    await waitFor(() => expect(result.current.hasPersistedApiKey).toBe(true));
+    storage.persistCodexConfig.mockClear();
+
+    act(() => {
+      result.current.updateConfig('apiKey', 'sk-secret');
+    });
+
+    await waitFor(() => expect(storage.persistCodexConfig).toHaveBeenCalled());
+    expect(
+      storage.persistCodexConfig.mock.calls.some(([, options]) => options && options.syncApiKey === true),
+    ).toBe(false);
+    expect(result.current.apiKeyNeedsSave).toBe(true);
+
+    await act(async () => {
+      await result.current.saveApiKey();
+    });
+
+    expect(storage.persistCodexConfig).toHaveBeenCalledWith(
+      expect.objectContaining({ apiKey: 'sk-secret' }),
+      { syncApiKey: true },
+    );
+    expect(result.current.apiKeyNeedsSave).toBe(false);
+    expect(result.current.apiKeySaveFeedback).toEqual({
+      tone: 'success',
+      message: 'API key guardada en sesion.',
+    });
   });
 });

--- a/tests/unit/renderer/codex-integration-card.dom.test.js
+++ b/tests/unit/renderer/codex-integration-card.dom.test.js
@@ -7,10 +7,15 @@ const CodexIntegrationCard = require('../../../src/renderer/features/settings/pr
 describe('CodexIntegrationCard', () => {
   test('abre el modal de politicas avanzadas sin sobrecargar la card principal', async () => {
     const user = userEvent.setup();
+    const onSaveApiKey = jest.fn();
 
     render(React.createElement(CodexIntegrationCard, {
       isReady: true,
       onChange: jest.fn(),
+      onSaveApiKey,
+      apiKeyNeedsSave: true,
+      isSavingApiKey: false,
+      apiKeySaveFeedback: null,
       config: {
         enabled: true,
         model: 'gpt-5.2-codex',
@@ -51,5 +56,8 @@ describe('CodexIntegrationCard', () => {
     expect(screen.getByRole('dialog', { name: /politicas avanzadas de codex/i })).toBeInTheDocument();
     expect(screen.getByLabelText(/focus areas para pr ai review/i)).toBeInTheDocument();
     expect(screen.getByLabelText(/patron o estilo a validar/i)).toBeInTheDocument();
+
+    await user.click(screen.getByRole('button', { name: /^guardar$/i }));
+    expect(onSaveApiKey).toHaveBeenCalledTimes(1);
   });
 });


### PR DESCRIPTION
## Resumen
Este PR implementa el feature solicitado en el issue #132:
- agrega un boton **Guardar** para la API key de Codex
- separa la edicion local de la API key de su persistencia en sesion
- muestra feedback de estado (cambios pendientes, guardando, exito/error)

## Cambios principales
- `useCodexSettings` ahora expone `saveApiKey`, `apiKeyNeedsSave`, `isSavingApiKey` y `apiKeySaveFeedback`.
- la persistencia de la API key ocurre solo al presionar **Guardar**.
- `isReady` de Codex depende de key realmente persistida en sesion.
- se actualizaron `Settings.tsx`, `SettingsIntegrationsPanel`, `CodexIntegrationCard` y `CodexIntegrationSettingsGrid`.
- se actualizaron tests de settings/codex para cubrir el nuevo flujo.

## Validacion
- pre-commit y pre-push quality gates en verde
- lint, typecheck, arquitectura, coverage, build y suite completa de tests en verde

Closes #132