### PR TITLE
feat(providers): paginar ramas en GitHub, GitLab y Azure

### DIFF
--- a/src/services/azure/azure.repositories.ts
+++ b/src/services/azure/azure.repositories.ts
@@ -1,5 +1,5 @@
 import type { AzureBranch, AzureConnectionConfig, AzureProject, AzureRepository } from '../../types/azure';
-import { AZURE_API_VERSION, getAzureConfig, getAzureContinuationToken, requestAzureJson, requestAzureJsonResponse } from './azure.api';
+import { AZURE_API_VERSION, getAzureConfig, getAzureContinuationToken, requestAzureJsonResponse } from './azure.api';
 import type { AzureProjectsResponse, AzureRefsResponse, AzureRepositoriesResponse } from './azure.types';
 import { getRequiredAzureProjectContext, getRequiredAzureRepositoryContext } from './azure.context';
 
@@ -83,12 +83,25 @@ export async function getAzureRepositories(config: AzureConnectionConfig): Promi
 export async function getAzureBranches(config: AzureConnectionConfig): Promise<AzureBranch[]> {
   const { organization, project, personalAccessToken, repositoryId } = getRequiredAzureRepositoryContext(config);
 
-  const requestUrl = `https://dev.azure.com/${encodeURIComponent(organization)}/${encodeURIComponent(project)}/_apis/git/repositories/${encodeURIComponent(repositoryId)}/refs?filter=heads/&api-version=${AZURE_API_VERSION}`;
-  const payload = await requestAzureJson<AzureRefsResponse>(requestUrl, personalAccessToken, 'branches request');
+  return requestAzureCollection<AzureRefsResponse['value'][number], AzureRefsResponse, AzureBranch>(
+    personalAccessToken,
+    'branches request',
+    (continuationToken) => {
+      const query = new URLSearchParams({
+        filter: 'heads/',
+        'api-version': AZURE_API_VERSION,
+      });
 
-  return payload.value.map((branch) => ({
-    name: branch.name.replace('refs/heads/', ''),
-    objectId: branch.objectId,
-    isDefault: branch.name === 'refs/heads/main' || branch.name === 'refs/heads/master',
-  }));
+      if (continuationToken) {
+        query.set('continuationToken', continuationToken);
+      }
+
+      return `https://dev.azure.com/${encodeURIComponent(organization)}/${encodeURIComponent(project)}/_apis/git/repositories/${encodeURIComponent(repositoryId)}/refs?${query.toString()}`;
+    },
+    (branch: AzureRefsResponse['value'][number]) => ({
+      name: branch.name.replace('refs/heads/', ''),
+      objectId: branch.objectId,
+      isDefault: branch.name === 'refs/heads/main' || branch.name === 'refs/heads/master',
+    }),
+  );
 }

--- a/src/services/github/github.repositories.ts
+++ b/src/services/github/github.repositories.ts
@@ -51,7 +51,7 @@ export async function getGitHubBranches(config: RepositoryConnectionConfig): Pro
     personalAccessToken,
     'repository request',
   );
-  const payload = await requestGitHubJson<GitHubBranchResponse[]>(
+  const payload = await requestGitHubPaginated<GitHubBranchResponse>(
     `https://api.github.com/repos/${encodeURIComponent(organization)}/${encodeURIComponent(repository)}/branches?per_page=100`,
     personalAccessToken,
     'branches request',

--- a/src/services/gitlab/gitlab.repositories.ts
+++ b/src/services/gitlab/gitlab.repositories.ts
@@ -1,5 +1,5 @@
 import type { RepositoryBranch, RepositoryConnectionConfig, RepositoryProject, RepositorySummary } from '../../types/repository';
-import { buildProject, buildRepository, GITLAB_API_BASE_URL, getGitLabConfig, normalizeNamespace, requestGitLabJson, requestGitLabPaginated } from './gitlab.api';
+import { buildProject, buildRepository, GITLAB_API_BASE_URL, getGitLabConfig, normalizeNamespace, requestGitLabPaginated } from './gitlab.api';
 import type { GitLabBranchResponse, GitLabProjectResponse } from './gitlab.types';
 
 export async function getGitLabRepositories(config: RepositoryConnectionConfig): Promise<RepositorySummary[]> {
@@ -37,10 +37,11 @@ export async function getGitLabBranches(config: RepositoryConnectionConfig): Pro
     throw new Error('Proyecto y token son obligatorios para GitLab.');
   }
 
-  const payload = await requestGitLabJson<GitLabBranchResponse[]>(
-    `${GITLAB_API_BASE_URL}/projects/${encodeURIComponent(project)}/repository/branches?per_page=100`,
+  const payload = await requestGitLabPaginated<GitLabBranchResponse>(
+    (page, perPage) => `${GITLAB_API_BASE_URL}/projects/${encodeURIComponent(project)}/repository/branches?per_page=${perPage}&page=${page}`,
     personalAccessToken,
     'branches request',
+    100,
   );
 
   return payload.map((branch) => ({

--- a/tests/unit/services/azure-modules.test.js
+++ b/tests/unit/services/azure-modules.test.js
@@ -53,16 +53,22 @@ describe('azure modules', () => {
   });
 
   test('getAzureRepositories y branches mapean payloads', async () => {
-    azureApi.requestAzureJsonResponse.mockResolvedValue({
-      data: {
-        value: [{ id: 'repo', name: 'Repo', webUrl: 'https://dev.azure.com/org/proj/_git/repo', defaultBranch: 'refs/heads/main' }],
-      },
-      headers: new Headers(),
-    });
-    azureApi.getAzureContinuationToken.mockReturnValue(null);
-    azureApi.requestAzureJson.mockResolvedValue({
-      value: [{ name: 'refs/heads/main', objectId: '1' }],
-    });
+    azureApi.requestAzureJsonResponse
+      .mockResolvedValueOnce({
+        data: {
+          value: [{ id: 'repo', name: 'Repo', webUrl: 'https://dev.azure.com/org/proj/_git/repo', defaultBranch: 'refs/heads/main' }],
+        },
+        headers: new Headers(),
+      })
+      .mockResolvedValueOnce({
+        data: {
+          value: [{ name: 'refs/heads/main', objectId: '1' }],
+        },
+        headers: new Headers(),
+      });
+    azureApi.getAzureContinuationToken
+      .mockReturnValueOnce(null)
+      .mockReturnValueOnce(null);
 
     const repositories = await getAzureRepositories({ organization: 'org', project: 'proj', personalAccessToken: 'pat' });
     const branches = await getAzureBranches({ organization: 'org', project: 'proj', repositoryId: 'repo', personalAccessToken: 'pat' });
@@ -72,9 +78,11 @@ describe('azure modules', () => {
   });
 
   test('getAzureBranches marca ramas no default correctamente', async () => {
-    azureApi.requestAzureJson.mockResolvedValue({
-      value: [{ name: 'refs/heads/feature/x', objectId: '2' }],
+    azureApi.requestAzureJsonResponse.mockResolvedValue({
+      data: { value: [{ name: 'refs/heads/feature/x', objectId: '2' }] },
+      headers: new Headers(),
     });
+    azureApi.getAzureContinuationToken.mockReturnValue(null);
 
     const branches = await getAzureBranches({
       organization: 'org',

--- a/tests/unit/services/github-repositories.module.test.js
+++ b/tests/unit/services/github-repositories.module.test.js
@@ -80,12 +80,11 @@ describe('github.repositories module', () => {
       repository: 'repo-a',
       personalAccessToken: 'pat',
     });
-    githubApi.requestGitHubJson
-      .mockResolvedValueOnce({ default_branch: 'main' })
-      .mockResolvedValueOnce([
-        { name: 'main', commit: { sha: 'sha-main' } },
-        { name: 'develop', commit: { sha: 'sha-dev' } },
-      ]);
+    githubApi.requestGitHubJson.mockResolvedValueOnce({ default_branch: 'main' });
+    githubApi.requestGitHubPaginated.mockResolvedValue([
+      { name: 'main', commit: { sha: 'sha-main' } },
+      { name: 'develop', commit: { sha: 'sha-dev' } },
+    ]);
 
     const branches = await getGitHubBranches({
       provider: 'github',
@@ -99,5 +98,10 @@ describe('github.repositories module', () => {
       { name: 'main', objectId: 'sha-main', isDefault: true },
       { name: 'develop', objectId: 'sha-dev', isDefault: false },
     ]);
+    expect(githubApi.requestGitHubPaginated).toHaveBeenCalledWith(
+      'https://api.github.com/repos/acme/repo-a/branches?per_page=100',
+      'pat',
+      'branches request',
+    );
   });
 });

--- a/tests/unit/services/gitlab-modules.test.js
+++ b/tests/unit/services/gitlab-modules.test.js
@@ -31,13 +31,19 @@ describe('gitlab modules', () => {
   });
 
   test('getGitLabBranches mapea ramas', async () => {
-    gitlabApi.requestGitLabJson.mockResolvedValue([
+    gitlabApi.requestGitLabPaginated.mockResolvedValue([
       { name: 'main', default: true, commit: { id: '1' } },
     ]);
 
     const branches = await getGitLabBranches({ project: 'acme/repo-a', personalAccessToken: 'pat' });
 
     expect(branches).toEqual([{ name: 'main', objectId: '1', isDefault: true }]);
+    expect(gitlabApi.requestGitLabPaginated).toHaveBeenCalledWith(
+      expect.any(Function),
+      'pat',
+      'branches request',
+      100,
+    );
   });
 
   test('getGitLabPullRequests agrega approvals, reviewers y assignees', async () => {


### PR DESCRIPTION
## Resumen
Implementa #128 para evitar truncamiento de ramas cuando hay más de 100.

## Cambios
- GitHub: `getGitHubBranches` usa `requestGitHubPaginated`.
- GitLab: `getGitLabBranches` usa `requestGitLabPaginated` con `page/per_page`.
- Azure DevOps: `getAzureBranches` ahora usa continuation token via `requestAzureCollection`.
- Tests unitarios actualizados para reflejar el flujo paginado en los 3 providers.

## Validacion
- Tests unitarios de providers en verde
- Quality gates de pre-commit y pre-push en verde
- Lint/typecheck/tests/coverage/build en verde

Closes #128